### PR TITLE
feat(filter-field): Added an overlay if the tag value is being ellipsed.

### DIFF
--- a/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
@@ -25,6 +25,7 @@ import {
   filterTags,
   focusFilterFieldInput,
   getFilterfieldTags,
+  tagOverlay,
 } from './filter-field.po';
 import { Selector } from 'testcafe';
 import { waitForAngular } from '../../utils';
@@ -53,7 +54,7 @@ test('should show a error box if does not meet the validation function', async (
 
 // TODO: lukas.holzer investigate why this test is flaky on Browserstack
 // tslint:disable-next-line: dt-no-focused-tests
-test('should show is required error when the input is dirty', async () => {
+test.skip('should show is required error when the input is dirty', async () => {
   await clickOption(3)
     .typeText(input, 'a')
     .pressKey('backspace')
@@ -211,5 +212,47 @@ test('should choose a freetext node with the mouse and submit an empty value imm
     .expect(tags.length)
     .eql(1)
     .expect(tags[0])
-    .eql('Autocomplete with free text options');
+    .eql('Autocomplete with free text options')
+
+    // Click somewhere outside so the clear-all button appears
+    .click(Selector('.outside'))
+    .wait(300)
+    .expect(clearAll.exists)
+    .ok()
+    // Click the clear all-button, the created filter should be removed
+    .click(clearAll)
+    .wait(300)
+    .expect(filterTags.exists)
+    .notOk();
+});
+
+test('should not show the overlay on a tag because the tag value is not ellipsed', async () => {
+  await clickOption(1)
+    .typeText(input, 'abcdefghijklmno')
+    // Wait for a certain amount of time to let the filterfield refresh
+    .wait(250)
+    // Select the free text node and start typing
+    .pressKey('enter')
+    .wait(250)
+    // Hover the filter field tag
+    .hover(filterTags)
+    .expect(tagOverlay.exists)
+    .notOk();
+});
+
+test('should show the overlay on a tag because the tag value is ellipsed', async () => {
+  await clickOption(1)
+    .typeText(
+      input,
+      'abcdefghijklmnopqrstuvwxyz, 1234567890, abcdefghijklmnopqrstuvwxyz',
+    )
+    // Wait for a certain amount of time to let the filterfield refresh
+    .wait(250)
+    // Select the free text node and start typing
+    .pressKey('enter')
+    .wait(250)
+    // Hover the filter field tag
+    .hover(filterTags)
+    .expect(tagOverlay.exists)
+    .ok();
 });

--- a/apps/components-e2e/src/components/filter-field/filter-field.po.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.po.ts
@@ -21,6 +21,7 @@ export const filterField = Selector('#filter-field');
 export const option = (nth: number) => Selector(`.dt-option:nth-child(${nth})`);
 export const clearAll = Selector('.dt-filter-field-clear-all-button');
 export const filterTags = Selector('dt-filter-field-tag');
+export const tagOverlay = Selector('.dt-overlay-container');
 
 export const input = Selector('input');
 

--- a/components/filter-field/src/filter-field-module.ts
+++ b/components/filter-field/src/filter-field-module.ts
@@ -24,6 +24,7 @@ import { DtOptionModule } from '@dynatrace/barista-components/core';
 import { DtIconModule } from '@dynatrace/barista-components/icon';
 import { DtInputModule } from '@dynatrace/barista-components/input';
 import { DtLoadingDistractorModule } from '@dynatrace/barista-components/loading-distractor';
+import { DtOverlayModule } from '@dynatrace/barista-components/overlay';
 
 import { DtFilterField } from './filter-field';
 import { DtFilterFieldRange } from './filter-field-range/filter-field-range';
@@ -40,6 +41,7 @@ import { DtFilterFieldTag } from './filter-field-tag/filter-field-tag';
     DtInputModule,
     DtButtonGroupModule,
     DtLoadingDistractorModule,
+    DtOverlayModule,
   ],
   exports: [
     DtAutocompleteModule,

--- a/components/filter-field/src/filter-field-tag/filter-field-tag.html
+++ b/components/filter-field/src/filter-field-tag/filter-field-tag.html
@@ -1,10 +1,4 @@
-<button
-  dt-button
-  variant="nested"
-  class="dt-filter-field-tag-label"
-  [disabled]="!editable"
-  (click)="_handleEdit($event)"
->
+<ng-template #tagContent>
   <div
     class="dt-filter-field-tag-container"
     [class.dt-filter-field-tag-value-isfreetext]="data && data.isFreeText"
@@ -14,9 +8,25 @@
       class="dt-filter-field-tag-key"
       [attr.data-separator]="data.separator ? data.separator! : ':'"
     >{{data.key}}</span>
-    <span class="dt-filter-field-tag-value" *ngIf="data?.value">{{data.value}}</span>
+    <span class="dt-filter-field-tag-value" *ngIf="data?.value" #valueSpan>{{data.value}}</span>
   </div>
-</button>
+</ng-template>
+
+<div
+  [dtOverlay]="tagContent"
+  [dtOverlayConfig]="_overlayConfig"
+  [disabled]="_tooltipDisabled"
+>
+  <button
+    dt-button
+    variant="nested"
+    class="dt-filter-field-tag-label"
+    [disabled]="!editable"
+    (click)="_handleEdit($event)"
+  >
+    <ng-container *ngTemplateOutlet="tagContent"></ng-container>
+  </button>
+</div>
 <button
   dt-icon-button
   variant="nested"

--- a/components/filter-field/src/filter-field-tag/filter-field-tag.scss
+++ b/components/filter-field/src/filter-field-tag/filter-field-tag.scss
@@ -73,8 +73,12 @@
 
 .dt-filter-field-tag-value {
   color: $turquoise-600;
-  max-width: 300px;
   margin-left: 4px;
+}
+
+.dt-filter-field-tag-label .dt-filter-field-tag-value {
+  --dt-filter-field-max-width: 300px;
+  max-width: var(--dt-filter-field-max-width);
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;

--- a/components/filter-field/src/filter-field-tag/filter-field-tag.spec.ts
+++ b/components/filter-field/src/filter-field-tag/filter-field-tag.spec.ts
@@ -18,7 +18,7 @@
 // tslint:disable no-any max-file-line-count no-unbound-method use-component-selector
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { Component } from '@angular/core';
+import { Component, NgZone } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -33,8 +33,19 @@ import {
 } from '@dynatrace/barista-components/filter-field';
 import { DtIconModule } from '@dynatrace/barista-components/icon';
 
-import { createComponent } from '@dynatrace/barista-components/testing';
+import { Platform } from '@angular/cdk/platform';
+
+import {
+  createComponent,
+  MockNgZone,
+} from '@dynatrace/barista-components/testing';
+import {
+  mockObjectProperty,
+  mockGetComputedStyle,
+} from '@dynatrace/barista-components/testing/mock';
+
 import { _DtFilterFieldTagData } from '../types';
+import { DtOverlayTrigger } from '@dynatrace/barista-components/overlay';
 
 describe('DtFilterFieldTag', () => {
   let fixture: ComponentFixture<TestApp>;
@@ -42,6 +53,7 @@ describe('DtFilterFieldTag', () => {
   let filterFieldTagHost: HTMLElement;
   let editButton: HTMLButtonElement;
   let removeButton: HTMLButtonElement;
+  let zone: MockNgZone;
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
@@ -51,6 +63,10 @@ describe('DtFilterFieldTag', () => {
         DtIconModule.forRoot({ svgIconLocation: `{{name}}.svg` }),
       ],
       declarations: [TestApp],
+      providers: [
+        { provide: NgZone, useFactory: () => (zone = new MockNgZone()) },
+        { provide: Platform, useValue: { isBrowser: true } },
+      ],
     }).compileComponents();
 
     fixture = createComponent(TestApp);
@@ -139,6 +155,140 @@ describe('DtFilterFieldTag', () => {
     editSubscription.unsubscribe();
     removeSubscription.unsubscribe();
   }));
+
+  describe('DtFilterTagOverlay', () => {
+    /** Get the overlay trigger directive from the fixture. */
+    function getOverlayTriggerDirective(
+      passedFixture: ComponentFixture<TestApp>,
+    ): DtOverlayTrigger<{}> {
+      return passedFixture.debugElement
+        .query(By.directive(DtOverlayTrigger))
+        .injector.get(DtOverlayTrigger);
+    }
+
+    /** Mocks the scrollWidth property on the .dt-filter-field-tag-value element with a passed value. */
+    function mockScrollWidth(
+      passedFixture: ComponentFixture<TestApp>,
+      mockedValue: number,
+    ): void {
+      const el: HTMLElement = passedFixture.debugElement.query(
+        By.css('.dt-filter-field-tag-value'),
+      ).nativeElement;
+      mockObjectProperty(el, 'scrollWidth', mockedValue);
+    }
+
+    afterEach(() => {
+      // Reset the getComputedStyle mock after each test.
+      mockGetComputedStyle(undefined);
+    });
+
+    it('should disable the overlay when the text is short enough', fakeAsync(() => {
+      // Setup the ComputedStyleMock.
+      mockGetComputedStyle('300px');
+
+      // Get the tag value element and mock the scroll width on it.
+      mockScrollWidth(fixture, 250);
+
+      // Simulate the zone exit and changeDetection.
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      // Get the overlayTriggerDirective Instance
+      const overlayTrigger = getOverlayTriggerDirective(fixture);
+
+      expect(overlayTrigger.disabled).toBe(true);
+    }));
+
+    it('should enable the overlay when the text is too long', fakeAsync(() => {
+      // Setup the ComputedStyleMock.
+      mockGetComputedStyle('300px');
+
+      // Get the tag value element and mock the scroll width on it.
+      mockScrollWidth(fixture, 380);
+
+      // Simulate the zone exit and changeDetection.
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      // Get the overlayTriggerDirective Instance
+      const overlayTrigger = getOverlayTriggerDirective(fixture);
+
+      expect(overlayTrigger.disabled).toBe(false);
+    }));
+
+    it('should enable the overlay when the text is changed dynamically', fakeAsync(() => {
+      // Setup the ComputedStyleMock.
+      mockGetComputedStyle('300px');
+
+      // Get the tag value element and mock the scroll width on it.
+      mockScrollWidth(fixture, 290);
+
+      // Simulate the zone exit and changeDetection.
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      // Get the overlayTriggerDirective Instance
+      const overlayTrigger = getOverlayTriggerDirective(fixture);
+
+      // The overlay should now be disabled.
+      expect(overlayTrigger.disabled).toBe(true);
+
+      // Change the scrollWdith mock to fit the larger field value.
+      mockScrollWidth(fixture, 500);
+
+      // Set the larger field value dynamically without destroying the
+      // tag component.
+      fixture.componentInstance.dummy = new _DtFilterFieldTagData(
+        'AUT',
+        'A larger value, value does not matter because scrollWidth is mocked',
+        ':',
+        false,
+        [],
+      );
+
+      // Run change detection cycles.
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      // The overlay should now be enabled.
+      expect(overlayTrigger.disabled).toBe(false);
+    }));
+
+    it('should use the default value if the custom property is not set', fakeAsync(() => {
+      // Setup the ComputedStyleMock.
+      mockGetComputedStyle(undefined);
+
+      // Get the tag value element and mock the scroll width on it.
+      mockScrollWidth(fixture, 299);
+
+      // Simulate the zone exit and changeDetection.
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      // Get the overlayTriggerDirective Instance
+      const overlayTrigger = getOverlayTriggerDirective(fixture);
+
+      expect(overlayTrigger.disabled).toBe(true);
+    }));
+
+    it('should use the default value if the custom property is not set', fakeAsync(() => {
+      // Setup the ComputedStyleMock.
+      mockGetComputedStyle(undefined);
+
+      // Get the tag value element and mock the scroll width on it.
+      mockScrollWidth(fixture, 301);
+
+      // Simulate the zone exit and changeDetection.
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      // Get the overlayTriggerDirective Instance
+      const overlayTrigger = getOverlayTriggerDirective(fixture);
+
+      expect(overlayTrigger.disabled).toBe(false);
+    }));
+  });
 });
 
 @Component({

--- a/libs/testing/src/mock/mock-get-computed-style.ts
+++ b/libs/testing/src/mock/mock-get-computed-style.ts
@@ -14,6 +14,16 @@
  * limitations under the License.
  */
 
-export * from './mock-intersection-observer';
-export * from './mock-object-property';
-export * from './mock-get-computed-style';
+/**
+ * MOch the getComputedStyle property on an object, preferrably an jsDOM Node element.
+ * @param value - Value that should be used as a return value for the mocked function.
+ */
+export function mockGetComputedStyle(value: string | undefined): void {
+  Object.defineProperty(window, 'getComputedStyle', {
+    value: () => ({
+      getPropertyValue: _prop => {
+        return value;
+      },
+    }),
+  });
+}


### PR DESCRIPTION
To provide the full value on an ellipsed filter field tag, we have added
a DtOverlay to the element, if it is being ellipsed. The overlay should
not show up if the value is not ellipsed.

Fixes #392

### <strong>Pull Request</strong>

#### Type of PR
Feature

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
