### PR TITLE
chore(commitlint): Removed references-empty rule so issue references are possible in commit message bodies.

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -43,7 +43,6 @@ module.exports = {
     'type-case': [2, 'always', 'lower-case'],
     'type-empty': [2, 'never'],
     'type-enum': [2, 'always', types],
-    'references-empty': [2, 'always'],
   },
   parserPreset: {
     parserOpts: {


### PR DESCRIPTION
chore(commitlint): Removed references-empty rule so issue references are possible in commit message bodies.