### PR TITLE
filter-field: Changes param ordering on definition creation functions and other breaking changes

### DIFF
--- a/components/filter-field/src/filter-field-default-data-source.ts
+++ b/components/filter-field/src/filter-field-default-data-source.ts
@@ -16,7 +16,6 @@
 
 import { BehaviorSubject, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { Validators } from '@angular/forms';
 import { isDefined, isObject } from '@dynatrace/barista-components/core';
 import { DtFilterFieldValidator } from './filter-field-validation';
 import { DtFilterFieldDataSource } from './filter-field-data-source';
@@ -54,7 +53,7 @@ export interface DtFilterFieldDefaultDataSourceFreeText {
   suggestions: Array<
     DtFilterFieldDefaultDataSourceOption | DtFilterFieldDefaultDataSourceGroup
   >;
-  validators?: DtFilterFieldValidator[];
+  validators: DtFilterFieldValidator[];
   unique?: boolean;
 }
 
@@ -277,15 +276,11 @@ export class DtFilterFieldDefaultDataSource<T>
 
   /** Transforms the provided data into a DtNodeDef which contains a DtFreeTextDef. */
   transformFreeText(data: DtFilterFieldDefaultDataSourceFreeText): DtNodeDef {
-    // @breaking-change 5.0.0 data.validators is then required so `|| []` can be removed
     const def = dtFreeTextDef(
       data,
       null,
       [],
-      data.validators || [
-        // tslint:disable-next-line: no-unbound-method
-        { validatorFn: Validators.required, error: 'Field is required' },
-      ],
+      data.validators,
       isDefined(data.unique) ? data.unique! : false,
     );
     def.freeText!.suggestions = this.transformList(data.suggestions, def);

--- a/components/filter-field/src/filter-field-default-data-source.ts
+++ b/components/filter-field/src/filter-field-default-data-source.ts
@@ -220,11 +220,11 @@ export class DtFilterFieldDefaultDataSource<T>
     data: DtFilterFieldDefaultDataSourceAutocomplete,
   ): DtNodeDef {
     const def = dtAutocompleteDef(
+      data,
+      null,
       [],
       !!data.distinct,
       !!data.async,
-      data,
-      null,
     );
     def.autocomplete!.optionsOrGroups = this.transformList(
       data.autocomplete,
@@ -249,10 +249,10 @@ export class DtFilterFieldDefaultDataSource<T>
         ? (parentAutocompleteOrOption as DtNodeDef)
         : null;
     return dtOptionDef(
-      typeof data === 'string' ? data : data.name,
       data,
-      null,
       existingDef,
+      typeof data === 'string' ? data : data.name,
+      null,
       parentAutocomplete,
       parentGroup,
     );
@@ -265,10 +265,10 @@ export class DtFilterFieldDefaultDataSource<T>
     existingDef: DtNodeDef | null = null,
   ): DtNodeDef {
     const def = dtGroupDef(
-      data.name,
-      [],
       data,
       existingDef,
+      data.name,
+      [],
       parentAutocomplete,
     );
     def.group!.options = this.transformList(data.options, def);
@@ -279,14 +279,14 @@ export class DtFilterFieldDefaultDataSource<T>
   transformFreeText(data: DtFilterFieldDefaultDataSourceFreeText): DtNodeDef {
     // @breaking-change 5.0.0 data.validators is then required so `|| []` can be removed
     const def = dtFreeTextDef(
+      data,
+      null,
       [],
       data.validators || [
         // tslint:disable-next-line: no-unbound-method
         { validatorFn: Validators.required, error: 'Field is required' },
       ],
       isDefined(data.unique) ? data.unique! : false,
-      data,
-      null,
     );
     def.freeText!.suggestions = this.transformList(data.suggestions, def);
     return def;
@@ -295,13 +295,13 @@ export class DtFilterFieldDefaultDataSource<T>
   /** Transforms the provided data into a DtNodeDef which contains a DtRangeDef. */
   transformRange(data: DtFilterFieldDefaultDataSourceRange): DtNodeDef {
     return dtRangeDef(
+      data,
+      null,
       !!data.range.operators.range,
       !!data.range.operators.equal,
       !!data.range.operators.greaterThanEqual,
       !!data.range.operators.lessThanEqual,
       data.range.unit,
-      data,
-      null,
       isDefined(data.unique) ? data.unique! : false,
     );
   }

--- a/components/filter-field/src/filter-field-default-data-source.ts
+++ b/components/filter-field/src/filter-field-default-data-source.ts
@@ -142,9 +142,9 @@ export type DtFilterFieldDefaultDataSourceType =
  *   }
  * }
  */
-// @breaking-change 5.0.0 Generic `T` to be changed to `T extends DtFilterFieldDefaultDataSourceType
-export class DtFilterFieldDefaultDataSource<T>
-  implements DtFilterFieldDataSource {
+export class DtFilterFieldDefaultDataSource<
+  T extends DtFilterFieldDefaultDataSourceType
+> implements DtFilterFieldDataSource {
   private readonly _data$: BehaviorSubject<T>;
 
   /** Structure of data that is used, transformed and rendered by the filter-field. */
@@ -165,9 +165,7 @@ export class DtFilterFieldDefaultDataSource<T>
    * displayed by the DtFilterFieldViewer (filter-field)
    */
   connect(): Observable<DtNodeDef | null> {
-    // @breaking-change 5.0.0 Type cast to `any` to be removed
-    // tslint:disable-next-line: no-any
-    return this._data$.pipe(map(data => this.transformObject(data as any)));
+    return this._data$.pipe(map(data => this.transformObject(data)));
   }
 
   /** Used by the DtFilterField. Called when it is destroyed. No-op. */

--- a/components/filter-field/src/filter-field-tag/filter-field-tag.spec.ts
+++ b/components/filter-field/src/filter-field-tag/filter-field-tag.spec.ts
@@ -34,7 +34,7 @@ import {
 import { DtIconModule } from '@dynatrace/barista-components/icon';
 
 import { createComponent } from '@dynatrace/barista-components/testing';
-import { DtFilterFieldTagData } from '../types';
+import { _DtFilterFieldTagData } from '../types';
 
 describe('DtFilterFieldTag', () => {
   let fixture: ComponentFixture<TestApp>;
@@ -149,5 +149,5 @@ describe('DtFilterFieldTag', () => {
 })
 export class TestApp {
   // we need to add this dummy data because the tags editable and deletable flags depend on the data being set
-  dummy = new DtFilterFieldTagData('AUT', 'Linz', ':', false, []);
+  dummy = new _DtFilterFieldTagData('AUT', 'Linz', ':', false, []);
 }

--- a/components/filter-field/src/filter-field-tag/filter-field-tag.ts
+++ b/components/filter-field/src/filter-field-tag/filter-field-tag.ts
@@ -25,7 +25,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 
-import { DtFilterFieldTagData } from '../types';
+import { _DtFilterFieldTagData } from '../types';
 
 // tslint:disable:class-name
 
@@ -45,7 +45,7 @@ import { DtFilterFieldTagData } from '../types';
 })
 export class DtFilterFieldTag {
   /** Tag data object that contains view values for displaying (like key, value and separator) and the original source. */
-  @Input() data: DtFilterFieldTagData;
+  @Input() data: _DtFilterFieldTagData;
 
   /** Emits when the filter should be removed (usually by clicking the remove button). */
   @Output() readonly remove = new EventEmitter<DtFilterFieldTag>();

--- a/components/filter-field/src/filter-field-util.spec.ts
+++ b/components/filter-field/src/filter-field-util.spec.ts
@@ -54,8 +54,8 @@ describe('DtFilterField Util', () => {
     it('should create a unique id for a simple option definition', () => {
       const optionDef = dtOptionDef(
         'Option 1',
-        'Option 1',
         null,
+        'Option 1',
         null,
         null,
         null,
@@ -65,13 +65,13 @@ describe('DtFilterField Util', () => {
     it('should create a unique id for an option definition inside a group', () => {
       const optionDef = dtOptionDef(
         'Option 1',
+        null,
         'Option 1',
         null,
         null,
         null,
-        null,
       );
-      const groupDef = dtGroupDef('Group', [optionDef], {}, null, null);
+      const groupDef = dtGroupDef({}, null, 'Group', [optionDef], null);
       optionDef.option!.parentGroup = groupDef;
       expect(generateOptionId(optionDef)).toBe(
         `Group${DELIMITER}Option 1${DELIMITER}`,
@@ -81,8 +81,8 @@ describe('DtFilterField Util', () => {
     it('should create a unique id for a simple option definition with a provided prefix', () => {
       const optionDef = dtOptionDef(
         'Option 1',
-        'Option 1',
         null,
+        'Option 1',
         null,
         null,
         null,
@@ -95,13 +95,13 @@ describe('DtFilterField Util', () => {
     it('should create a unique id for an option definition inside a group with a provided prefix', () => {
       const optionDef = dtOptionDef(
         'Option 1',
+        null,
         'Option 1',
         null,
         null,
         null,
-        null,
       );
-      const groupDef = dtGroupDef('Group', [optionDef], {}, null, null);
+      const groupDef = dtGroupDef({}, null, 'Group', [optionDef], null);
       optionDef.option!.parentGroup = groupDef;
       expect(generateOptionId(optionDef, `Prefix${DELIMITER}`)).toBe(
         `Prefix${DELIMITER}Group${DELIMITER}Option 1${DELIMITER}`,
@@ -111,8 +111,8 @@ describe('DtFilterField Util', () => {
     it('should return the prefix if prefixOnly is set to true', () => {
       const optionDef = dtOptionDef(
         'Option 1',
-        'Option 1',
         null,
+        'Option 1',
         null,
         null,
         null,
@@ -127,9 +127,9 @@ describe('DtFilterField Util', () => {
     it('should return the existing uid of an option definition', () => {
       const optionDef = dtOptionDef(
         'Option 1',
+        null,
         'Option 1',
         'id1',
-        null,
         null,
         null,
       );
@@ -139,8 +139,8 @@ describe('DtFilterField Util', () => {
     it('should create and return an uid of an option definition if there is none', () => {
       const optionDef = dtOptionDef(
         'Option 1',
-        'Option 1',
         null,
+        'Option 1',
         null,
         null,
         null,
@@ -153,8 +153,8 @@ describe('DtFilterField Util', () => {
       const prefix = `Autocomplete${DELIMITER}`;
       const optionDef = dtOptionDef(
         'Option 1',
-        'Option 1',
         null,
+        'Option 1',
         null,
         null,
         null,
@@ -169,8 +169,8 @@ describe('DtFilterField Util', () => {
       const prefix = `Autocomplete${DELIMITER}`;
       const optionDef = dtOptionDef(
         'Option 1',
-        'Option 1',
         null,
+        'Option 1',
         null,
         null,
         null,
@@ -182,11 +182,11 @@ describe('DtFilterField Util', () => {
 
   describe('findDefForSourceObj', () => {
     it('should return null if the provided root definition is not of type autocomplete', () => {
-      expect(findDefForSource({}, dtFreeTextDef([], {}, null))).toBe(null);
+      expect(findDefForSource({}, dtFreeTextDef({}, null, [], []))).toBe(null);
       expect(
-        findDefForSource({}, dtOptionDef('', {}, null, null, null, null)),
+        findDefForSource({}, dtOptionDef({}, null, '', null, null, null)),
       ).toBe(null);
-      expect(findDefForSource({}, dtGroupDef('', [], {}, null, null))).toBe(
+      expect(findDefForSource({}, dtGroupDef({}, null, '', [], null))).toBe(
         null,
       );
     });
@@ -195,19 +195,19 @@ describe('DtFilterField Util', () => {
       const optionSource = { name: 'Option 1' };
       const autocompleteSource = [optionSource];
       const optionDef = dtOptionDef(
-        optionSource.name,
         optionSource,
         null,
+        optionSource.name,
         null,
         null,
         null,
       );
       const autocompleteDef = dtAutocompleteDef(
+        autocompleteSource,
+        null,
         [optionDef],
         false,
         false,
-        autocompleteSource,
-        null,
       );
       optionDef.option!.parentAutocomplete = autocompleteDef;
       expect(findDefForSource(optionSource, autocompleteDef)).toBe(optionDef);
@@ -222,26 +222,26 @@ describe('DtFilterField Util', () => {
         const autocompleteSource = [groupSource];
 
         const optionDef = dtOptionDef(
-          optionSource.name,
           optionSource,
           null,
+          optionSource.name,
           null,
           null,
           null,
         );
         const groupDef = dtGroupDef(
-          'Group 1',
-          [optionDef],
           groupSource,
           null,
+          'Group 1',
+          [optionDef],
           null,
         );
         const autocompleteDef = dtAutocompleteDef(
+          autocompleteSource,
+          null,
           [groupDef],
           false,
           false,
-          autocompleteSource,
-          null,
         );
         optionDef.option!.parentAutocomplete = autocompleteDef;
         optionDef.option!.parentGroup = groupDef;
@@ -255,18 +255,18 @@ describe('DtFilterField Util', () => {
       const autocompleteSource = [optionSource];
       const optionDef = dtOptionDef(
         optionSource,
-        optionSource,
         null,
+        optionSource,
         null,
         null,
         null,
       );
       const autocompleteDef = dtAutocompleteDef(
+        autocompleteSource,
+        null,
         [optionDef],
         false,
         false,
-        autocompleteSource,
-        null,
       );
       optionDef.option!.parentAutocomplete = autocompleteDef;
       expect(findDefForSource(optionSource, autocompleteDef)).toBe(optionDef);
@@ -276,19 +276,19 @@ describe('DtFilterField Util', () => {
       const optionSource = { name: 'Option 1' };
       const autocompleteSource = [optionSource];
       const optionDef = dtOptionDef(
-        optionSource.name,
         optionSource,
         null,
+        optionSource.name,
         null,
         null,
         null,
       );
       const autocompleteDef = dtAutocompleteDef(
+        autocompleteSource,
+        null,
         [optionDef],
         false,
         false,
-        autocompleteSource,
-        null,
       );
       optionDef.option!.parentAutocomplete = autocompleteDef;
       expect(findDefForSource({}, autocompleteDef)).toBe(null);
@@ -301,19 +301,19 @@ describe('DtFilterField Util', () => {
       const autocompleteSource = [optionSource];
 
       const optionDef = dtOptionDef(
-        optionSource.name,
         optionSource,
         null,
+        optionSource.name,
         null,
         null,
         null,
       );
       const autocompleteDef = dtAutocompleteDef(
+        autocompleteSource,
+        null,
         [optionDef],
         false,
         false,
-        autocompleteSource,
-        null,
       );
       optionDef.option!.parentAutocomplete = autocompleteDef;
 
@@ -334,26 +334,26 @@ describe('DtFilterField Util', () => {
       const autocompleteSource = [groupSource];
 
       const optionDef = dtOptionDef(
-        optionSource.name,
         optionSource,
         null,
+        optionSource.name,
         null,
         null,
         null,
       );
       const groupDef = dtGroupDef(
-        'Group 1',
-        [optionDef],
         groupSource,
         null,
+        'Group 1',
+        [optionDef],
         null,
       );
       const autocompleteDef = dtAutocompleteDef(
+        autocompleteSource,
+        null,
         [groupDef],
         false,
         false,
-        autocompleteSource,
-        null,
       );
       optionDef.option!.parentAutocomplete = autocompleteDef;
       optionDef.option!.parentGroup = groupDef;
@@ -380,34 +380,34 @@ describe('DtFilterField Util', () => {
 
       const innerOptionDef = dtOptionDef(
         innerOptionSource,
-        innerOptionSource,
         null,
+        innerOptionSource,
         null,
         null,
         null,
       );
       const outerOptionDef = dtOptionDef(
-        outerOptionSource.name,
         outerOptionSource,
         null,
+        outerOptionSource.name,
         null,
         null,
         null,
       );
       const outerOptionAutocompleteDef = dtAutocompleteDef(
+        outerOptionSource,
+        outerOptionDef,
         [innerOptionDef],
         false,
         false,
-        outerOptionSource,
-        outerOptionDef,
       );
       innerOptionDef.option!.parentAutocomplete = outerOptionAutocompleteDef;
       const rootAutocompleteDef = dtAutocompleteDef(
+        rootAutocompleteSource,
+        null,
         [outerOptionAutocompleteDef],
         false,
         false,
-        rootAutocompleteSource,
-        null,
       );
       outerOptionAutocompleteDef.option!.parentAutocomplete = rootAutocompleteDef;
 
@@ -439,20 +439,20 @@ describe('DtFilterField Util', () => {
       const autocompleteSource = [optionSource];
 
       const optionDef = dtOptionDef(
-        optionSource.name,
         optionSource,
         null,
+        optionSource.name,
         null,
         null,
         null,
       );
-      const freeTextDef = dtFreeTextDef([], optionSource, optionDef);
+      const freeTextDef = dtFreeTextDef(optionSource, optionDef, [], []);
       const autocompleteDef = dtAutocompleteDef(
+        autocompleteSource,
+        null,
         [freeTextDef],
         false,
         false,
-        autocompleteSource,
-        null,
       );
       freeTextDef.option!.parentAutocomplete = autocompleteDef;
 
@@ -473,27 +473,27 @@ describe('DtFilterField Util', () => {
       const autocompleteSource = [groupSource];
 
       const optionDef = dtOptionDef(
-        optionSource.name,
         optionSource,
         null,
+        optionSource.name,
         null,
         null,
         null,
       );
-      const freeTextDef = dtFreeTextDef([], optionSource, optionDef);
+      const freeTextDef = dtFreeTextDef(optionSource, optionDef, [], []);
       const groupDef = dtGroupDef(
-        'Group 1',
-        [freeTextDef],
         groupSource,
         null,
+        'Group 1',
+        [freeTextDef],
         null,
       );
       const autocompleteDef = dtAutocompleteDef(
+        autocompleteSource,
+        null,
         [groupDef],
         false,
         false,
-        autocompleteSource,
-        null,
       );
       freeTextDef.option!.parentGroup = groupDef;
       freeTextDef.option!.parentAutocomplete = autocompleteDef;
@@ -515,9 +515,9 @@ describe('DtFilterField Util', () => {
     it('should return true if the viewValue of the option starts the filter text', () => {
       const optionSource = { name: 'Option 1' };
       const optionDef = dtOptionDef(
-        optionSource.name,
         optionSource,
         null,
+        optionSource.name,
         null,
         null,
         null,
@@ -528,9 +528,9 @@ describe('DtFilterField Util', () => {
     it('should return true if the viewValue of the option contains the filter text', () => {
       const optionSource = { name: 'Option 1' };
       const optionDef = dtOptionDef(
-        optionSource.name,
         optionSource,
         null,
+        optionSource.name,
         null,
         null,
         null,
@@ -541,9 +541,9 @@ describe('DtFilterField Util', () => {
     it('should return false if the viewValue of the option does not contain the filter text', () => {
       const optionSource = { name: 'Option 1' };
       const optionDef = dtOptionDef(
-        optionSource.name,
         optionSource,
         null,
+        optionSource.name,
         null,
         null,
         null,
@@ -557,10 +557,10 @@ describe('DtFilterField Util', () => {
       const optionSource = { name: 'Option 1', uid: '1' };
       const selectedIds = new Set([optionSource.uid]);
       const optionDef = dtOptionDef(
-        optionSource.name,
         optionSource,
-        optionSource.uid,
         null,
+        optionSource.name,
+        optionSource.uid,
         null,
         null,
       );
@@ -574,10 +574,10 @@ describe('DtFilterField Util', () => {
       const optionSource = { name: 'Option 1', uid: '1' };
       const selectedIds = new Set(['2']);
       const optionDef = dtOptionDef(
-        optionSource.name,
         optionSource,
-        optionSource.uid,
         null,
+        optionSource.name,
+        optionSource.uid,
         null,
         null,
       );
@@ -592,19 +592,19 @@ describe('DtFilterField Util', () => {
         const optionSource = { name: 'Option 1', uid: '1', autocomplete: [] };
         const selectedIds = new Set([optionSource.uid]);
         let optionDef = dtOptionDef(
-          optionSource.name,
           optionSource,
-          optionSource.uid,
           null,
+          optionSource.name,
+          optionSource.uid,
           null,
           null,
         );
         optionDef = dtAutocompleteDef(
+          optionSource,
+          optionDef,
           [],
           false,
           false,
-          optionSource,
-          optionDef,
         );
         expect(optionSelectedPredicate(optionDef, selectedIds, false)).toBe(
           true,
@@ -619,19 +619,19 @@ describe('DtFilterField Util', () => {
         const optionSource = { name: 'Option 1', uid: '1', autocomplete: [] };
         const selectedIds = new Set([optionSource.uid]);
         let optionDef = dtOptionDef(
-          optionSource.name,
           optionSource,
-          optionSource.uid,
           null,
+          optionSource.name,
+          optionSource.uid,
           null,
           null,
         );
         optionDef = dtAutocompleteDef(
+          optionSource,
+          optionDef,
           [],
           false,
           false,
-          optionSource,
-          optionDef,
         );
         expect(optionSelectedPredicate(optionDef, selectedIds, true)).toBe(
           false,
@@ -645,14 +645,14 @@ describe('DtFilterField Util', () => {
       const optionSource = { name: 'Option 1', uid: '1' };
       const selectedIds = new Set([optionSource.uid]);
       const optionDef = dtOptionDef(
-        optionSource.name,
         optionSource,
+        null,
+        optionSource.name,
         optionSource.uid,
         null,
         null,
-        null,
       );
-      const groupDef = dtGroupDef('Group 1', [optionDef], {}, null, null);
+      const groupDef = dtGroupDef({}, null, 'Group 1', [optionDef], null);
       optionDef.option!.parentGroup = groupDef;
       expect(optionOrGroupFilteredPredicate(groupDef, selectedIds, false)).toBe(
         false,
@@ -666,27 +666,27 @@ describe('DtFilterField Util', () => {
       const option1Source = { name: 'Option 1', uid: '1' };
       const option2Source = { name: 'Option 2', uid: '2' };
       const option1Def = dtOptionDef(
-        option1Source.name,
         option1Source,
-        option1Source.uid,
         null,
+        option1Source.name,
+        option1Source.uid,
         null,
         null,
       );
       const option2Def = dtOptionDef(
-        option2Source.name,
         option2Source,
-        option2Source.uid,
         null,
+        option2Source.name,
+        option2Source.uid,
         null,
         null,
       );
       const selectedIds = new Set([option1Source.uid]);
       const groupDef = dtGroupDef(
-        'Group 1',
-        [option1Def, option2Def],
         {},
         null,
+        'Group 1',
+        [option1Def, option2Def],
         null,
       );
       option1Def.option!.parentGroup = groupDef;
@@ -700,28 +700,28 @@ describe('DtFilterField Util', () => {
       const option1Source = { name: 'Option 1', uid: '1' };
       const option2Source = { name: 'Option 2', uid: '2' };
       const option1Def = dtOptionDef(
-        option1Source.name,
         option1Source,
-        option1Source.uid,
         null,
+        option1Source.name,
+        option1Source.uid,
         null,
         null,
       );
       const option2Def = dtOptionDef(
-        option2Source.name,
         option2Source,
-        option2Source.uid,
         null,
+        option2Source.name,
+        option2Source.uid,
         null,
         null,
       );
 
       const selectedIds = new Set([option1Source.uid]);
       const groupDef = dtGroupDef(
-        'Group 1',
-        [option1Def, option2Def],
         {},
         null,
+        'Group 1',
+        [option1Def, option2Def],
         null,
       );
       option1Def.option!.parentGroup = groupDef;
@@ -735,27 +735,27 @@ describe('DtFilterField Util', () => {
       const option1Source = { name: 'Option 1', uid: '1' };
       const option2Source = { name: 'Option 2', uid: '2' };
       const option1Def = dtOptionDef(
-        option1Source.name,
         option1Source,
-        option1Source.uid,
         null,
+        option1Source.name,
+        option1Source.uid,
         null,
         null,
       );
       const option2Def = dtOptionDef(
-        option2Source.name,
         option2Source,
-        option2Source.uid,
         null,
+        option2Source.name,
+        option2Source.uid,
         null,
         null,
       );
       const selectedIds = new Set();
       const groupDef = dtGroupDef(
-        'Group 1',
-        [option1Def, option2Def],
         {},
         null,
+        'Group 1',
+        [option1Def, option2Def],
         null,
       );
       option1Def.option!.parentGroup = groupDef;
@@ -771,22 +771,22 @@ describe('DtFilterField Util', () => {
 
   describe('defDistinctPredicate', () => {
     it('should return true if an autocomplete is async and also an option; it is not selected and not distinct', () => {
-      let def = dtAutocompleteDef([], false, true, {}, null);
-      def = dtOptionDef('foo', {}, 'id0', def, null, null);
+      let def = dtAutocompleteDef({}, null, [], false, true);
+      def = dtOptionDef({}, null, 'foo', 'id0', def, null);
       const ids = new Set(['id1']);
       expect(defDistinctPredicate(def, ids, false)).toBe(true);
     });
 
     it('should return true if an autocomplete is async and also an option; it is selected but not distinct', () => {
-      let def = dtAutocompleteDef([], false, true, {}, null);
-      def = dtOptionDef('foo', {}, 'id0', def, null, null);
+      let def = dtAutocompleteDef({}, null, [], false, true);
+      def = dtOptionDef({}, def, 'foo', 'id0', def, null);
       const ids = new Set(['id0', 'id1']);
       expect(defDistinctPredicate(def, ids, false)).toBe(true);
     });
 
     it('should return false if an autocomplete is async and also an option; it is selected and distinct', () => {
-      let def = dtAutocompleteDef([], true, true, {}, null);
-      def = dtOptionDef('foo', {}, 'id0', def, null, null);
+      let def = dtAutocompleteDef({}, null, [], true, true);
+      def = dtOptionDef({}, null, 'foo', 'id0', def, null);
       const ids = new Set(['id0', 'id1']);
       expect(defDistinctPredicate(def, ids, false)).toBe(false);
     });
@@ -809,14 +809,14 @@ describe('DtFilterField Util', () => {
       validator = { validatorFn: Validators.required, error: 'is required' };
     });
     it('should create a dtFreeTextDef with the deprecated API without validators and unique and no existing def', () => {
-      const freeTextDef = dtFreeTextDef([], optionSource, null);
+      const freeTextDef = dtFreeTextDef(optionSource, null, [], []);
       expect(isDtFreeTextDef(freeTextDef)).toBeTruthy();
       expect(freeTextDef.freeText!.suggestions).toEqual([]);
       expect(freeTextDef.freeText!.unique).toBeFalsy();
       expect(freeTextDef.freeText!.validators).toEqual([]);
     });
     it('should create a dtFreeTextDef with the deprecated API without validators and unique', () => {
-      const freeTextDef = dtFreeTextDef([], optionSource, optionDef);
+      const freeTextDef = dtFreeTextDef(optionSource, optionDef, [], []);
       expect(isDtFreeTextDef(freeTextDef)).toBeTruthy();
       expect(freeTextDef.freeText!.suggestions).toEqual([]);
       expect(freeTextDef.freeText!.unique).toBeFalsy();
@@ -824,10 +824,10 @@ describe('DtFilterField Util', () => {
     });
     it('should create a dtFreeTextDef with validators', () => {
       const freeTextDef = dtFreeTextDef(
-        [],
-        [validator],
         optionSource,
         optionDef,
+        [],
+        [validator],
       );
       expect(isDtFreeTextDef(freeTextDef)).toBeTruthy();
       expect(freeTextDef.freeText!.suggestions).toEqual([]);
@@ -837,11 +837,11 @@ describe('DtFilterField Util', () => {
 
     it('should create a dtFreeTextDef with validators', () => {
       const freeTextDef = dtFreeTextDef(
+        optionSource,
+        optionDef,
         [],
         [validator],
         true,
-        optionSource,
-        optionDef,
       );
       expect(isDtFreeTextDef(freeTextDef)).toBeTruthy();
       expect(freeTextDef.freeText!.suggestions).toEqual([]);
@@ -855,14 +855,14 @@ describe('DtFilterField Util', () => {
       const optionSource = { name: 'Option 1', uid: '1' };
       const selectedIds = new Set([optionSource.uid]);
       const optionDef = dtOptionDef(
-        optionSource.name,
         optionSource,
+        null,
+        optionSource.name,
         optionSource.uid,
         null,
         null,
-        null,
       );
-      const freeTextDef = dtFreeTextDef([], [], true, optionSource, optionDef);
+      const freeTextDef = dtFreeTextDef(optionSource, optionDef, [], [], true);
       expect(defUniquePredicate(freeTextDef, selectedIds)).toBe(false);
     });
 
@@ -870,14 +870,14 @@ describe('DtFilterField Util', () => {
       const optionSource = { name: 'Option 1', uid: '1' };
       const selectedIds = new Set();
       const optionDef = dtOptionDef(
-        optionSource.name,
         optionSource,
+        null,
+        optionSource.name,
         optionSource.uid,
         null,
         null,
-        null,
       );
-      const freeTextDef = dtFreeTextDef([], [], true, optionSource, optionDef);
+      const freeTextDef = dtFreeTextDef(optionSource, optionDef, [], [], true);
       expect(defUniquePredicate(freeTextDef, selectedIds)).toBe(true);
     });
 
@@ -885,14 +885,14 @@ describe('DtFilterField Util', () => {
       const optionSource = { name: 'Option 1', uid: '1' };
       const selectedIds = new Set([optionSource.uid]);
       const optionDef = dtOptionDef(
-        optionSource.name,
         optionSource,
+        null,
+        optionSource.name,
         optionSource.uid,
         null,
         null,
-        null,
       );
-      const freeTextDef = dtFreeTextDef([], [], false, optionSource, optionDef);
+      const freeTextDef = dtFreeTextDef(optionSource, optionDef, [], [], false);
       expect(defUniquePredicate(freeTextDef, selectedIds)).toBe(true);
     });
 
@@ -900,21 +900,21 @@ describe('DtFilterField Util', () => {
       const optionSource = { name: 'Option 1', uid: '1' };
       const selectedIds = new Set([optionSource.uid]);
       const optionDef = dtOptionDef(
-        optionSource.name,
         optionSource,
-        optionSource.uid,
         null,
+        optionSource.name,
+        optionSource.uid,
         null,
         null,
       );
       const rangeDef = dtRangeDef(
+        optionSource,
+        optionDef,
         true,
         true,
         true,
         true,
         's',
-        optionSource,
-        optionDef,
         true,
       );
       expect(defUniquePredicate(rangeDef, selectedIds)).toBe(false);
@@ -924,21 +924,21 @@ describe('DtFilterField Util', () => {
       const optionSource = { name: 'Option 1', uid: '1' };
       const selectedIds = new Set();
       const optionDef = dtOptionDef(
-        optionSource.name,
         optionSource,
-        optionSource.uid,
         null,
+        optionSource.name,
+        optionSource.uid,
         null,
         null,
       );
       const rangeDef = dtRangeDef(
+        optionSource,
+        optionDef,
         true,
         true,
         true,
         true,
         's',
-        optionSource,
-        optionDef,
         true,
       );
       expect(defUniquePredicate(rangeDef, selectedIds)).toBe(true);
@@ -948,21 +948,21 @@ describe('DtFilterField Util', () => {
       const optionSource = { name: 'Option 1', uid: '1' };
       const selectedIds = new Set([optionSource.uid]);
       const optionDef = dtOptionDef(
-        optionSource.name,
         optionSource,
-        optionSource.uid,
         null,
+        optionSource.name,
+        optionSource.uid,
         null,
         null,
       );
       const rangeDef = dtRangeDef(
+        optionSource,
+        optionDef,
         true,
         true,
         true,
         true,
         's',
-        optionSource,
-        optionDef,
         false,
       );
       expect(defUniquePredicate(rangeDef, selectedIds)).toBe(true);
@@ -1015,17 +1015,17 @@ describe('DtFilterField Util', () => {
     it('should return true if both are options and both have the same uid without initial uid', () => {
       const optionSource = { name: 'Option 1' };
       const a = dtOptionDef(
-        optionSource.name,
         optionSource,
         null,
+        optionSource.name,
         null,
         null,
         null,
       ) as DtAutocompleteValue;
       const b = dtOptionDef(
-        optionSource.name,
         optionSource,
         null,
+        optionSource.name,
         null,
         null,
         null,
@@ -1036,17 +1036,17 @@ describe('DtFilterField Util', () => {
     it('should return true if both are options and both have the same uid with a already having a uid', () => {
       const optionSource = { name: 'Option 1' };
       const a = dtOptionDef(
-        optionSource.name,
         optionSource,
-        `${optionSource.name}${DELIMITER}`,
         null,
+        optionSource.name,
+        `${optionSource.name}${DELIMITER}`,
         null,
         null,
       ) as DtAutocompleteValue;
       const b = dtOptionDef(
-        optionSource.name,
         optionSource,
         null,
+        optionSource.name,
         null,
         null,
         null,
@@ -1059,17 +1059,17 @@ describe('DtFilterField Util', () => {
       const prefix = `US${DELIMITER}`;
       const optionSource = { name: 'Option 1' };
       const a = dtOptionDef(
-        optionSource.name,
         optionSource,
-        `${prefix}${optionSource.name}${DELIMITER}`,
         null,
+        optionSource.name,
+        `${prefix}${optionSource.name}${DELIMITER}`,
         null,
         null,
       ) as DtAutocompleteValue;
       const b = dtOptionDef(
-        optionSource.name,
         optionSource,
         null,
+        optionSource.name,
         null,
         null,
         null,
@@ -1081,18 +1081,18 @@ describe('DtFilterField Util', () => {
     it('should return false if options dont match with the uid', () => {
       const optionSourceA = { name: 'Option 1' };
       const a = dtOptionDef(
-        optionSourceA.name,
         optionSourceA,
         null,
+        optionSourceA.name,
         null,
         null,
         null,
       ) as DtAutocompleteValue;
       const optionSourceB = { name: 'Option 2' };
       const b = dtOptionDef(
-        optionSourceB.name,
         optionSourceB,
         null,
+        optionSourceB.name,
         null,
         null,
         null,
@@ -1103,19 +1103,19 @@ describe('DtFilterField Util', () => {
     it('should return false if options dont match with the uid already set', () => {
       const optionSourceA = { name: 'Option 1' };
       const a = dtOptionDef(
-        optionSourceA.name,
         optionSourceA,
         null,
+        optionSourceA.name,
         null,
         null,
         null,
       ) as DtAutocompleteValue;
       const optionSourceB = { name: 'Option 2' };
       const b = dtOptionDef(
-        optionSourceB.name,
         optionSourceB,
-        `${optionSourceB.name}${DELIMITER}`,
         null,
+        optionSourceB.name,
+        `${optionSourceB.name}${DELIMITER}`,
         null,
         null,
       ) as DtAutocompleteValue;

--- a/components/filter-field/src/filter-field-util.spec.ts
+++ b/components/filter-field/src/filter-field-util.spec.ts
@@ -182,7 +182,9 @@ describe('DtFilterField Util', () => {
 
   describe('findDefForSourceObj', () => {
     it('should return null if the provided root definition is not of type autocomplete', () => {
-      expect(findDefForSource({}, dtFreeTextDef({}, null, [], []))).toBe(null);
+      expect(findDefForSource({}, dtFreeTextDef({}, null, [], [], false))).toBe(
+        null,
+      );
       expect(
         findDefForSource({}, dtOptionDef({}, null, '', null, null, null)),
       ).toBe(null);
@@ -446,7 +448,7 @@ describe('DtFilterField Util', () => {
         null,
         null,
       );
-      const freeTextDef = dtFreeTextDef(optionSource, optionDef, [], []);
+      const freeTextDef = dtFreeTextDef(optionSource, optionDef, [], [], false);
       const autocompleteDef = dtAutocompleteDef(
         autocompleteSource,
         null,
@@ -480,7 +482,7 @@ describe('DtFilterField Util', () => {
         null,
         null,
       );
-      const freeTextDef = dtFreeTextDef(optionSource, optionDef, [], []);
+      const freeTextDef = dtFreeTextDef(optionSource, optionDef, [], [], false);
       const groupDef = dtGroupDef(
         groupSource,
         null,
@@ -809,14 +811,14 @@ describe('DtFilterField Util', () => {
       validator = { validatorFn: Validators.required, error: 'is required' };
     });
     it('should create a dtFreeTextDef with the deprecated API without validators and unique and no existing def', () => {
-      const freeTextDef = dtFreeTextDef(optionSource, null, [], []);
+      const freeTextDef = dtFreeTextDef(optionSource, null, [], [], false);
       expect(isDtFreeTextDef(freeTextDef)).toBeTruthy();
       expect(freeTextDef.freeText!.suggestions).toEqual([]);
       expect(freeTextDef.freeText!.unique).toBeFalsy();
       expect(freeTextDef.freeText!.validators).toEqual([]);
     });
     it('should create a dtFreeTextDef with the deprecated API without validators and unique', () => {
-      const freeTextDef = dtFreeTextDef(optionSource, optionDef, [], []);
+      const freeTextDef = dtFreeTextDef(optionSource, optionDef, [], [], false);
       expect(isDtFreeTextDef(freeTextDef)).toBeTruthy();
       expect(freeTextDef.freeText!.suggestions).toEqual([]);
       expect(freeTextDef.freeText!.unique).toBeFalsy();
@@ -828,6 +830,7 @@ describe('DtFilterField Util', () => {
         optionDef,
         [],
         [validator],
+        false,
       );
       expect(isDtFreeTextDef(freeTextDef)).toBeTruthy();
       expect(freeTextDef.freeText!.suggestions).toEqual([]);

--- a/components/filter-field/src/filter-field-util.spec.ts
+++ b/components/filter-field/src/filter-field-util.spec.ts
@@ -42,9 +42,9 @@ import {
   peekOptionId,
 } from './filter-field-util';
 import {
-  DtAutocompleteValue,
-  DtFilterValue,
-  DtRangeValue,
+  _DtAutocompleteValue,
+  _DtFilterValue,
+  _DtRangeValue,
   dtRangeDef,
   isDtFreeTextDef,
 } from './types';
@@ -319,7 +319,7 @@ describe('DtFilterField Util', () => {
       );
       optionDef.option!.parentAutocomplete = autocompleteDef;
 
-      const values = [optionDef] as DtFilterValue[];
+      const values = [optionDef] as _DtFilterValue[];
       const tagData = createTagDataForFilterValues(values);
 
       expect(tagData).not.toBeNull();
@@ -361,7 +361,7 @@ describe('DtFilterField Util', () => {
       optionDef.option!.parentGroup = groupDef;
       groupDef.group!.parentAutocomplete = autocompleteDef;
 
-      const values = [optionDef] as DtFilterValue[];
+      const values = [optionDef] as _DtFilterValue[];
       const tagData = createTagDataForFilterValues(values);
 
       expect(tagData).not.toBeNull();
@@ -413,7 +413,7 @@ describe('DtFilterField Util', () => {
       );
       outerOptionAutocompleteDef.option!.parentAutocomplete = rootAutocompleteDef;
 
-      const values = [outerOptionDef, innerOptionDef] as DtFilterValue[];
+      const values = [outerOptionDef, innerOptionDef] as _DtFilterValue[];
       const tagData = createTagDataForFilterValues(values);
 
       expect(tagData).not.toBeNull();
@@ -458,7 +458,7 @@ describe('DtFilterField Util', () => {
       );
       freeTextDef.option!.parentAutocomplete = autocompleteDef;
 
-      const values = [freeTextDef, 'Some Text'] as DtFilterValue[];
+      const values = [freeTextDef, 'Some Text'] as _DtFilterValue[];
       const tagData = createTagDataForFilterValues(values);
 
       expect(tagData).not.toBeNull();
@@ -501,7 +501,7 @@ describe('DtFilterField Util', () => {
       freeTextDef.option!.parentAutocomplete = autocompleteDef;
       groupDef.group!.parentAutocomplete = autocompleteDef;
 
-      const values = [optionDef, 'Some Text'] as DtFilterValue[];
+      const values = [optionDef, 'Some Text'] as _DtFilterValue[];
       const tagData = createTagDataForFilterValues(values);
 
       expect(tagData).not.toBeNull();
@@ -974,13 +974,13 @@ describe('DtFilterField Util', () => {
 
   describe('isDtRangeValueEqual', () => {
     it('should return true if range values are equal', () => {
-      const test: DtRangeValue = { operator: '=', range: 1 };
+      const test: _DtRangeValue = { operator: '=', range: 1 };
       expect(isDtRangeValueEqual(test, test)).toBeTruthy();
 
-      const test1: DtRangeValue = { operator: 'range', range: [1, 2] };
+      const test1: _DtRangeValue = { operator: 'range', range: [1, 2] };
       expect(isDtRangeValueEqual(test1, test1)).toBeTruthy();
 
-      const test2: DtRangeValue = {
+      const test2: _DtRangeValue = {
         operator: 'range',
         range: [1, 2],
         unit: 's',
@@ -988,28 +988,28 @@ describe('DtFilterField Util', () => {
       expect(isDtRangeValueEqual(test2, test2)).toBeTruthy();
     });
     it('should return true if range values have different array instances but the same values within', () => {
-      const a: DtRangeValue = { operator: 'range', range: [1, 2] };
-      const b: DtRangeValue = { operator: 'range', range: [1, 2] };
+      const a: _DtRangeValue = { operator: 'range', range: [1, 2] };
+      const b: _DtRangeValue = { operator: 'range', range: [1, 2] };
       expect(isDtRangeValueEqual(a, b)).toBeTruthy();
     });
     it('should return false when a has unit set but b does not', () => {
-      const a: DtRangeValue = { operator: 'range', range: [1, 2] };
-      const b: DtRangeValue = { operator: 'range', range: [1, 2], unit: 's' };
+      const a: _DtRangeValue = { operator: 'range', range: [1, 2] };
+      const b: _DtRangeValue = { operator: 'range', range: [1, 2], unit: 's' };
       expect(isDtRangeValueEqual(a, b)).toBeFalsy();
     });
     it('should return false when a has different numbers in the range array than b', () => {
-      const a: DtRangeValue = { operator: 'range', range: [1, 2] };
-      const b: DtRangeValue = { operator: 'range', range: [2, 3] };
+      const a: _DtRangeValue = { operator: 'range', range: [1, 2] };
+      const b: _DtRangeValue = { operator: 'range', range: [2, 3] };
       expect(isDtRangeValueEqual(a, b)).toBeFalsy();
     });
     it('should return false when a has the range numbers ordered differently than than b', () => {
-      const a: DtRangeValue = { operator: 'range', range: [1, 2] };
-      const b: DtRangeValue = { operator: 'range', range: [2, 1] };
+      const a: _DtRangeValue = { operator: 'range', range: [1, 2] };
+      const b: _DtRangeValue = { operator: 'range', range: [2, 1] };
       expect(isDtRangeValueEqual(a, b)).toBeFalsy();
     });
     it('should return false when a has the range array and b has a number', () => {
-      const a: DtRangeValue = { operator: 'range', range: [1, 2] };
-      const b: DtRangeValue = { operator: 'range', range: 1 };
+      const a: _DtRangeValue = { operator: 'range', range: [1, 2] };
+      const b: _DtRangeValue = { operator: 'range', range: 1 };
       expect(isDtRangeValueEqual(a, b)).toBeFalsy();
     });
   });
@@ -1024,7 +1024,7 @@ describe('DtFilterField Util', () => {
         null,
         null,
         null,
-      ) as DtAutocompleteValue;
+      ) as _DtAutocompleteValue;
       const b = dtOptionDef(
         optionSource,
         null,
@@ -1032,7 +1032,7 @@ describe('DtFilterField Util', () => {
         null,
         null,
         null,
-      ) as DtAutocompleteValue;
+      ) as _DtAutocompleteValue;
       expect(isDtAutocompleteValueEqual(a, b)).toBeTruthy();
       expect(isDtAutocompleteValueEqual(b, a)).toBeTruthy();
     });
@@ -1045,7 +1045,7 @@ describe('DtFilterField Util', () => {
         `${optionSource.name}${DELIMITER}`,
         null,
         null,
-      ) as DtAutocompleteValue;
+      ) as _DtAutocompleteValue;
       const b = dtOptionDef(
         optionSource,
         null,
@@ -1053,7 +1053,7 @@ describe('DtFilterField Util', () => {
         null,
         null,
         null,
-      ) as DtAutocompleteValue;
+      ) as _DtAutocompleteValue;
       expect(isDtAutocompleteValueEqual(a, b)).toBeTruthy();
       expect(isDtAutocompleteValueEqual(b, a)).toBeTruthy();
     });
@@ -1068,7 +1068,7 @@ describe('DtFilterField Util', () => {
         `${prefix}${optionSource.name}${DELIMITER}`,
         null,
         null,
-      ) as DtAutocompleteValue;
+      ) as _DtAutocompleteValue;
       const b = dtOptionDef(
         optionSource,
         null,
@@ -1076,7 +1076,7 @@ describe('DtFilterField Util', () => {
         null,
         null,
         null,
-      ) as DtAutocompleteValue;
+      ) as _DtAutocompleteValue;
       expect(isDtAutocompleteValueEqual(a, b, prefix)).toBeTruthy();
       expect(isDtAutocompleteValueEqual(b, a, prefix)).toBeTruthy();
     });
@@ -1090,7 +1090,7 @@ describe('DtFilterField Util', () => {
         null,
         null,
         null,
-      ) as DtAutocompleteValue;
+      ) as _DtAutocompleteValue;
       const optionSourceB = { name: 'Option 2' };
       const b = dtOptionDef(
         optionSourceB,
@@ -1099,7 +1099,7 @@ describe('DtFilterField Util', () => {
         null,
         null,
         null,
-      ) as DtAutocompleteValue;
+      ) as _DtAutocompleteValue;
       expect(isDtAutocompleteValueEqual(a, b)).toBeFalsy();
       expect(isDtAutocompleteValueEqual(b, a)).toBeFalsy();
     });
@@ -1112,7 +1112,7 @@ describe('DtFilterField Util', () => {
         null,
         null,
         null,
-      ) as DtAutocompleteValue;
+      ) as _DtAutocompleteValue;
       const optionSourceB = { name: 'Option 2' };
       const b = dtOptionDef(
         optionSourceB,
@@ -1121,7 +1121,7 @@ describe('DtFilterField Util', () => {
         `${optionSourceB.name}${DELIMITER}`,
         null,
         null,
-      ) as DtAutocompleteValue;
+      ) as _DtAutocompleteValue;
       expect(isDtAutocompleteValueEqual(a, b)).toBeFalsy();
       expect(isDtAutocompleteValueEqual(b, a)).toBeFalsy();
     });

--- a/components/filter-field/src/filter-field-util.ts
+++ b/components/filter-field/src/filter-field-util.ts
@@ -57,11 +57,11 @@ export function filterAutocompleteDef(
     .filter(optionOrGroup => optionOrGroup !== null) as DtNodeDef[];
   return def.autocomplete!.async || optionsOrGroups.length
     ? dtAutocompleteDef(
+        def.data,
+        def,
         optionsOrGroups,
         def.autocomplete!.distinct,
         def.autocomplete!.async,
-        def.data,
-        def,
       )
     : null;
 }
@@ -78,11 +78,11 @@ export function filterFreeTextDef(
     : [];
 
   return dtFreeTextDef(
+    def.data,
+    def,
     suggestions,
     def.freeText!.validators || [],
     isDefined(def.freeText!.unique) ? def.freeText!.unique! : false,
-    def.data,
-    def,
   );
 }
 
@@ -100,11 +100,11 @@ export function filterGroupDef(
   );
   return options.length
     ? dtGroupDef(
+        def,
+        def.group!.parentAutocomplete,
         def.group!.label,
         options,
         def.data,
-        def,
-        def.group!.parentAutocomplete,
       )
     : null;
 }

--- a/components/filter-field/src/filter-field-util.ts
+++ b/components/filter-field/src/filter-field-util.ts
@@ -18,24 +18,24 @@ import { isDefined } from '@dynatrace/barista-components/core';
 
 import { DtFilterFieldDataSource } from './filter-field-data-source';
 import {
-  DtAutocompleteValue,
-  DtFilterFieldTagData,
-  DtFilterValue,
-  DtFreeTextValue,
+  _DtAutocompleteValue,
+  _DtFilterFieldTagData,
+  _DtFilterValue,
+  _DtFreeTextValue,
   DtNodeDef,
-  DtRangeValue,
+  _DtRangeValue,
   dtAutocompleteDef,
   dtFreeTextDef,
   dtGroupDef,
   isAsyncDtAutocompleteDef,
   isDtAutocompleteDef,
-  isDtAutocompleteValue,
+  _isDtAutocompleteValue,
   isDtFreeTextDef,
   isDtFreeTextValue,
   isDtGroupDef,
   isDtOptionDef,
   isDtRangeDef,
-  isDtRangeValue,
+  _isDtRangeValue,
   isDtRenderType,
 } from './types';
 
@@ -259,7 +259,7 @@ function isOptionSelected(def: DtNodeDef, selectedIds: Set<string>): boolean {
 /** Transforms a RangeSource to the Tag data values. */
 // tslint:disable-next-line: no-any
 function transformRangeSourceToTagData(
-  result: DtRangeValue,
+  result: _DtRangeValue,
 ): { separator: string; value: string } {
   if (result.operator === 'range') {
     return {
@@ -287,10 +287,10 @@ function transformRangeSourceToTagData(
 }
 
 export function createTagDataForFilterValues(
-  filterValues: DtFilterValue[],
+  filterValues: _DtFilterValue[],
   editable?: boolean,
   deletable?: boolean,
-): DtFilterFieldTagData | null {
+): _DtFilterFieldTagData | null {
   let key: string | null = null;
   let value: string | null = null;
   let separator: string | null = null;
@@ -298,7 +298,7 @@ export function createTagDataForFilterValues(
   let isFirstValue = true;
 
   for (const filterValue of filterValues) {
-    if (isDtAutocompleteValue(filterValue)) {
+    if (_isDtAutocompleteValue(filterValue)) {
       if (isFirstValue && filterValues.length > 1) {
         key = filterValue.option.viewValue;
       }
@@ -310,7 +310,7 @@ export function createTagDataForFilterValues(
         separator = '~';
       }
       break;
-    } else if (isDtRangeValue(filterValue)) {
+    } else if (_isDtRangeValue(filterValue)) {
       // Assigning variables destructed variables to already defined ones needs to be within braces.
       ({ value, separator } = transformRangeSourceToTagData(filterValue));
       break;
@@ -319,7 +319,7 @@ export function createTagDataForFilterValues(
   }
 
   return filterValues.length && value !== null
-    ? new DtFilterFieldTagData(
+    ? new _DtFilterFieldTagData(
         key,
         value,
         separator,
@@ -336,8 +336,8 @@ export function findFilterValuesForSources<T>(
   rootDef: DtNodeDef,
   asyncDefs: Map<DtNodeDef, DtNodeDef>,
   dataSource: DtFilterFieldDataSource,
-): DtFilterValue[] | null {
-  const foundValues: DtFilterValue[] = [];
+): _DtFilterValue[] | null {
+  const foundValues: _DtFilterValue[] = [];
   let parentDef = rootDef;
 
   for (let i = 0; i < sources.length; i++) {
@@ -350,7 +350,7 @@ export function findFilterValuesForSources<T>(
     if (
       isLastSource &&
       ((isDtFreeTextValue(source) && isDtFreeTextDef(parentDef)) ||
-        (isDtRangeValue(source) && isDtRangeDef(parentDef)))
+        (_isDtRangeValue(source) && isDtRangeDef(parentDef)))
     ) {
       foundValues.push(source);
       return foundValues;
@@ -363,7 +363,7 @@ export function findFilterValuesForSources<T>(
           const asyncDef = asyncDefs.get(def);
           if (asyncDef) {
             parentDef = asyncDef;
-            foundValues.push(def, asyncDef as DtAutocompleteValue);
+            foundValues.push(def, asyncDef as _DtAutocompleteValue);
           } else {
             parentDef = def;
             foundValues.push(def);
@@ -468,8 +468,8 @@ export function applyDtOptionIds(
 
 /** Checks whether two autocomplete values are both options and have the same uid */
 export function isDtAutocompleteValueEqual(
-  a: DtAutocompleteValue,
-  b: DtAutocompleteValue,
+  a: _DtAutocompleteValue,
+  b: _DtAutocompleteValue,
   prefix?: string,
 ): boolean {
   return peekOptionId(a, prefix) === peekOptionId(b, prefix);
@@ -477,14 +477,17 @@ export function isDtAutocompleteValueEqual(
 
 /** Checks whether two freetext values are equal */
 export function isDtFreeTextValueEqual(
-  a: DtFreeTextValue,
-  b: DtFreeTextValue,
+  a: _DtFreeTextValue,
+  b: _DtFreeTextValue,
 ): boolean {
   return a === b;
 }
 
 /** Checks whether two range values are equal */
-export function isDtRangeValueEqual(a: DtRangeValue, b: DtRangeValue): boolean {
+export function isDtRangeValueEqual(
+  a: _DtRangeValue,
+  b: _DtRangeValue,
+): boolean {
   if (a.operator === b.operator && a.unit === b.unit) {
     return Array.isArray(a.range) && Array.isArray(b.range)
       ? a.range.join(DELIMITER) === b.range.join(DELIMITER)

--- a/components/filter-field/src/filter-field.spec.ts
+++ b/components/filter-field/src/filter-field.spec.ts
@@ -844,7 +844,7 @@ describe('DtFilterField', () => {
 
       it('should throw', () => {
         expect(() => {
-          dtRangeDef({}, null, false, false, false, false, 's');
+          dtRangeDef({}, null, false, false, false, false, 's', false);
         }).toThrowError(
           wrappedErrorMessage(getDtFilterFieldRangeNoOperatorsError()),
         );

--- a/components/filter-field/src/filter-field.spec.ts
+++ b/components/filter-field/src/filter-field.spec.ts
@@ -844,7 +844,7 @@ describe('DtFilterField', () => {
 
       it('should throw', () => {
         expect(() => {
-          dtRangeDef(false, false, false, false, 's', {}, null);
+          dtRangeDef({}, null, false, false, false, false, 's');
         }).toThrowError(
           wrappedErrorMessage(getDtFilterFieldRangeNoOperatorsError()),
         );

--- a/components/filter-field/src/filter-field.ts
+++ b/components/filter-field/src/filter-field.ts
@@ -108,19 +108,19 @@ import {
 } from './filter-field-util';
 import { DtFilterFieldControl } from './filter-field-validation';
 import {
-  DtAutocompleteValue,
-  DtFilterFieldTagData,
-  DtFilterValue,
+  _DtAutocompleteValue,
+  _DtFilterFieldTagData,
+  _DtFilterValue,
   DtNodeDef,
-  getSourcesOfDtFilterValues,
+  _getSourcesOfDtFilterValues,
   isAsyncDtAutocompleteDef,
   isDtAutocompleteDef,
-  isDtAutocompleteValue,
+  _isDtAutocompleteValue,
   isDtFreeTextDef,
   isDtFreeTextValue,
   isDtOptionDef,
   isDtRangeDef,
-  isDtRangeValue,
+  _isDtRangeValue,
 } from './types';
 
 // tslint:disable:no-any
@@ -213,13 +213,13 @@ export class DtFilterField<T> implements AfterViewInit, OnDestroy, OnChanges {
   /** Currently applied filters */
   @Input()
   get filters(): any[][] {
-    return this._filters.map(values => getSourcesOfDtFilterValues(values));
+    return this._filters.map(values => _getSourcesOfDtFilterValues(values));
   }
   set filters(value: any[][]) {
     this._tryApplyFilters(value);
     this._changeDetectorRef.markForCheck();
   }
-  private _filters: DtFilterValue[][] = [];
+  private _filters: _DtFilterValue[][] = [];
 
   /** Set the Aria-Label attribute */
   @Input('aria-label') ariaLabel = '';
@@ -279,7 +279,7 @@ export class DtFilterField<T> implements AfterViewInit, OnDestroy, OnChanges {
   >;
 
   /** @internal List of sources of the filter that the user currently works on. */
-  _currentFilterValues: DtFilterValue[] = [];
+  _currentFilterValues: _DtFilterValue[] = [];
 
   /**
    * @internal
@@ -303,13 +303,13 @@ export class DtFilterField<T> implements AfterViewInit, OnDestroy, OnChanges {
   _autocompleteOptionsOrGroups: DtNodeDef[] = [];
 
   /** @internal Filter nodes to be rendered _before_ the input element. */
-  _prefixTagData: DtFilterFieldTagData[] = [];
+  _prefixTagData: _DtFilterFieldTagData[] = [];
 
   /** @internal Filter nodes to be rendered _after_ the input element. */
-  _suffixTagData: DtFilterFieldTagData[] = [];
+  _suffixTagData: _DtFilterFieldTagData[] = [];
 
   /** Holds all tagdata including the data for a tag that might be edited */
-  tagData: DtFilterFieldTagData[] = [];
+  tagData: _DtFilterFieldTagData[] = [];
 
   /**
    * @internal
@@ -357,7 +357,7 @@ export class DtFilterField<T> implements AfterViewInit, OnDestroy, OnChanges {
   private readonly _destroy = new Subject<void>();
 
   /** Member value that holds the previous filter values, to reset them if edit-mode is cancelled. */
-  private _editModeStashedValue: DtFilterValue[] | null;
+  private _editModeStashedValue: _DtFilterValue[] | null;
 
   /** Whether the filter field or one of it's child elements is focused. */
   private _isFocused = false;
@@ -575,7 +575,7 @@ export class DtFilterField<T> implements AfterViewInit, OnDestroy, OnChanges {
     if (!this._currentFilterValues.length && event.data.filterValues.length) {
       const value = event.data.filterValues[0];
       if (
-        (isDtAutocompleteValue(value) && isDtAutocompleteDef(value)) ||
+        (_isDtAutocompleteValue(value) && isDtAutocompleteDef(value)) ||
         isDtRangeDef(value) ||
         isDtFreeTextDef(value)
       ) {
@@ -594,7 +594,7 @@ export class DtFilterField<T> implements AfterViewInit, OnDestroy, OnChanges {
         if (removed.length === 1) {
           // Needed to reassign in order for typescript to understand the type.
           const recentRangeValue = removed[0];
-          if (isDtRangeValue(recentRangeValue) && this._currentDef.range) {
+          if (_isDtRangeValue(recentRangeValue) && this._currentDef.range) {
             // Needed to set this in typescript, because template binding of input would be evaluated to late.
             this._filterfieldRange.enabledOperators = this._currentDef.range.operatorFlags;
             this._filterfieldRange._setValues(recentRangeValue.range);
@@ -626,8 +626,8 @@ export class DtFilterField<T> implements AfterViewInit, OnDestroy, OnChanges {
     const { remaining, removed } = this.tagData.reduce(
       (
         aggregator: {
-          remaining: DtFilterValue[][];
-          removed: DtFilterValue[][];
+          remaining: _DtFilterValue[][];
+          removed: _DtFilterValue[][];
         },
         data,
       ) => {
@@ -648,7 +648,7 @@ export class DtFilterField<T> implements AfterViewInit, OnDestroy, OnChanges {
   }
 
   /** Returns the index in the filters for the filter values given or -1 if not found */
-  private _findIndexForFilter(needleFilterValueArr: DtFilterValue[]): number {
+  private _findIndexForFilter(needleFilterValueArr: _DtFilterValue[]): number {
     return this._filters.findIndex(filterValueArr => {
       // check whether the length is the same, if not we can quit here
       if (filterValueArr.length !== needleFilterValueArr.length) {
@@ -664,16 +664,16 @@ export class DtFilterField<T> implements AfterViewInit, OnDestroy, OnChanges {
           (isDtFreeTextValue(filterValue) &&
             isDtFreeTextValue(needleFilterValue) &&
             isDtFreeTextValueEqual(filterValue, needleFilterValue)) ||
-          (isDtRangeValue(filterValue) &&
-            isDtRangeValue(needleFilterValue) &&
+          (_isDtRangeValue(filterValue) &&
+            _isDtRangeValue(needleFilterValue) &&
             isDtRangeValueEqual(filterValue, needleFilterValue))
         ) {
           idx++;
           continue;
         }
         if (
-          isDtAutocompleteValue(filterValue) &&
-          isDtAutocompleteValue(needleFilterValue) &&
+          _isDtAutocompleteValue(filterValue) &&
+          _isDtAutocompleteValue(needleFilterValue) &&
           isDtAutocompleteValueEqual(filterValue, needleFilterValue, prefix)
         ) {
           prefix = peekOptionId(filterValue, undefined, true);
@@ -761,7 +761,7 @@ export class DtFilterField<T> implements AfterViewInit, OnDestroy, OnChanges {
   private _handleAutocompleteSelected(
     event: DtAutocompleteSelectedEvent<DtNodeDef>,
   ): void {
-    const optionDef = event.option.value as DtAutocompleteValue;
+    const optionDef = event.option.value as _DtAutocompleteValue;
     this._peekCurrentFilterValues().push(optionDef);
     // Reset input value to empty string after handling the value provided by the autocomplete.
     // Otherwise the value of the autocomplete would be in the input elements and the next options
@@ -857,7 +857,7 @@ export class DtFilterField<T> implements AfterViewInit, OnDestroy, OnChanges {
    * Returns the currentFilterSources. If no currentFilterSources are available, a new one is created.
    * These sources will also be added to the global list of filters if they are not already part of it.
    */
-  private _peekCurrentFilterValues(): DtFilterValue[] {
+  private _peekCurrentFilterValues(): _DtFilterValue[] {
     let values = this._currentFilterValues;
     if (!values) {
       values = [];
@@ -873,7 +873,7 @@ export class DtFilterField<T> implements AfterViewInit, OnDestroy, OnChanges {
    * Removes a filter (a list of sources) from the list of current selected ones.
    * It is usually called when the user clicks the remove button of a filter
    */
-  private _removeFilterAndEmit(filterValues: DtFilterValue[]): void {
+  private _removeFilterAndEmit(filterValues: _DtFilterValue[]): void {
     const removedFilters = this._removeFilter(filterValues);
     if (filterValues.length) {
       if (filterValues === this._currentFilterValues) {
@@ -891,8 +891,8 @@ export class DtFilterField<T> implements AfterViewInit, OnDestroy, OnChanges {
   }
 
   /** Removes a filter (a list of sources) from the list of current selected ones. */
-  private _removeFilter(filterValues: DtFilterValue[]): DtFilterValue[][] {
-    let removedFilters: DtFilterValue[][] = [];
+  private _removeFilter(filterValues: _DtFilterValue[]): _DtFilterValue[][] {
+    let removedFilters: _DtFilterValue[][] = [];
     const removableIndex = this._filters.indexOf(filterValues);
     if (removableIndex !== -1) {
       removedFilters = this._filters.splice(removableIndex, 1);
@@ -905,29 +905,29 @@ export class DtFilterField<T> implements AfterViewInit, OnDestroy, OnChanges {
    * so the consumer can not override it from the outside.
    */
   private _emitFilterChanges(
-    added: DtFilterValue[][],
-    removed: DtFilterValue[][],
+    added: _DtFilterValue[][],
+    removed: _DtFilterValue[][],
   ): void {
     this.filterChanges.emit(
       new DtFilterFieldChangeEvent(
         this,
-        added.map(values => getSourcesOfDtFilterValues(values)),
-        removed.map(values => getSourcesOfDtFilterValues(values)),
+        added.map(values => _getSourcesOfDtFilterValues(values)),
+        removed.map(values => _getSourcesOfDtFilterValues(values)),
         this.filters,
       ),
     );
   }
 
   private _emitCurrentFilterChanges(
-    addedValues: DtFilterValue[],
-    removedValues: DtFilterValue[],
+    addedValues: _DtFilterValue[],
+    removedValues: _DtFilterValue[],
   ): void {
     this.currentFilterChanges.emit(
       new DtFilterFieldCurrentFilterChangeEvent(
         this,
-        getSourcesOfDtFilterValues(addedValues),
-        getSourcesOfDtFilterValues(removedValues),
-        getSourcesOfDtFilterValues(this._currentFilterValues),
+        _getSourcesOfDtFilterValues(addedValues),
+        _getSourcesOfDtFilterValues(removedValues),
+        _getSourcesOfDtFilterValues(this._currentFilterValues),
         this.filters,
       ),
     );
@@ -1047,7 +1047,7 @@ export class DtFilterField<T> implements AfterViewInit, OnDestroy, OnChanges {
     if (this._rootDef) {
       const splitIndex = this._filters.indexOf(this._currentFilterValues);
       const tags = this._filters.map((values, i) => {
-        let prevData: DtFilterFieldTagData | undefined;
+        let prevData: _DtFilterFieldTagData | undefined;
         if (this.tagData.length) {
           prevData = this.tagData[i];
         }
@@ -1065,12 +1065,12 @@ export class DtFilterField<T> implements AfterViewInit, OnDestroy, OnChanges {
 
       this._prefixTagData = this.tagData
         .slice(0, this._currentFilterValues.length ? splitIndex : undefined)
-        .filter((tag: DtFilterFieldTagData | null) => tag !== null);
+        .filter((tag: _DtFilterFieldTagData | null) => tag !== null);
 
       this._suffixTagData = this._currentFilterValues.length
         ? this.tagData
             .slice(this._filters.indexOf(this._currentFilterValues) + 1)
-            .filter((tag: DtFilterFieldTagData | null) => tag !== null)
+            .filter((tag: _DtFilterFieldTagData | null) => tag !== null)
         : [];
     }
   }
@@ -1119,7 +1119,7 @@ export class DtFilterField<T> implements AfterViewInit, OnDestroy, OnChanges {
     for (const currentFilter of this._filters) {
       let currentId = '';
       for (const value of currentFilter) {
-        if (isDtAutocompleteValue(value)) {
+        if (_isDtAutocompleteValue(value)) {
           const id = peekOptionId(value, currentId);
           ids.add(id);
           currentId = id;

--- a/components/filter-field/src/index.ts
+++ b/components/filter-field/src/index.ts
@@ -23,5 +23,24 @@ export * from './filter-field-data-source';
 export * from './filter-field-default-data-source';
 export * from './filter-field-errors';
 
-// @breaking-change 5.0.0 Export only necessary types
-export * from './types';
+export {
+  DtNodeFlags,
+  DtNodeDef,
+  isDtNodeDef,
+  DtAutocompleteDef,
+  DtFreeTextDef,
+  DtGroupDef,
+  DtOptionDef,
+  DtRangeOperatorFlags,
+  DtRangeDef,
+  dtAutocompleteDef,
+  isDtAutocompleteDef,
+  dtFreeTextDef,
+  isDtFreeTextDef,
+  dtRangeDef,
+  isDtRangeDef,
+  dtOptionDef,
+  isDtOptionDef,
+  dtGroupDef,
+  isDtGroupDef,
+} from './types';

--- a/components/filter-field/src/types.ts
+++ b/components/filter-field/src/types.ts
@@ -53,7 +53,7 @@ export interface DtAutocompleteDef {
 export interface DtFreeTextDef {
   suggestions: DtNodeDef[];
   // @breaking-change 5.0.0 To be non optional
-  validators?: DtFilterFieldValidator[];
+  validators: DtFilterFieldValidator[];
   unique: boolean;
 }
 

--- a/components/filter-field/src/types.ts
+++ b/components/filter-field/src/types.ts
@@ -54,8 +54,7 @@ export interface DtFreeTextDef {
   suggestions: DtNodeDef[];
   // @breaking-change 5.0.0 To be non optional
   validators?: DtFilterFieldValidator[];
-  // @breaking-change 5.0.0 To be non optional
-  unique?: boolean;
+  unique: boolean;
 }
 
 export interface DtGroupDef {
@@ -245,8 +244,7 @@ export function dtFreeTextDef(
   existingNodeDef: DtNodeDef | null,
   suggestions: DtNodeDef[],
   validators: DtFilterFieldValidator[],
-  // @breaking-change 5.0.0 Make mandatory
-  unique: boolean = false,
+  unique: boolean,
 ): DtNodeDef {
   const def = {
     ...nodeDef(data, existingNodeDef),

--- a/components/filter-field/src/types.ts
+++ b/components/filter-field/src/types.ts
@@ -314,12 +314,6 @@ export function isDtAutocompleteValue(
 ): value is DtAutocompleteValue {
   return isDtOptionDef(value);
 }
-/**
- * @internal
- * @deprecated Use `isDtAutocompleteValue` instead.
- * @breaking-change 5.0.0 To be removed.
- */
-export const isDtAutocompletValue = isDtAutocompleteValue;
 
 /** @internal */
 export interface DtRangeValue {

--- a/components/filter-field/src/types.ts
+++ b/components/filter-field/src/types.ts
@@ -97,18 +97,16 @@ export interface DtRangeDef {
   unique?: boolean;
 }
 
-/**
- * Creates a new DtRangeDef onto a provided existing NodeDef or a newly created one.
- * @breaking-change 5.0.0 change param order move data, exisiting nodes to be the first two params
- */
+/** Creates a new DtRangeDef onto a provided existing NodeDef or a newly created one. */
 export function dtRangeDef(
+  data: any,
+  existingNodeDef: DtNodeDef | null,
   hasRangeOperator: boolean,
   hasEqualOperator: boolean,
   hasGreaterEqualOperator: boolean,
   hasLowerEqualOperator: boolean,
   unit: string,
-  data: any,
-  existingNodeDef: DtNodeDef | null,
+  // @breaking-change 5.0.0 Make mandatory
   unique: boolean = false,
 ): DtNodeDef {
   // if none of the operators are defined, throw an error.
@@ -154,16 +152,13 @@ export function isDtRangeDef(def: any): def is DtNodeDef & DtRangeDef {
   return isDtNodeDef(def) && !!(def.nodeFlags & DtNodeFlags.TypeRange);
 }
 
-/**
- * Creates a new DtAutocompleteDef onto a provided existing NodeDef or a newly created one.
- * @breaking-change 5.0.0 change param order move data, exisiting nodes to be the first two params
- */
+/** Creates a new DtAutocompleteDef onto a provided existing NodeDef or a newly created one. */
 export function dtAutocompleteDef(
+  data: any,
+  existingNodeDef: DtNodeDef | null,
   optionsOrGroups: DtNodeDef[],
   distinct: boolean,
   async: boolean,
-  data: any,
-  existingNodeDef: DtNodeDef | null,
 ): DtNodeDef {
   const def = {
     ...nodeDef(data, existingNodeDef),
@@ -188,15 +183,12 @@ export function isAsyncDtAutocompleteDef(
   );
 }
 
-/**
- * Creates a new DtOptionDef onto a provided existing NodeDef or a newly created one.
- * @breaking-change 5.0.0 change param order move data, exisiting nodes to be the first two params
- */
+/** Creates a new DtOptionDef onto a provided existing NodeDef or a newly created one. */
 export function dtOptionDef(
-  viewValue: string,
   data: any,
-  uid: string | null,
   existingNodeDef: DtNodeDef | null,
+  viewValue: string,
+  uid: string | null,
   parentAutocomplete: DtNodeDef | null,
   parentGroup: DtNodeDef | null,
 ): DtNodeDef {
@@ -220,15 +212,12 @@ export function isDtOptionDef(
   return isDtNodeDef(def) && !!(def.nodeFlags & DtNodeFlags.TypeOption);
 }
 
-/**
- * Creates a new DtGroupDef onto a provided existing NodeDef or a newly created one.
- * @breaking-change 5.0.0 change param order move data, exisiting nodes to be the first two params
- */
+/** Creates a new DtGroupDef onto a provided existing NodeDef or a newly created one. */
 export function dtGroupDef(
-  label: string,
-  options: DtNodeDef[],
   data: any,
   existingNodeDef: DtNodeDef | null,
+  label: string,
+  options: DtNodeDef[],
   parentAutocomplete: DtNodeDef | null,
 ): DtNodeDef {
   const def = {
@@ -250,76 +239,17 @@ export function isDtGroupDef(
   return isDtNodeDef(def) && !!(def.nodeFlags & DtNodeFlags.TypeGroup);
 }
 
-/**
- * @deprecated
- * Creates a new DtFreeTextDef onto a provided existing NodeDef or a newly created one.
- *
- * @breaking-change 5.0.0 To be removed, validators required
- */
+/** Creates a new DtFreeTextDef onto a provided existing NodeDef or a newly created one. */
 export function dtFreeTextDef(
-  suggestions: DtNodeDef[],
   data: any,
   existingNodeDef: DtNodeDef | null,
-): DtNodeDef;
-
-/**
- * @deprecated
- * Creates a new DtFreeTextDef onto a provided existing NodeDef or a newly created one.
- * @breaking-change 5.0.0 To be removed, unique required
- */
-export function dtFreeTextDef(
   suggestions: DtNodeDef[],
   validators: DtFilterFieldValidator[],
-  data: any,
-  existingNodeDef: DtNodeDef | null,
-): DtNodeDef;
-
-/**
- * Creates a new DtFreeTextDef onto a provided existing NodeDef or a newly created one.
- * @breaking-change 5.0.0 change param order move data, exisiting nodes to be the first two params
- */
-export function dtFreeTextDef(
-  suggestions: DtNodeDef[],
-  validators: DtFilterFieldValidator[],
-  unique: boolean,
-  data: any,
-  existingNodeDef: DtNodeDef | null,
-): DtNodeDef;
-
-export function dtFreeTextDef(
-  suggestions: DtNodeDef[],
-  validatorsOrData: any | DtFilterFieldValidator[],
-  uniqueOrDataOrExistingNodeDef: DtNodeDef | null | any | boolean,
-  existingNodeDefOrData: DtNodeDef | null | any = null,
-  existingNodeDef: DtNodeDef | null = null,
+  // @breaking-change 5.0.0 Make mandatory
+  unique: boolean = false,
 ): DtNodeDef {
-  let data: any = validatorsOrData;
-  let validators: DtFilterFieldValidator[] = [];
-  let currentNodeDef: DtNodeDef | null = existingNodeDefOrData;
-  let unique;
-
-  if (
-    isDtNodeDef(uniqueOrDataOrExistingNodeDef) ||
-    uniqueOrDataOrExistingNodeDef === null
-  ) {
-    validators = [];
-    unique = false;
-    data = validatorsOrData;
-    currentNodeDef = uniqueOrDataOrExistingNodeDef;
-  } else if (typeof uniqueOrDataOrExistingNodeDef === 'boolean') {
-    validators = validatorsOrData;
-    unique = uniqueOrDataOrExistingNodeDef;
-    data = existingNodeDefOrData;
-    currentNodeDef = existingNodeDef;
-  } else {
-    validators = validatorsOrData;
-    unique = false;
-    data = uniqueOrDataOrExistingNodeDef;
-    currentNodeDef = existingNodeDef;
-  }
-
   const def = {
-    ...nodeDef(data, currentNodeDef),
+    ...nodeDef(data, existingNodeDef),
     freeText: { suggestions, validators, unique },
   };
   def.nodeFlags |= DtNodeFlags.TypeFreeText;

--- a/components/filter-field/src/types.ts
+++ b/components/filter-field/src/types.ts
@@ -285,45 +285,47 @@ export function isDtNodeDef(def: any): def is DtNodeDef {
 }
 
 /** @internal Holds all the view values and the original filter source for providing it to the DtFilterFieldTag to display. */
-export class DtFilterFieldTagData {
+// tslint:disable-next-line: class-name
+export class _DtFilterFieldTagData {
   constructor(
     public key: string | null,
     public value: string | null,
     public separator: string | null,
     public isFreeText: boolean,
-    public filterValues: DtFilterValue[],
+    public filterValues: _DtFilterValue[],
     public editable: boolean = true,
     public deletable: boolean = true,
   ) {}
 }
 
 /** @internal */
-export type DtFreeTextValue = string;
+export type _DtFreeTextValue = string;
 
 /** @internal */
-export function isDtFreeTextValue(value: any): value is DtFreeTextValue {
+export function isDtFreeTextValue(value: any): value is _DtFreeTextValue {
   return typeof value === 'string';
 }
 
 /** @internal */
-export type DtAutocompleteValue = DtNodeDef & { option: DtOptionDef };
+export type _DtAutocompleteValue = DtNodeDef & { option: DtOptionDef };
 
 /** @internal */
-export function isDtAutocompleteValue(
+export function _isDtAutocompleteValue(
   value: any,
-): value is DtAutocompleteValue {
+): value is _DtAutocompleteValue {
   return isDtOptionDef(value);
 }
 
 /** @internal */
-export interface DtRangeValue {
+// tslint:disable-next-line: class-name
+export interface _DtRangeValue {
   range: number | [number, number];
   operator: string;
   unit?: string;
 }
 
 /** @internal */
-export function isDtRangeValue(value: any): value is DtRangeValue {
+export function _isDtRangeValue(value: any): value is _DtRangeValue {
   return (
     isObject(value) &&
     value.hasOwnProperty('operator') &&
@@ -332,14 +334,17 @@ export function isDtRangeValue(value: any): value is DtRangeValue {
 }
 
 /** @internal */
-export type DtFilterValue =
-  | DtAutocompleteValue
-  | DtFreeTextValue
-  | DtRangeValue;
+export type _DtFilterValue =
+  | _DtAutocompleteValue
+  | _DtFreeTextValue
+  | _DtRangeValue;
 
-export function getSourceOfDtFilterValue<T>(value: DtFilterValue): T {
+/** @internal */
+export function _getSourceOfDtFilterValue<T>(value: _DtFilterValue): T {
   return isDtNodeDef(value) ? value.data : value;
 }
-export function getSourcesOfDtFilterValues(values: DtFilterValue[]): any[] {
-  return values.map(value => getSourceOfDtFilterValue<any>(value));
+
+/** @internal */
+export function _getSourcesOfDtFilterValues(values: _DtFilterValue[]): any[] {
+  return values.map(value => _getSourceOfDtFilterValue<any>(value));
 }

--- a/components/filter-field/src/types.ts
+++ b/components/filter-field/src/types.ts
@@ -307,12 +307,6 @@ export function isDtFreeTextValue(value: any): value is DtFreeTextValue {
 
 /** @internal */
 export type DtAutocompleteValue = DtNodeDef & { option: DtOptionDef };
-/**
- * @internal
- * @deprecated Use `DtAutocompleteValue` instead.
- * @breaking-change 5.0.0 To be removed.
- */
-export type DtAutocompletValue = DtAutocompleteValue;
 
 /** @internal */
 export function isDtAutocompleteValue(

--- a/components/filter-field/src/types.ts
+++ b/components/filter-field/src/types.ts
@@ -52,7 +52,6 @@ export interface DtAutocompleteDef {
 
 export interface DtFreeTextDef {
   suggestions: DtNodeDef[];
-  // @breaking-change 5.0.0 To be non optional
   validators: DtFilterFieldValidator[];
   unique: boolean;
 }
@@ -92,8 +91,7 @@ export const enum DtRangeOperatorFlags {
 export interface DtRangeDef {
   operatorFlags: DtRangeOperatorFlags;
   unit: string;
-  // @breaking-change 6.0.0 To be non optional
-  unique?: boolean;
+  unique: boolean;
 }
 
 /** Creates a new DtRangeDef onto a provided existing NodeDef or a newly created one. */
@@ -105,8 +103,7 @@ export function dtRangeDef(
   hasGreaterEqualOperator: boolean,
   hasLowerEqualOperator: boolean,
   unit: string,
-  // @breaking-change 5.0.0 Make mandatory
-  unique: boolean = false,
+  unique: boolean,
 ): DtNodeDef {
   // if none of the operators are defined, throw an error.
   if (


### PR DESCRIPTION
### <strong>Pull Request</strong>

filter-field: Changes param ordering on definition creation functions.

BREAKING CHANGE: Changed param ordering on definition creation functions and removed deprecated overrides for better extendibility when adding new params.

Please choose the type appropriate for the changes below: <br>

#### Type of PR
Breaking change (fix or change that would cause existing functionality to not work as expected)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
