### PR TITLE
ci: Use the unix epoch to have always a unique cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,7 @@ jobs:
             fi
             git rev-parse HEAD > "$MASTER_SHA_FILE"
       - save_cache:
-          key: last-{{ .Environment.CIRCLE_BRANCH }}-sha
+          key: last-{{ .Environment.CIRCLE_BRANCH }}-sha-{{ epoch }}
           paths:
             - ./.config/last-{{ .Environment.CIRCLE_BRANCH }}-sha.txt
 


### PR DESCRIPTION
### <strong>Pull Request</strong>

#### Type of PR

Fixes the cache key generation that was currently skipped:

```
Skipping cache generation, cache already exists for key: last-master-sha
Found one created at 2019-12-06 08:07:18 +0000 UTC
````

now with the unix epoch timestamp, it is a unique cache and does not need to be overridden.


#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
