### PR TITLE
chore(show-more): Added back change event to notify about statechanges.

### DIFF
--- a/components/show-more/README.md
+++ b/components/show-more/README.md
@@ -30,7 +30,7 @@ the content to add a show more label above the arrow icon.
 | ------------------- | --------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `<ng-content>`      |           |             | The text which gets displayed above the arrow.                                                                                                            |
 | `showLess`          | `boolean` | `false`     | Whether on click the content that has been expanded is collapsed again. When `true` the show more arrow points upwards and the show more label is hidden. |
-| `ariaLabelShowLess` | `string`  | `Show less` | The aria label for the show less button without text.                                                                                                     |
+| `ariaLabelShowLess` | `string`  | `Show less` | The aria label for the show less button without text.                                                                                                     | `(changed)` | `event<void>` |  | The event which gets fired when the state changes. The event is fired when the user clicks on the component, as well as using SPACE or ENTER keys. |  |
 
 ## Usage
 

--- a/components/show-more/src/show-more.spec.ts
+++ b/components/show-more/src/show-more.spec.ts
@@ -103,6 +103,13 @@ describe('DtShowMore', () => {
       instanceElement.click();
       expect(testComponent.clickCount).toBe(0);
     });
+
+    it('should fire event when the host button is clicked', () => {
+      const spied = jest.spyOn(fixture.componentInstance, 'changedHandler');
+      instanceElement.click();
+      expect(spied).toHaveBeenCalled();
+      spied.mockRestore();
+    });
   });
 });
 
@@ -115,6 +122,7 @@ describe('DtShowMore', () => {
       [disabled]="isDisabled"
       (click)="clickHandler()"
       ariaLabelShowLess="Collapse content"
+      (changed)="changedHandler()"
     >
       More
     </button>
@@ -128,4 +136,6 @@ class TestApp {
   clickHandler(): void {
     this.clickCount++;
   }
+
+  changedHandler(): void {}
 }

--- a/components/show-more/src/show-more.ts
+++ b/components/show-more/src/show-more.ts
@@ -23,6 +23,8 @@ import {
   Input,
   OnDestroy,
   ViewEncapsulation,
+  Output,
+  EventEmitter,
 } from '@angular/core';
 import { CanDisable, mixinDisabled } from '@dynatrace/barista-components/core';
 
@@ -40,6 +42,7 @@ const _DtShowMoreMixinBase = mixinDisabled(DtShowMoreBase);
     '[class.dt-show-more-show-less]': 'showLess',
     '[attr.disabled]': 'disabled || null',
     '[attr.aria-label]': '_ariaLabel',
+    '(click)': '_handleClick()',
   },
   inputs: ['disabled'],
   preserveWhitespaces: false,
@@ -75,6 +78,12 @@ export class DtShowMore extends _DtShowMoreMixinBase
       : null;
   }
 
+  /**
+   * Emits when the show more element was clicked and notifies
+   * about the changed expanded state.
+   */
+  @Output() readonly changed = new EventEmitter<void>();
+
   constructor(
     private _elementRef: ElementRef,
     private _focusMonitor: FocusMonitor,
@@ -85,5 +94,10 @@ export class DtShowMore extends _DtShowMoreMixinBase
 
   ngOnDestroy(): void {
     this._focusMonitor.stopMonitoring(this._elementRef.nativeElement);
+  }
+
+  /** @internal Emits the change event on the show more component. */
+  _handleClick(): void {
+    this.changed.emit();
   }
 }


### PR DESCRIPTION
We have previously removed the change event from the show more, because
we have assumed that, due to its button selector, the component has to
be used within the template. As this is not the case and you are able to
use the component without a template, there was no way to get notified
about state changes because consumers were not able to bind to the click
handler. This is why we have added the change event back.

### <strong>Pull Request</strong>

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
