### PR TITLE
fix(filter-field): Fixes an issue with inconsistent clearAll functionality

### DIFF
--- a/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
@@ -26,6 +26,7 @@ import {
   focusFilterFieldInput,
   getFilterfieldTags,
   tagOverlay,
+  setupSecondTestScenario,
 } from './filter-field.po';
 import { Selector } from 'testcafe';
 import { waitForAngular } from '../../utils';
@@ -255,4 +256,31 @@ test('should show the overlay on a tag because the tag value is ellipsed', async
     .hover(filterTags)
     .expect(tagOverlay.exists)
     .ok();
+});
+
+test('should remove all removable filters when clicking the clear-all button', async (testController: TestController) => {
+  // Setup the second datasource.
+  await testController
+    .click(setupSecondTestScenario)
+    // Wait for the filterfield to catch up.
+    .wait(500);
+
+  // Manually set an option, because this seems to break the
+  // clear all change detection.
+  await clickOption(1);
+  await clickOption(1)
+    .expect(filterTags.count)
+    .eql(2)
+    // Click somewhere outside so the clear-all button appears
+    .click(Selector('.outside'))
+    // Wait for the filterfield to catch up.
+    .wait(500)
+    .expect(clearAll.exists)
+    .ok()
+    // Click the clear all-button, the created filter should be removed
+    .click(clearAll)
+    // Wait for the filterfield to catch up.
+    .wait(500)
+    .expect(filterTags.count)
+    .eql(1);
 });

--- a/apps/components-e2e/src/components/filter-field/filter-field.html
+++ b/apps/components-e2e/src/components/filter-field/filter-field.html
@@ -6,3 +6,14 @@
   label="Filter by"
   clearAllLabel="Clear all"
 ></dt-filter-field>
+
+<button id="switchToFirstDatasource" (click)="switchToDatasource(0)">
+  Switch to first datasource
+</button>
+<button id="switchToSecondDatasource" (click)="switchToDatasource(1)">
+  Switch to second datasource
+</button>
+
+<button id="setupSecondTestScenario" (click)="setupSecondTestScenario()">
+  setupSecondTestScenario
+</button>

--- a/apps/components-e2e/src/components/filter-field/filter-field.po.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.po.ts
@@ -25,11 +25,16 @@ export const tagOverlay = Selector('.dt-overlay-container');
 
 export const input = Selector('input');
 
+export const switchToFirstDatasource = Selector('#switchToFirstDatasource');
+export const switchToSecondDatasource = Selector('#switchToSecondDatasource');
+export const setupSecondTestScenario = Selector('#setupSecondTestScenario');
+
 export function clickOption(
   nth: number,
   testController?: TestController,
 ): TestControllerPromise {
   const controller = testController || t;
+
   return controller
     .click(filterField)
     .wait(150)

--- a/components/filter-field/src/filter-field.html
+++ b/components/filter-field/src/filter-field.html
@@ -20,7 +20,8 @@
     variant="secondary"
     class="dt-filter-field-clear-all-button"
     (click)="_clearAll()"
-    *ngIf="_showClearAll"
+    *ngIf="clearAllLabel"
+    [class.dt-filter-field-clear-all-button-hidden]="!_showClearAll"
   >{{clearAllLabel}}</button>
 
   <div class="dt-filter-field-infix">

--- a/components/filter-field/src/filter-field.scss
+++ b/components/filter-field/src/filter-field.scss
@@ -112,6 +112,11 @@ button.dt-filter-field-clear-all-button {
   line-height: 22px;
 }
 
+button.dt-filter-field-clear-all-button-hidden {
+  visibility: hidden;
+  position: absolute;
+}
+
 // We need to double the class to get a better specificity
 // than the original autocomplete panel selector
 ::ng-deep .dt-autocomplete-panel.dt-filter-field-panel.dt-filter-field-panel {

--- a/components/filter-field/src/filter-field.spec.ts
+++ b/components/filter-field/src/filter-field.spec.ts
@@ -1654,7 +1654,8 @@ describe('DtFilterField', () => {
     });
 
     it('should not display the clear all button if no filters are set', () => {
-      expect(getClearAll(fixture)).toBeNull();
+      // Check if the clear all is initially not visible.
+      expect(isClearAllVisible(fixture)).toBe(false);
 
       const autocompleteFilter = [
         TEST_DATA_EDITMODE.autocomplete[0],
@@ -1665,7 +1666,8 @@ describe('DtFilterField', () => {
       filterField.filters = [autocompleteFilter];
       fixture.detectChanges();
 
-      expect(getClearAll(fixture)).not.toBeNull();
+      // After setting the filters, there should be a clear all button visible.
+      expect(isClearAllVisible(fixture)).toBe(true);
     });
 
     // the user is in the edit mode of a filter
@@ -1684,7 +1686,7 @@ describe('DtFilterField', () => {
       zone.simulateZoneExit();
       fixture.detectChanges();
 
-      expect(getClearAll(fixture)).toBeNull();
+      expect(isClearAllVisible(fixture)).toBe(false);
     });
 
     // the user is in the edit mode of a filter
@@ -1707,7 +1709,7 @@ describe('DtFilterField', () => {
       const autOption = options[0];
       autOption.click();
 
-      expect(getClearAll(fixture)).toBeNull();
+      expect(isClearAllVisible(fixture)).toBe(false);
     });
 
     it('should not display the clear all button if no label is provided', () => {
@@ -1721,7 +1723,7 @@ describe('DtFilterField', () => {
       fixture.componentInstance.clearAllLabel = '';
       fixture.detectChanges();
 
-      expect(getClearAll(fixture)).toBeNull();
+      expect(isClearAllVisible(fixture)).toBe(false);
     });
 
     it('should reset the entire filter field', () => {
@@ -2142,18 +2144,26 @@ function getTagButtons(
   return { label, deleteButton };
 }
 
-// tslint:disable-next-line:no-any
 function getInput(fixture: ComponentFixture<any>): HTMLInputElement {
   return fixture.debugElement.query(By.css('.dt-filter-field-input'))
     .nativeElement;
 }
 
-// tslint:disable-next-line:no-any
+/** Get the clearAll button. */
 function getClearAll(fixture: ComponentFixture<any>): HTMLButtonElement | null {
   const dbgEl = fixture.debugElement.query(
     By.css('.dt-filter-field-clear-all-button'),
   );
   return dbgEl ? dbgEl.nativeElement : null;
+}
+
+/** Get the clearAll button and evaluate if it is visible or not. */
+function isClearAllVisible(fixture: ComponentFixture<any>): boolean {
+  const clearAll = getClearAll(fixture);
+  return (
+    clearAll !== null &&
+    !clearAll.classList.contains('dt-filter-field-clear-all-button-hidden')
+  );
 }
 
 @Component({


### PR DESCRIPTION
The clearAll button rendering depended on the filterfield not being
focussed. When the clearAll button was rendered and was clicked, the
cdkFocusMonitor kicked in, set the focus and removed the clearAll button
again. As a result the clearAll button lost its focus, the document
focus was set back to the body and the clearAll was rendered again. The
click event on the clearAll was never fired.
We no longer remove the clearAll from the DOM, but hide it via css
classes. This makes it not lose focus, and results in a more consistent
behavior.

Fixes #435

### <strong>Pull Request</strong>

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
