### PR TITLE
ci: Check if components folder exists befor trying to tar it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,14 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/barista
-      - run: cd dist && tar czf components.tar.gz ./components/
+      - run:
+          name: Create components package if it exists
+          command: |
+            if [[ -d ./dist/components ]];
+            then
+              cd dist
+              tar czf components.tar.gz ./components/
+            fi
       - store_artifacts:
           path: dist/components.tar.gz
           destination: barista-components


### PR DESCRIPTION
### <strong>Pull Request</strong>

Currently, the build fails when the build stage doesn't build the components library. In case there is no dist folder with components that can be packed.

So we have to pack it only when the folder exists.

Fixes #420 