### PR TITLE
Fix build on Windows by adding explicit type annotations

### DIFF
--- a/components/core/src/animations/error-animations.ts
+++ b/components/core/src/animations/error-animations.ts
@@ -14,14 +14,21 @@
  * limitations under the License.
  */
 
-import { animation, animate, style } from '@angular/animations';
+import {
+  animation,
+  animate,
+  style,
+  AnimationReferenceMetadata,
+} from '@angular/animations';
 
-export const DT_ERROR_ENTER_ANIMATION = animation([
+export const DT_ERROR_ENTER_ANIMATION: AnimationReferenceMetadata = animation([
   style({ opacity: 0, transform: 'scaleY(0)' }),
   animate('150ms cubic-bezier(0.55, 0, 0.55, 0.2)'),
 ]);
 
-export const DT_ERROR_ENTER_DELAYED_ANIMATION = animation([
-  style({ opacity: 0, transform: 'scaleY(0)' }),
-  animate(`250ms 150ms cubic-bezier(0.55, 0, 0.55, 0.2)`),
-]);
+export const DT_ERROR_ENTER_DELAYED_ANIMATION: AnimationReferenceMetadata = animation(
+  [
+    style({ opacity: 0, transform: 'scaleY(0)' }),
+    animate(`250ms 150ms cubic-bezier(0.55, 0, 0.55, 0.2)`),
+  ],
+);

--- a/components/expandable-panel/src/expandable-panel.ts
+++ b/components/expandable-panel/src/expandable-panel.ts
@@ -32,6 +32,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { filter } from 'rxjs/operators';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'dt-expandable-panel',
@@ -123,14 +124,14 @@ export class DtExpandablePanel {
   >();
 
   /** @internal Event emitted when the panel is expanded. */
-  @Output('expanded') readonly _panelExpanded = this.expandChange.pipe(
-    filter(v => v),
-  );
+  @Output('expanded') readonly _panelExpanded: Observable<
+    boolean
+  > = this.expandChange.pipe(filter(v => v));
 
   /**  @internal Event emitted when the panel is collapsed. */
-  @Output('collapsed') readonly _panelCollapsed = this.expandChange.pipe(
-    filter(v => !v),
-  );
+  @Output('collapsed') readonly _panelCollapsed: Observable<
+    boolean
+  > = this.expandChange.pipe(filter(v => !v));
   /**
    * Event emitted when the panel has been opened.
    * @deprecated Use expandChange instead.

--- a/components/expandable-text/src/expandable-text.ts
+++ b/components/expandable-text/src/expandable-text.ts
@@ -25,6 +25,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { filter } from 'rxjs/operators';
+import { Observable } from 'rxjs';
 
 /**
  * Provides basic expand/collaps functionality for
@@ -69,15 +70,15 @@ export class DtExpandableText {
 
   /** @internal Event emitted when text is expanded */
   // tslint:disable-next-line: dt-annotate-internal-fields
-  @Output('expanded') readonly _textExpanded = this.expandChanged.pipe(
-    filter(v => v),
-  );
+  @Output('expanded') readonly _textExpanded: Observable<
+    boolean
+  > = this.expandChanged.pipe(filter(v => v));
 
   /** @internal Event emitted when text is collapsed */
   // tslint:disable-next-line: dt-annotate-internal-fields
-  @Output('collapsed') readonly _textCollapsed = this.expandChanged.pipe(
-    filter(v => !v),
-  );
+  @Output('collapsed') readonly _textCollapsed: Observable<
+    boolean
+  > = this.expandChanged.pipe(filter(v => !v));
 
   constructor(private _changeDetectorRef: ChangeDetectorRef) {}
 

--- a/components/secondary-nav/src/section/secondary-nav-section.ts
+++ b/components/secondary-nav/src/section/secondary-nav-section.ts
@@ -25,7 +25,7 @@ import {
   Output,
   ViewEncapsulation,
 } from '@angular/core';
-import { Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
 @Directive({
@@ -117,14 +117,14 @@ export class DtSecondaryNavSection {
   @Output() readonly expandChange = new EventEmitter<boolean>();
 
   /** @internal Event emitted when the section is expanded. */
-  @Output('expanded') readonly _sectionExpand = this.expandChange.pipe(
-    filter(v => v),
-  );
+  @Output('expanded') readonly _sectionExpand: Observable<
+    boolean
+  > = this.expandChange.pipe(filter(v => v));
 
   /** @internal Event emitted when the section is collapsed. */
-  @Output('collapsed') readonly _sectionCollapse = this.expandChange.pipe(
-    filter(v => !v),
-  );
+  @Output('collapsed') readonly _sectionCollapse: Observable<
+    boolean
+  > = this.expandChange.pipe(filter(v => !v));
 
   /** @internal Subject used to communicate programmatic change of section opening and closing */
   _sectionExpandChange$: Subject<DtSecondaryNavSection> = new Subject();

--- a/components/table/src/expandable/expandable-row.ts
+++ b/components/table/src/expandable/expandable-row.ts
@@ -42,7 +42,8 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { Subscription } from 'rxjs';
+
+import { Observable, Subscription } from 'rxjs';
 import { filter, startWith } from 'rxjs/operators';
 
 import {
@@ -143,9 +144,9 @@ export class DtExpandableRow extends DtRow
     filter(changeEvent => changeEvent.row.expanded),
   );
   /** @internal Event emitted when the row is collapsed. */
-  @Output('collapsed') readonly _collapsedStream = this.expandChange.pipe(
-    filter(changeEvent => !changeEvent.row.expanded),
-  );
+  @Output('collapsed') readonly _collapsedStream: Observable<
+    DtExpandableRowChangeEvent
+  > = this.expandChange.pipe(filter(changeEvent => !changeEvent.row.expanded));
 
   @ViewChild('dtExpandableRow', { static: true }) private _rowRef: ElementRef;
 


### PR DESCRIPTION
I have added explicit type annotations where they were missing and breaking the build. For details see issue #343 