### PR TITLE
ci: Use xlarge resource classes.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,7 @@ jobs:
 # - sonar checks
   sonar:
     <<: *defaults
+    resource_class: xlarge
     steps:
       - attach_workspace:
           at: ~/barista
@@ -182,6 +183,7 @@ jobs:
 # - build all the packages
   build:
     <<: *defaults
+    resource_class: xlarge
     steps:
       - attach_workspace:
           at: ~/barista
@@ -214,9 +216,10 @@ jobs:
 
 # - run end to end tests
   e2e-test:
+    <<: *defaults
     environment:
       BROWSERSTACK_USE_AUTOMATE: 1
-    <<: *defaults
+    resource_class: xlarge
     steps:
       - attach_workspace:
           at: ~/barista


### PR DESCRIPTION
All resource intense tasks like building e2e testing and code checking should use the xlarge resource class.

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
