### PR TITLE
ci: Store build artefacts for components.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,8 @@ jobs:
           name: Generate examples for the demo application
           command: npm run examples-tools
       - run: yarn affected:build ${AFFECTED_ARGS} --configuration=production --exclude=examples-tools
+      - store_artifacts:
+          path: dist/components
       - persist_to_workspace:
           root: ~/barista
           paths:


### PR DESCRIPTION
The built components library artefacts are needed to be downloadable for releasing a new version of the Library.

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
