### PR TITLE
fix(overlay): Fixes an issue with overlay placement in firefox.

### DIFF
--- a/components/overlay/src/overlay-trigger.ts
+++ b/components/overlay/src/overlay-trigger.ts
@@ -163,12 +163,22 @@ export class DtOverlayTrigger<T> extends _DtOverlayTriggerMixin
         offsetX = offsetX - (hostLeft - this._svgRect.left);
         offsetY = offsetY - (hostTop - this._svgRect.top);
       }
-      if (event.target !== host) {
+      if (target !== host && target instanceof HTMLElement) {
         const targetRect = target.getBoundingClientRect();
         const targetLeft = targetRect.left;
         const targetTop = targetRect.top;
         offsetX = targetLeft - hostLeft + offsetX;
         offsetY = targetTop - hostTop + offsetY;
+      }
+      // Run a special case, if the target is an SVG.
+      // Firefox gives back offsetX and offsetY when hovering on svgShapeElements
+      // that are relating to the viewBox of the root svg.
+      // We need to fall back to other ways of calculating the offset
+      // positioning, as there is no consistency across browser vendors
+      // on how they calculate offsetX and offsetY within svgShapeElements.
+      if (target !== host && target instanceof SVGElement) {
+        offsetX = event.clientX - hostLeft;
+        offsetY = event.clientY - hostTop;
       }
       this._dtOverlayRef.updatePosition(offsetX, offsetY);
     }


### PR DESCRIPTION
When hovering a SVGElement in firefox the MouseEvent delivered a wrong
value for the placement offset. Added a special code branch that
deals with that issue.

Closes #339

### <strong>Pull Request</strong>

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
