### PR TITLE
ci(pull-request-labeler): Fixes incorrect applied labels for non fix/feat commits.

### DIFF
--- a/tools/pull-request-labeler/src/utils/process-commit-messages.ts
+++ b/tools/pull-request-labeler/src/utils/process-commit-messages.ts
@@ -90,7 +90,7 @@ export function processCommitMessages(
     if (hasBreakingCommits) {
       // The pull request contains breaking changes, it should be
       targets.push('target: major');
-    } else if (hasFeatureCommits || !hasFixCommits) {
+    } else if (hasFeatureCommits && !hasFixCommits) {
       targets.push('target: minor');
     } else if (hasFixCommits) {
       targets.push('target: minor', 'target: patch');


### PR DESCRIPTION
ci(pull-request-labeler): Fixes incorrect applied labels for non fix/feat commits.