### PR TITLE
Fixes missing export for using indicators in progress-bars

### DIFF
--- a/components/progress-bar/src/progress-bar-module.ts
+++ b/components/progress-bar/src/progress-bar-module.ts
@@ -15,13 +15,20 @@
  */
 
 import { NgModule } from '@angular/core';
+import { DtIndicatorModule } from '@dynatrace/barista-components/core';
 
 import { DtProgressBar } from './progress-bar';
 import { DtProgressBarCount } from './progress-bar-count';
 import { DtProgressBarDescription } from './progress-bar-description';
 
 @NgModule({
-  exports: [DtProgressBar, DtProgressBarDescription, DtProgressBarCount],
+  exports: [
+    DtProgressBar,
+    DtProgressBarDescription,
+    DtProgressBarCount,
+    // @breaking-change Remove export in 6.0.0 (Issue #214 has to be solved first)
+    DtIndicatorModule,
+  ],
   declarations: [DtProgressBar, DtProgressBarDescription, DtProgressBarCount],
 })
 export class DtProgressBarModule {}


### PR DESCRIPTION
### <strong>Pull Request</strong>

fix(progress-bar): Fixes an issue when using the indicator without importing the core indicator-module causes an error.

#### Type of PR

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or change that would cause existing functionality to
      not work as expected)
- [ ] Documentation update (changes to documentation)
- [ ] Other (if none of the above apply)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
