### PR TITLE
chore: Lock remote edge e2e test version to 18 on windows.

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -164,11 +164,14 @@
           },
           "configurations": {
             "remote": {
-              "browsers": ["browserstack:chrome", "browserstack:edge"],
+              "browsers": [
+                "browserstack:chrome",
+                "browserstack:edge@18:windows"
+              ],
               "concurrency": 2
             },
             "remote-pr": {
-              "browsers": ["browserstack:edge"],
+              "browsers": ["browserstack:edge@18:windows"],
               "concurrency": 4
             },
             "watch": {

--- a/apps/components-e2e/src/components/key-value-list/key-value-list.e2e.ts
+++ b/apps/components-e2e/src/components/key-value-list/key-value-list.e2e.ts
@@ -15,11 +15,14 @@
  */
 
 import { Selector } from 'testcafe';
+import { waitForAngular } from '../../utils';
 
 const items = Selector('.dt-key-value-list-item', { visibilityCheck: true });
 
 fixture('Key Value List').page('http://localhost:4200/key-value-list');
 
 test('should have 16 items visible', async (testController: TestController) => {
+  await waitForAngular();
+
   await testController.expect(await items.count).eql(16);
 });


### PR DESCRIPTION
As the default value for browserstack always targets the latest version
of a browser, we needed to lock the version and operating system to edge
version 18 on windows. Browserstack would have defaulted to newer edge
versions based on chromium, which would not provide any benefit.

### <strong>Pull Request</strong>

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
