### PR TITLE
Fixes missing export for using chart-tooltips in micro charts

### DIFF
--- a/components/micro-chart/src/micro-chart-module.ts
+++ b/components/micro-chart/src/micro-chart-module.ts
@@ -22,7 +22,7 @@ import { DtMicroChart } from './micro-chart';
 
 @NgModule({
   imports: [DtChartModule],
-  exports: [DtMicroChart],
+  exports: [DtMicroChart, DtChartModule],
   declarations: [DtMicroChart],
 })
 export class DtMicroChartModule {}


### PR DESCRIPTION
fix(micro-chart): Fixes an issue when using the chart-tooltip in a micro-chart without importing the chart-module causes an error.

#### Type of PR

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or change that would cause existing functionality to
      not work as expected)
- [ ] Documentation update (changes to documentation)
- [ ] Other (if none of the above apply)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
