### PR TITLE
build(components): Fixes issue where missing angular compiler options…

### DIFF
--- a/components/tsconfig.json
+++ b/components/tsconfig.json
@@ -1,5 +1,13 @@
 {
   "extends": "../tsconfig.json",
+  "angularCompilerOptions": {
+    "annotateForClosureCompiler": true,
+    "skipTemplateCodegen": true,
+    "strictMetadataEmit": true,
+    "fullTemplateTypeCheck": true,
+    "strictInjectionParameters": true,
+    "enableResourceInlining": true
+  },
   "compilerOptions": {
     "types": ["node", "jest"]
   },


### PR DESCRIPTION
 Fixes issue where missing angular compiler options causes the components build to fail.
