### PR TITLE
fix(filter-field): Fixes an issue with instant submission of free-text.

### DIFF
--- a/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
@@ -23,56 +23,193 @@ import {
   input,
   clearAll,
   filterTags,
+  focusFilterFieldInput,
+  getFilterfieldTags,
 } from './filter-field.po';
 import { Selector } from 'testcafe';
+import { waitForAngular } from '../../utils';
 
-fixture('Filter Field').page('http://localhost:4200/filter-field');
+fixture('Filter Field')
+  .page('http://localhost:4200/filter-field')
+  .beforeEach(async () => waitForAngular());
 
-test('should not show a error box if there is no validator provided', async (testController: TestController) => {
-  await clickOption(1);
-  await testController.typeText(input, 'abc');
-  await testController.expect(await errorBox.exists).notOk();
+test('should not show a error box if there is no validator provided', async () => {
+  await clickOption(1)
+    .typeText(input, 'abc')
+    .expect(errorBox.exists)
+    .notOk();
 });
 
-test('should show a error box if does not meet the validation function', async (testController: TestController) => {
-  await clickOption(3);
-  await testController.typeText(input, 'a');
-  await testController.expect(await errorBox.exists).ok();
-  await testController
-    .expect(await errorBox.innerText)
+test('should show a error box if does not meet the validation function', async () => {
+  await clickOption(3)
+    .typeText(input, 'a')
+    // Wait for the filter field to refresh the error message.
+    .wait(250)
+    .expect(errorBox.exists)
+    .ok()
+    .expect(errorBox.innerText)
     .match(/min 3 characters/gm);
 });
 
 // TODO: lukas.holzer investigate why this test is flaky on Browserstack
 // tslint:disable-next-line: dt-no-focused-tests
-test.skip('should show is required error when the input is dirty', async (testController: TestController) => {
-  await clickOption(3);
-  await testController.typeText(input, 'a');
-  await testController.pressKey('backspace');
-  await testController.expect(await errorBox.exists).ok();
-  await testController
-    .expect(await errorBox.innerText)
+test('should show is required error when the input is dirty', async () => {
+  await clickOption(3)
+    .typeText(input, 'a')
+    .pressKey('backspace')
+    .expect(errorBox.exists)
+    .ok()
+    .expect(errorBox.innerText)
     .match(/field is required/gm);
 });
 
-test('should hide the error box when the node was deleted', async (testController: TestController) => {
-  await clickOption(3);
-  await testController.pressKey('backspace').pressKey('backspace');
-  await testController.expect(await errorBox.exists).notOk();
+test('should hide the error box when the node was deleted', async () => {
+  await clickOption(3)
+    .pressKey('backspace')
+    .pressKey('backspace')
+    .expect(errorBox.exists)
+    .notOk();
 });
 
-test('should remove all filters when clicking the clear-all button', async (testController: TestController) => {
+test('should remove all filters when clicking the clear-all button', async () => {
   // Create a new filter by clicking the outer- and inner-option
   await clickOption(4);
-  await clickOption(1);
+  await clickOption(1)
+    // Click somewhere outside so the clear-all button appears
+    .click(Selector('.outside'))
+    .wait(300)
+    .expect(clearAll.exists)
+    .ok()
+    // Click the clear all-button, the created filter should be removed
+    .click(clearAll)
+    .wait(300)
+    .expect(filterTags.exists)
+    .notOk();
+});
 
-  // Click somewhere outside so the clear-all button appears
-  await testController.click(Selector('.outside'));
-  await testController.wait(300);
-  await testController.expect(await clearAll.exists).ok();
+test('should choose a freetext node with the keyboard and submit the correct value', async (testController: TestController) => {
+  // Focus the filter field.
+  await focusFilterFieldInput();
 
-  // Click the clear all-button, the created filter should be removed
-  await testController.click(clearAll);
-  await testController.wait(300);
-  await testController.expect(await filterTags.exists).notOk();
+  // Select the test autocomplete
+  await testController
+    .pressKey('down down down down enter')
+    // Wait for a certain amount of time to let the filterfield refresh
+    .wait(250)
+    // Select the free text node and start typing
+    .pressKey('down down down enter')
+    .typeText(input, 'Custom selection')
+    // Wait for a certain amout fo time to let the filterfield refresh
+    .wait(250)
+    // Confirm the text typed in
+    .pressKey('enter');
+
+  const tags = await getFilterfieldTags();
+
+  await testController
+    .expect(tags.length)
+    .eql(1)
+    .expect(tags[0])
+    .eql('Autocomplete with free text optionsCustom selection');
+});
+
+test('should choose a freetext node with the keyboard and submit an empty value', async (testController: TestController) => {
+  // Focus the filter field.
+  await focusFilterFieldInput();
+
+  // Select the test autocomplete
+  await testController
+    .pressKey('down down down down enter')
+    // Wait for a certain amount of time to let the filterfield refresh
+    .wait(250)
+    // Select the free text node and start typing
+    .pressKey('down down down enter')
+    // Wait for a certain amout fo time to let the filterfield refresh
+    .wait(250)
+    // Confirm the text typed in
+    .pressKey('enter');
+
+  const tags = await getFilterfieldTags();
+
+  await testController
+    .expect(tags.length)
+    .eql(1)
+    .expect(tags[0])
+    .eql('Autocomplete with free text options');
+});
+
+test('should choose a freetext node with the keyboard and submit an empyty value immediately', async (testController: TestController) => {
+  await focusFilterFieldInput();
+
+  // Select the test autocomplete
+  await testController
+    .pressKey('down down down down enter')
+    // Wait for a certain amount of time to let the filterfield refresh
+    .wait(250)
+    // Select the free text node and start typing
+    .pressKey('down down down enter')
+    // Focus the filter field
+    .pressKey('enter');
+
+  const tags = await getFilterfieldTags();
+
+  await testController
+    .expect(tags.length)
+    .eql(1)
+    .expect(tags[0])
+    .eql('Autocomplete with free text options');
+});
+
+test('should choose a freetext node with the mouse and submit the correct value immediately', async (testController: TestController) => {
+  // Select the test autocomplete
+  await clickOption(5)
+    // Wait for a certain amount of time to let the filterfield refresh
+    .wait(250);
+
+  // Select the free text node and start typing
+  await clickOption(4)
+    // Wait for a certain amout fo time to let the filterfield refresh
+    .wait(250)
+    // Send the correct value into the input field
+    .typeText(input, 'Custom selection');
+
+  // Focus the filter field
+  await focusFilterFieldInput();
+
+  // Submit the value immediately
+  await testController.pressKey('enter');
+
+  const tags = await getFilterfieldTags();
+
+  await testController
+    .expect(tags.length)
+    .eql(1)
+    .expect(tags[0])
+    .eql('Autocomplete with free text optionsCustom selection');
+});
+
+test('should choose a freetext node with the mouse and submit an empty value immediately', async (testController: TestController) => {
+  // Select the test autocomplete
+  await clickOption(5)
+    // Wait for a certain amount of time to let the filterfield refresh
+    .wait(250);
+
+  // Select the free text node and start typing
+  await clickOption(4)
+    // Wait for a certain amout fo time to let the filterfield refresh
+    .wait(250);
+
+  // Confirm the text typed in
+  await focusFilterFieldInput();
+
+  // Submit the empty value immediately
+  await testController.pressKey('enter');
+
+  const tags = await getFilterfieldTags();
+
+  await testController
+    .expect(tags.length)
+    .eql(1)
+    .expect(tags[0])
+    .eql('Autocomplete with free text options');
 });

--- a/apps/components-e2e/src/components/filter-field/filter-field.po.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.po.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Selector, t } from 'testcafe';
+import { Selector, t, ClientFunction } from 'testcafe';
 
 export const errorBox = Selector('.dt-filter-field-error');
 export const filterField = Selector('#filter-field');
@@ -24,12 +24,30 @@ export const filterTags = Selector('dt-filter-field-tag');
 
 export const input = Selector('input');
 
-export async function clickOption(
+export function clickOption(
   nth: number,
   testController?: TestController,
-): Promise<void> {
+): TestControllerPromise {
   const controller = testController || t;
-
-  await controller.click(filterField);
-  await controller.click(option(nth));
+  return controller
+    .click(filterField)
+    .wait(150)
+    .click(option(nth));
 }
+
+/** Focus the input of the filter field to send key events to it. */
+export const focusFilterFieldInput = ClientFunction(() => {
+  (document.querySelector('#filter-field input') as HTMLElement).focus();
+});
+
+/** Retreive all set tags in the filter field and their values. */
+export const getFilterfieldTags = ClientFunction(() => {
+  const filterFieldTags: HTMLElement[] = [].slice.call(
+    document.querySelectorAll('.dt-filter-field-tag'),
+  );
+  const contents: string[] = [];
+  for (const tag of filterFieldTags) {
+    contents.push(tag.textContent || '');
+  }
+  return contents;
+});

--- a/apps/components-e2e/src/components/filter-field/filter-field.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.ts
@@ -54,6 +54,19 @@ const TEST_DATA: DtFilterFieldDefaultDataSourceType = {
         },
       ],
     },
+    {
+      name: 'Autocomplete with free text options',
+      autocomplete: [
+        { name: 'Autocomplete option 1' },
+        { name: 'Autocomplete option 2' },
+        { name: 'Autocomplete option 3' },
+        {
+          name: 'Autocomplete free text',
+          suggestions: ['Suggestion 1', 'Suggestion 2', 'Suggestion 3'],
+          validators: [],
+        },
+      ],
+    },
   ],
 };
 

--- a/components/filter-field/src/filter-field.html
+++ b/components/filter-field/src/filter-field.html
@@ -35,7 +35,6 @@
       [dtFilterFieldRange]="range"
       [dtFilterFieldRangeDisabled]="!(_currentDef && !!_currentDef!.range) || loading"
       (keydown)="_handleInputKeyDown($event)"
-      (keyup)="_handleInputKeyUp($event)"
       [value]="_inputValue"
     />
     <dt-autocomplete


### PR DESCRIPTION
When selecting a freetext node from the autocomplete with the keyboard
the the different eventHandlers of the autocomplete and the filterfield
raced to a broken state. To prevent the instant submission of an empty
free-text when selecting it with the keyboard, we are now checking for a
value in the free-text submission.

Fixes #294

### <strong>Pull Request</strong>

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
