### PR TITLE
Fixes flaky chart selection area e2e tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,6 +231,8 @@ jobs:
     <<: *defaults
     environment:
       BROWSERSTACK_USE_AUTOMATE: 1
+      BROWSERSTACK_DISPLAY_RESOLUTION: 1920x1080
+      BROWSERSTACK_TIMEZONE: UTC+1
     steps:
       - attach_workspace:
           at: ~/barista

--- a/angular.json
+++ b/angular.json
@@ -172,7 +172,7 @@
             },
             "remote-pr": {
               "browsers": ["browserstack:edge@18:windows"],
-              "concurrency": 4
+              "concurrency": 5
             },
             "watch": {
               "browsers": ["chrome"],

--- a/apps/components-e2e/src/components/chart/selection-area/selection-area.e2e.ts
+++ b/apps/components-e2e/src/components/chart/selection-area/selection-area.e2e.ts
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-// tslint:disable no-lifecycle-call no-use-before-declare no-magic-numbers
-// tslint:disable no-any max-file-line-count no-unbound-method use-component-selector
-
+import { isCloseTo, waitForAngular } from '../../../utils';
 import {
   chartClickTargets,
-  closeOverlay,
+  closeButton,
   createRange,
   createTimestamp,
   dragHandle,
@@ -37,124 +35,120 @@ import {
   timestamp,
   timestampSelection,
 } from './selection-area.po';
-import { waitForAngular, isCloseTo } from '../../../utils';
 
 fixture('Selection Area')
   .page('http://localhost:4200/chart/selection-area')
-  .beforeEach(async () => await waitForAngular());
+  .beforeEach(async (testController: TestController) => {
+    await testController.resizeWindow(1200, 800);
+    await waitForAngular();
+  });
 
 test('should have the possibility to create a range and a timestamp', async (testController: TestController) => {
-  await testController.expect(range.exists).ok();
-  await testController.expect(timestamp.exists).ok();
+  await testController
+    .expect(range.exists)
+    .ok()
+    .expect(timestamp.exists)
+    .ok();
 });
 
 test('should not have an initial selection', async (testController: TestController) => {
-  await testController.expect(await selection.exists).notOk();
-  await testController.expect(await rangeSelection.exists).notOk();
-  await testController.expect(await timestampSelection.exists).notOk();
+  await testController
+    .expect(selection.exists)
+    .notOk()
+    .expect(rangeSelection.exists)
+    .notOk()
+    .expect(timestampSelection.exists)
+    .notOk();
 });
 
-// TODO: lukas.holzer investigate why on Browserstack the overlay has outdated information
-// AssertionError: expected 'Jul 31 00:17 — 00:22' to match /Jul 31 \d{2}:17 — \d{2}:23/g
-// Maybe changeDetection issue?
-// tslint:disable-next-line: dt-no-focused-tests
-test.skip('should create a range when a selection will be dragged', async (testController: TestController) => {
-  await testController.resizeWindow(1200, 800);
-  const start = { x: 310, y: 100 };
-  await createRange(520, start);
-  // in case of flakyness that the overlay does not update to the right values
-  await testController.wait(500);
-  await testController.expect(await rangeSelection.exists).ok();
-  await testController.expect(await timestampSelection.exists).notOk();
-  await testController
-    .expect(await overlayText.textContent)
+test('should create a range when a selection will be dragged', async (testController: TestController) => {
+  await createRange(520, { x: 310, y: 100 }, testController)
+    .expect(rangeSelection.exists)
+    .ok()
+    .expect(timestampSelection.exists)
+    .notOk()
+    .expect(overlayText.textContent)
     .match(/Jul 31 \d{2}:17 — \d{2}:23/g);
 });
 
 test('should create a range that is disabled when it does not meet the 5min constraints', async (testController: TestController) => {
-  const start = { x: 300, y: 100 };
-  await createRange(50, start);
-  await testController.expect(await isRangeValid()).notOk();
-  await testController.expect(await overlayApply.hasAttribute('disabled')).ok();
+  await createRange(50, { x: 300, y: 100 }, testController)
+    .expect(await isRangeValid())
+    .notOk()
+    .expect(overlayApply.hasAttribute('disabled'))
+    .ok();
 });
 
 test('should close the overlay of a range when the close overlay button was triggered', async (testController: TestController) => {
-  const start = { x: 300, y: 100 };
-  await createRange(50, start);
-
-  await testController.expect(await selection.exists).ok();
-  await testController.expect(await overlay.exists).ok();
-
-  await closeOverlay();
-
-  await testController.expect(await selection.exists).notOk();
-  await testController.expect(await overlay.exists).notOk();
+  await createRange(50, { x: 300, y: 100 }, testController)
+    .expect(selection.exists)
+    .ok()
+    .expect(overlay.exists)
+    .ok()
+    .click(closeButton)
+    .expect(selection.exists)
+    .notOk()
+    .expect(overlay.exists)
+    .notOk();
 });
 
-// TODO: lukas.holzer investigate why on Browserstack the overlay has outdated information
-// AssertionError: expected 'Jul 31 00:17 — 00:22' to match /Jul 31 \d{2}:17 — \d{2}:23/g
-// Maybe changeDetection issue?
-// tslint:disable-next-line: dt-no-focused-tests
-test.skip('should increase the selection by dragging the right handle', async (testController: TestController) => {
-  await testController.resizeWindow(1200, 800);
-  const start = { x: 310, y: 100 };
-  await createRange(520, start);
-  // in case of flakyness that the overlay does not update to the right values
-  await testController.wait(500);
+test('should increase the selection by dragging the right handle', async (testController: TestController) => {
+  await createRange(520, { x: 310, y: 100 }, testController);
 
-  await testController.expect(isCloseTo(await getRangeWidth(), 520)).ok();
+  let width = await getRangeWidth();
+
   await testController
-    .expect(await overlayText.textContent)
+    .expect(isCloseTo(width, 520))
+    .ok(`The range size of ${width} is not close to the expected 520`)
+    .expect(overlayText.textContent)
     .match(/Jul 31 \d{2}:17 — \d{2}:23/g);
 
   await dragHandle(rightHandle, 80);
-  await testController.wait(100);
-  const width = await getRangeWidth();
+
+  width = await getRangeWidth();
+
   await testController
     .expect(isCloseTo(width, 599))
-    .ok(`The range size of ${width} is not close to the expected 599`);
-  await testController
+    .ok(`The range size of ${width} is not close to the expected 599`)
+    .click(overlay)
     .expect(await overlayText.textContent)
     .match(/Jul 31 \d{2}:17 — \d{2}:24/g);
 });
 
-// TODO: lukas.holzer investigate why on Browserstack the overlay has outdated information
-// AssertionError: expected 'Jul 31 00:17 — 00:22' to match /Jul 31 \d{2}:17 — \d{2}:23/g
-// Maybe changeDetection issue?
-// tslint:disable-next-line: dt-no-focused-tests
-test.skip('should increase the selection by dragging the left handle', async (testController: TestController) => {
-  await testController.resizeWindow(1200, 800);
-  const start = { x: 310, y: 100 };
-  await createRange(520, start);
-  // in case of flakyness that the overlay does not update to the right values
-  await testController.wait(500);
+test('should increase the selection by dragging the left handle', async (testController: TestController) => {
+  await createRange(520, { x: 310, y: 100 }, testController);
 
-  await testController.expect(isCloseTo(await getRangeWidth(), 520)).ok();
+  let width = await getRangeWidth();
+
   await testController
-    .expect(await overlayText.textContent)
+    .expect(isCloseTo(width, 520))
+    .ok(`The range size of ${width} is not close to the expected 520`)
+    .expect(overlayText.textContent)
     .match(/Jul 31 \d{2}:17 — \d{2}:23/g);
 
   await dragHandle(leftHandle, -170);
 
-  await testController.expect(isCloseTo(await getRangeWidth(), 688)).ok();
+  width = await getRangeWidth();
+
   await testController
-    .expect(await overlayText.textContent)
+    .expect(isCloseTo(width, 688))
+    .ok(`The range size of ${width} is not close to the expected 688`)
+    .expect(overlayText.textContent)
     .match(/Jul 31 \d{2}:15 — \d{2}:23/g);
 });
 
 test('should create a timestamp when it was clicked on a certain point of the screen', async (testController: TestController) => {
-  await testController.resizeWindow(1200, 800);
   await createTimestamp(
     { x: 400, y: 100 },
     chartClickTargets[1],
     testController,
-  );
-
-  await testController.expect(await timestampSelection.exists).ok();
-  await testController.expect(await rangeSelection.exists).notOk();
-  await testController
-    .expect(await overlayText.textContent)
-    .match(/Jul 31, \d{2}:18/g);
+  )
+    .expect(timestampSelection.exists)
+    .ok()
+    .expect(overlayText.textContent)
+    .match(/Jul 31, \d{2}:18/g)
+    .expect(rangeSelection.exists)
+    .notOk();
 });
 
 test('should close the overlay of a timestamp when the close overlay button was triggered', async (testController: TestController) => {
@@ -162,95 +156,87 @@ test('should close the overlay of a timestamp when the close overlay button was 
     { x: 400, y: 100 },
     chartClickTargets[1],
     testController,
-  );
-
-  await testController.expect(await timestampSelection.exists).ok();
-  await testController.expect(await overlay.exists).ok();
-
-  await closeOverlay();
-
-  await testController.expect(await timestampSelection.exists).notOk();
-  await testController.expect(await overlay.exists).notOk();
+  )
+    .expect(timestampSelection.exists)
+    .ok()
+    .expect(overlay.exists)
+    .ok()
+    .click(closeButton)
+    .expect(timestampSelection.exists)
+    .notOk()
+    .expect(overlay.exists)
+    .notOk();
 });
 
 chartClickTargets.forEach(selector => {
   test(`Should create a timestamp on different chart regions`, async (testController: TestController) => {
-    await createTimestamp({ x: 400, y: 100 }, selector, testController);
-    await testController.expect(await timestampSelection.exists).ok();
-    await testController.expect(await overlay.exists).ok();
+    await createTimestamp({ x: 400, y: 100 }, selector, testController)
+      .expect(timestampSelection.exists)
+      .ok()
+      .expect(overlay.exists)
+      .ok();
   });
 });
 
 test('should switch to a timestamp if there is a open range and a click will be performed', async (testController: TestController) => {
-  await testController.resizeWindow(1200, 800);
-  const start = { x: 300, y: 100 };
-  await createRange(550, start);
+  await createRange(550, { x: 300, y: 100 })
+    .expect(rangeSelection.exists)
+    .ok();
 
-  await testController.expect(await rangeSelection.exists).ok();
   await createTimestamp(
     { x: 450, y: 100 },
     chartClickTargets[1],
     testController,
-  );
-
-  await testController.expect(await timestampSelection.exists).ok();
-  await testController
-    .expect(await overlayText.textContent)
+  )
+    .expect(timestampSelection.exists)
+    .ok()
+    .expect(overlayText.textContent)
     .match(/Jul 31, \d{2}:19/g);
 });
 
-// TODO: @lukas.holzer could you please revisit this test, as it
-// continues to be flaky.
-// tslint:disable-next-line: dt-no-focused-tests
-test.skip('should switch to a range if there is a open timestamp and a drag will be performed', async (testController: TestController) => {
-  await testController.resizeWindow(1200, 800);
+test('should switch to a range if there is a open timestamp and a drag will be performed', async (testController: TestController) => {
   await createTimestamp(
     { x: 450, y: 100 },
     chartClickTargets[1],
     testController,
-  );
-
-  await testController
-    .expect(await overlayText.textContent)
+  )
+    .expect(overlayText.textContent)
     .match(/Jul 31, \d{2}:19/g);
 
-  const start = { x: 310, y: 100 };
-  await createRange(520, start);
-  // in case of flakyness that the overlay does not update to the right values
-  await testController.wait(500);
-  await testController
-    .expect(await overlayText.textContent)
+  await createRange(520, { x: 310, y: 100 })
+    .wait(500)
+    .expect(overlayText.textContent)
     .match(/Jul 31 \d{2}:17 — \d{2}:23/g);
 });
 
 test('should focus the selection area if tab key is pressed', async (testController: TestController) => {
-  await testController.pressKey('tab');
-  await testController.expect(await selectionArea.focused).ok();
+  await testController
+    .pressKey('tab')
+    .expect(selectionArea.focused)
+    .ok();
 });
 
 test('should create an initial timestamp when the chart is focused and enter is pressed', async (testController: TestController) => {
-  await testController.resizeWindow(1200, 800);
-  await testController.pressKey('tab');
-  await testController.pressKey('enter');
-
-  await testController.expect(await timestampSelection.exists).ok();
   await testController
-    .expect(await overlayText.textContent)
-    .match(/Jul 31, \d{2}:20/g);
-
-  await testController.expect(await selection.focused).ok();
+    .pressKey('tab')
+    .pressKey('enter')
+    .expect(timestampSelection.exists)
+    .ok()
+    .expect(overlayText.textContent)
+    .match(/Jul 31, \d{2}:20/g)
+    .expect(selection.focused)
+    .ok();
 });
 
 test('should create a range out of the timestamp with shift + left arrow key', async (testController: TestController) => {
-  await testController.resizeWindow(1200, 800);
-  await testController.pressKey('tab');
-  await testController.pressKey('enter');
-  await testController.pressKey('shift+left');
-
-  await testController.expect(await timestampSelection.exists).notOk();
-  await testController.expect(await rangeSelection.exists).ok();
-
   await testController
-    .expect(await overlayText.textContent)
+    .pressKey('tab')
+    .pressKey('enter')
+    .pressKey('shift+left')
+    .expect(timestampSelection.exists)
+    .notOk()
+    .expect(rangeSelection.exists)
+    .ok()
+    .expect(overlayText.textContent)
     .match(/Jul 31 \d{2}:20 — \d{2}:25/g);
 });

--- a/apps/components-e2e/src/components/chart/selection-area/selection-area.po.ts
+++ b/apps/components-e2e/src/components/chart/selection-area/selection-area.po.ts
@@ -40,37 +40,39 @@ export const chartClickTargets = [
 ];
 
 /** The range slider */
-export const rangeSelection = range
-  .child('div')
-  .withAttribute('aria-role', 'slider');
+export const rangeSelection = range.child('.dt-chart-range-container');
 
 /** The time-frame slider  */
-export const timestampSelection = timestamp
-  .child('div')
-  .withAttribute('aria-role', 'slider');
+export const timestampSelection = timestamp.child(
+  '.dt-chart-timestamp-selector',
+);
 
 export const overlay = Selector('.dt-chart-selection-area-overlay');
 export const overlayApply = overlay.child('button').withText('Apply');
 export const overlayText = overlay.child('.dt-selection-area-overlay-text');
+export const closeButton = overlay
+  .child('button')
+  .withAttribute('aria-label', /close/gim);
 
 /** Creates a selection from the starting point with the provided width */
-export async function createRange(
+export function createRange(
   width: number,
   start: Point,
   testController?: TestController,
-): Promise<void> {
+): TestControllerPromise {
   const controller = testController || t;
   return controller.drag(plotBackground, width, 0, {
     offsetX: start.x,
     offsetY: start.y,
+    speed: 0.01,
   });
 }
 
-export async function createTimestamp(
+export function createTimestamp(
   point: Point,
   selector?: Selector,
   testController?: TestController,
-): Promise<void> {
+): TestControllerPromise {
   const controller = testController || t;
   return controller.click(selector || plotBackground, {
     offsetX: point.x,
@@ -79,26 +81,14 @@ export async function createTimestamp(
 }
 
 /** Execute a drag on a range handle to increase or decrease the selection */
-export async function dragHandle(
+export function dragHandle(
   handle: Selector,
   offsetX: number,
   testController?: TestController,
-): Promise<void> {
+): TestControllerPromise {
   const controller = testController || t;
 
-  await controller.drag(handle, offsetX, 0, { speed: 0.01 });
-  await controller.wait(300);
-}
-
-export async function closeOverlay(
-  testController?: TestController,
-): Promise<void> {
-  const controller = testController || t;
-  const closeButton = await overlay
-    .child('button')
-    .withAttribute('aria-label', /close/gim);
-
-  return controller.click(closeButton);
+  return controller.drag(handle, offsetX, 0, { speed: 0.01 });
 }
 
 /** checks if the current range is valid */

--- a/apps/components-e2e/src/components/drawer/drawer.e2e.ts
+++ b/apps/components-e2e/src/components/drawer/drawer.e2e.ts
@@ -16,7 +16,7 @@
 import { Selector, ClientFunction } from 'testcafe';
 
 import {
-  closeOverlay,
+  closeButton,
   createRange,
   overlay,
   rangeSelection,
@@ -102,32 +102,36 @@ test('should move heatfield overlay with the chart on scroll', async (testContro
 });
 
 test('should move selection area overlay with the chart on scroll', async (testController: TestController) => {
-  await testController.click(open);
-
-  const start = { x: 310, y: 100 };
-  await createRange(520, start);
-
-  await testController.expect(await selection.exists).ok();
-  await testController.expect(await overlay.exists).ok();
-
-  // in case of flakyness that the overlay does not update to the right values
-  await testController.wait(500);
-  await testController.expect(await rangeSelection.exists).ok();
-
   const rangeOverlay = Selector('.dt-chart-selection-area-overlay');
-  const prevPosition = await rangeOverlay.getBoundingClientRectProperty('top');
-  await scrollDown(scrollDistance);
-  await testController.expect(rangeOverlay.exists).ok();
-
-  await testController.wait(500);
-  const currPosition = await rangeOverlay.getBoundingClientRectProperty('top');
-  await testController.expect(prevPosition).notEql(currPosition);
-  await testController
-    .expect(isCloseTo(currPosition, prevPosition - scrollDistance, 10))
+  await testController.click(open);
+  await createRange(520, { x: 310, y: 100 })
+    .expect(selection.exists)
+    .ok()
+    .expect(overlay.exists)
+    .ok()
+    .wait(500)
+    .expect(rangeSelection.exists)
     .ok();
 
-  await closeOverlay();
+  const prevPosition = await rangeOverlay.getBoundingClientRectProperty('top');
 
-  await testController.expect(await selection.exists).notOk();
-  await testController.expect(await overlay.exists).notOk();
+  await scrollDown(scrollDistance);
+
+  await testController
+    .expect(rangeOverlay.exists)
+    .ok()
+    .wait(500);
+
+  const currPosition = await rangeOverlay.getBoundingClientRectProperty('top');
+
+  await testController
+    .expect(prevPosition)
+    .notEql(currPosition)
+    .expect(isCloseTo(currPosition, prevPosition - scrollDistance, 10))
+    .ok()
+    .click(closeButton)
+    .expect(selection.exists)
+    .notOk()
+    .expect(overlay.exists)
+    .notOk();
 });


### PR DESCRIPTION
Closes #244 Fixes the failing selection area tests by using the chaining that is provided by testcafe and throttling the drag speed from 1 to 0.01.

As performance benefit, we are now running 5 tests in parallel on BrowserStack to get the maximum speed.

### <strong>Pull Request</strong>

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

Fixing flaky end to end tests

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
