### PR TITLE
ci: Fixes an issue with the autolabeler applying wrong labels.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -107,3 +107,7 @@
 /tools/stylelint/** @thomaspink
 
 /tools/tslint-rules/** @thomaspink
+
+/tools/pull-request-labeler/** @tomheller
+
+/tools/cherry-picker/** @tomheller

--- a/angular.json
+++ b/angular.json
@@ -787,6 +787,28 @@
         }
       }
     },
+    "tools-pull-request-labeler": {
+      "root": "tools/pull-request-labeler",
+      "sourceRoot": "tools/pull-request-labeler/src",
+      "projectType": "library",
+      "architect": {
+        "lint": {
+          "builder": "@angular-devkit/build-angular:tslint",
+          "options": {
+            "tsConfig": ["tools/pull-request-labeler/tsconfig.json"],
+            "exclude": ["**/node_modules/**", "!tools/pull-request-labeler/**"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "tools/pull-request-labeler/jest.config.js",
+            "tsConfig": "tools/pull-request-labeler/tsconfig.spec.json",
+            "setupFile": "tools/pull-request-labeler/src/test-setup.ts"
+          }
+        }
+      }
+    },
     "tools-shared": {
       "root": "tools/shared",
       "sourceRoot": "tools/shared/src",

--- a/nx.json
+++ b/nx.json
@@ -40,6 +40,9 @@
     "tools-release": {
       "tags": ["type:tooling"]
     },
+    "tools-pull-request-labeler": {
+      "tags": ["type:tooling"]
+    },
     "tools-shared": {
       "tags": ["type:tooling", "type:shared"]
     },

--- a/tools/pull-request-labeler/jest.config.js
+++ b/tools/pull-request-labeler/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  name: 'tools-pull-request-labeler',
+  preset: '../../jest.config.js',
+  coverageDirectory: '../../coverage/tools/pr-labeler',
+};

--- a/tools/pull-request-labeler/src/main.ts
+++ b/tools/pull-request-labeler/src/main.ts
@@ -52,6 +52,7 @@ async function run() {
     console.log(
       'Not ready to label just yet, add pr: lgtm label to it to start the process.',
     );
+    process.exit(1);
     return;
   }
 

--- a/tools/pull-request-labeler/src/test-setup.ts
+++ b/tools/pull-request-labeler/src/test-setup.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/tools/pull-request-labeler/src/utils/process-commit-messages.spec.ts
+++ b/tools/pull-request-labeler/src/utils/process-commit-messages.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { processCommitMessages } from './process-commit-messages';
+
+it('should add minor and patch labels to a single chore commits', () => {
+  const commits = ['chore: some chore commit'];
+  const result = processCommitMessages(commits);
+  expect(result.errors).toHaveLength(0);
+  expect(result.targets).toEqual(['target: minor', 'target: patch']);
+});
+
+it('should add minor and patch labels to a single fix commits', () => {
+  const commits = ['fix: Fixes a special bug.'];
+  const result = processCommitMessages(commits);
+  expect(result.errors).toHaveLength(0);
+  expect(result.targets).toEqual(['target: minor', 'target: patch']);
+});
+
+it('should add minor and patch labels to multiple mixed non fix/feat/perf commits', () => {
+  const commits = [
+    'chore: some chore commit.',
+    'test: Added some tests.',
+    'style: Applied proper code formatting.',
+  ];
+  const result = processCommitMessages(commits);
+  expect(result.errors).toHaveLength(0);
+  expect(result.targets).toEqual(['target: minor', 'target: patch']);
+});
+
+it('should add minor label if commits include a feature', () => {
+  const commits = ['feat: Added a special feature.'];
+  const result = processCommitMessages(commits);
+  expect(result.errors).toHaveLength(0);
+  expect(result.targets).toEqual(['target: minor']);
+});
+
+it('should add major lablel if commits include breaking changes', () => {
+  const commits = ['feat: Added a special feature BREAKING CHANGE.'];
+  const result = processCommitMessages(commits);
+  expect(result.errors).toHaveLength(0);
+  expect(result.targets).toEqual(['target: major']);
+});
+
+it('should fail if there are multiple feature commits present', () => {
+  const commits = [
+    'feat: Added a special feature.',
+    'feat: Added another special feature.',
+  ];
+  const result = processCommitMessages(commits);
+  expect(result.errors).toEqual([
+    'There should be no more than one feature commits, within a single pull request, but found 2.',
+  ]);
+  expect(result.targets).toHaveLength(0);
+});
+
+it('should fail if there are multiple fix commits present', () => {
+  const commits = [
+    'fix: Fixes a special bug.',
+    'fix: Fixes another special bug.',
+  ];
+  const result = processCommitMessages(commits);
+  expect(result.errors).toEqual([
+    'There should be no more than one fix commits, within a single pull request, but found 2.',
+  ]);
+  expect(result.targets).toHaveLength(0);
+});
+
+it('should fail if there are mixed commits present', () => {
+  const commits = [
+    'feat: Added a special feature.',
+    'fix: Fixes a special bug.',
+  ];
+  const result = processCommitMessages(commits);
+  expect(result.errors).toEqual([
+    'Feature and fix commits should not be mixed.',
+  ]);
+  expect(result.targets).toHaveLength(0);
+});

--- a/tools/pull-request-labeler/src/utils/process-commit-messages.ts
+++ b/tools/pull-request-labeler/src/utils/process-commit-messages.ts
@@ -80,6 +80,12 @@ export function processCommitMessages(
       `There should be no more than one fix commits, within a single pull request, but found ${fixCommits.length}.`,
     );
   }
+
+  // If there are fix and feat commits mixed in a pull request,
+  // push an error.
+  if (featureCommits.length > 0 && fixCommits.length > 0) {
+    errors.push(`Feature and fix commits should not be mixed.`);
+  }
   // If there are no errors, determine the targets
   if (!errors.length) {
     const hasFeatureCommits = featureCommits.length > 0;

--- a/tools/pull-request-labeler/src/utils/split-message-into-components.spec.ts
+++ b/tools/pull-request-labeler/src/utils/split-message-into-components.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { splitStringIntoCommitMessage } from './split-message-into-components';
+import { CommitTypes } from '../interfaces/commit-message';
+
+it('should split a feature commit correctly', () => {
+  const message = 'feat(ng-update): Added test for .spec file';
+  const split = splitStringIntoCommitMessage(message);
+  expect(split.breakingChange).toBeFalsy();
+  expect(split.releaseCommit).toBeFalsy();
+  expect(split.components).toEqual(['ng-update']);
+  expect(split.message).toBe('Added test for .spec file');
+  expect(split.type).toBe(CommitTypes.FEAT);
+});
+
+it('should split a fix commit correctly', () => {
+  const message = 'fix(ng-update): Added test for .spec file';
+  const split = splitStringIntoCommitMessage(message);
+  expect(split.breakingChange).toBeFalsy();
+  expect(split.releaseCommit).toBeFalsy();
+  expect(split.components).toEqual(['ng-update']);
+  expect(split.message).toBe('Added test for .spec file');
+  expect(split.type).toBe(CommitTypes.FIX);
+});
+
+it('should split a chore commit correctly', () => {
+  const message = 'chore: Bump something';
+  const split = splitStringIntoCommitMessage(message);
+  expect(split.breakingChange).toBeFalsy();
+  expect(split.releaseCommit).toBeFalsy();
+  expect(split.components).toEqual([]);
+  expect(split.message).toBe('Bump something');
+  expect(split.type).toBe(CommitTypes.CHORE);
+});
+
+it('should split a barista commit correctly', () => {
+  const message = 'barista: Some design system changes';
+  const split = splitStringIntoCommitMessage(message);
+  expect(split.breakingChange).toBeFalsy();
+  expect(split.releaseCommit).toBeFalsy();
+  expect(split.components).toEqual([]);
+  expect(split.message).toBe('Some design system changes');
+  expect(split.type).toBe(CommitTypes.BARISTA);
+});
+
+it('should split a build commit correctly', () => {
+  const message = 'build: Some build system changes';
+  const split = splitStringIntoCommitMessage(message);
+  expect(split.breakingChange).toBeFalsy();
+  expect(split.releaseCommit).toBeFalsy();
+  expect(split.components).toEqual([]);
+  expect(split.message).toBe('Some build system changes');
+  expect(split.type).toBe(CommitTypes.BUILD);
+});
+
+it('should split a ci commit correctly', () => {
+  const message = 'ci: Some ci system changes';
+  const split = splitStringIntoCommitMessage(message);
+  expect(split.breakingChange).toBeFalsy();
+  expect(split.releaseCommit).toBeFalsy();
+  expect(split.components).toEqual([]);
+  expect(split.message).toBe('Some ci system changes');
+  expect(split.type).toBe(CommitTypes.CI);
+});
+
+it('should split a docs commit correctly', () => {
+  const message = 'docs: Some docs changes';
+  const split = splitStringIntoCommitMessage(message);
+  expect(split.breakingChange).toBeFalsy();
+  expect(split.releaseCommit).toBeFalsy();
+  expect(split.components).toEqual([]);
+  expect(split.message).toBe('Some docs changes');
+  expect(split.type).toBe(CommitTypes.DOCS);
+});
+
+it('should split a perf commit correctly', () => {
+  const message = 'perf: Some performance changes';
+  const split = splitStringIntoCommitMessage(message);
+  expect(split.breakingChange).toBeFalsy();
+  expect(split.releaseCommit).toBeFalsy();
+  expect(split.components).toEqual([]);
+  expect(split.message).toBe('Some performance changes');
+  expect(split.type).toBe(CommitTypes.PERF);
+});
+
+it('should split a refactor commit correctly', () => {
+  const message = 'refactor: Some refactor changes';
+  const split = splitStringIntoCommitMessage(message);
+  expect(split.breakingChange).toBeFalsy();
+  expect(split.releaseCommit).toBeFalsy();
+  expect(split.components).toEqual([]);
+  expect(split.message).toBe('Some refactor changes');
+  expect(split.type).toBe(CommitTypes.REFACTOR);
+});
+
+it('should split a style commit correctly', () => {
+  const message = 'style: Some style changes';
+  const split = splitStringIntoCommitMessage(message);
+  expect(split.breakingChange).toBeFalsy();
+  expect(split.releaseCommit).toBeFalsy();
+  expect(split.components).toEqual([]);
+  expect(split.message).toBe('Some style changes');
+  expect(split.type).toBe(CommitTypes.STYLE);
+});
+
+it('should split a test commit correctly', () => {
+  const message = 'test: Some test changes';
+  const split = splitStringIntoCommitMessage(message);
+  expect(split.breakingChange).toBeFalsy();
+  expect(split.releaseCommit).toBeFalsy();
+  expect(split.components).toEqual([]);
+  expect(split.message).toBe('Some test changes');
+  expect(split.type).toBe(CommitTypes.TEST);
+});
+
+it('should split a multiple components correctly', () => {
+  const message = 'feat(ng-update, autocomplete): Added test for .spec file';
+  const split = splitStringIntoCommitMessage(message);
+  expect(split.breakingChange).toBeFalsy();
+  expect(split.releaseCommit).toBeFalsy();
+  expect(split.components).toEqual(['ng-update', 'autocomplete']);
+  expect(split.message).toBe('Added test for .spec file');
+  expect(split.type).toBe(CommitTypes.FEAT);
+});
+
+it('should split a multiline message correctly', () => {
+  const message = `fix(chart): Fixes an issue where tooltips in pie/donut charts did not work anymore
+
+Fixes an issue where the tooltip was not updated when a different series was hovered on the same x-datapoint`;
+  const split = splitStringIntoCommitMessage(message);
+  expect(split.breakingChange).toBeFalsy();
+  expect(split.releaseCommit).toBeFalsy();
+  expect(split.components).toEqual(['chart']);
+  expect(split.message)
+    .toBe(`Fixes an issue where tooltips in pie/donut charts did not work anymore
+
+Fixes an issue where the tooltip was not updated when a different series was hovered on the same x-datapoint`);
+  expect(split.type).toBe(CommitTypes.FIX);
+});
+
+it('should detect release commits correctly', () => {
+  const message = 'chore: Bump version to 5.0.0 w/ changelog';
+  const split = splitStringIntoCommitMessage(message);
+  expect(split.breakingChange).toBeFalsy();
+  expect(split.releaseCommit).toBeTruthy();
+  expect(split.components).toEqual([]);
+  expect(split.message).toBe('Bump version to 5.0.0 w/ changelog');
+  expect(split.type).toBe(CommitTypes.CHORE);
+});
+
+it('should detect breaking changes in single-line', () => {
+  const message = 'feat: Changed something critical BREAKING CHANGE.';
+  const split = splitStringIntoCommitMessage(message);
+  expect(split.breakingChange).toBeTruthy();
+  expect(split.releaseCommit).toBeFalsy();
+  expect(split.components).toEqual([]);
+  expect(split.message).toBe('Changed something critical BREAKING CHANGE.');
+  expect(split.type).toBe(CommitTypes.FEAT);
+});
+
+it('should detect breaking changes in multi-line', () => {
+  const message = `feat(filter-field): Improves typing for the data structures the default-data-source takes.
+
+BREAKING CHANGE: Changes the typing for the default-data-source to better match the data structures.`;
+  const split = splitStringIntoCommitMessage(message);
+  expect(split.breakingChange).toBeTruthy();
+  expect(split.releaseCommit).toBeFalsy();
+  expect(split.components).toEqual(['filter-field']);
+  expect(split.message)
+    .toBe(`Improves typing for the data structures the default-data-source takes.
+
+BREAKING CHANGE: Changes the typing for the default-data-source to better match the data structures.`);
+  expect(split.type).toBe(CommitTypes.FEAT);
+});

--- a/tools/pull-request-labeler/src/utils/split-message-into-components.ts
+++ b/tools/pull-request-labeler/src/utils/split-message-into-components.ts
@@ -16,19 +16,19 @@
 
 import { CommitMessage, CommitTypes } from '../interfaces/commit-message';
 
-const expression = new RegExp(
-  `(?<type>${Object.values(CommitTypes).join(
-    '|',
-  )})(?<component>\(.*?\))?:(?<message>.*)`,
-  'gims',
-);
 /**
  * Splits the commit message string into its own components. This helps for
  * further processing of the commit messages.
  * @param original Original string of the commit message.
  */
 export function splitStringIntoCommitMessage(original: string): CommitMessage {
-  const matching = original.match(expression);
+  const expression = new RegExp(
+    `(?<type>${Object.values(CommitTypes).join(
+      '|',
+    )})(?<component>\(.*?\))?:(?<message>.*)`,
+    'gims',
+  );
+  const matching = expression.exec(original);
 
   if (!matching) {
     throw new Error(`Message was not parsable: ${original}`);
@@ -42,6 +42,7 @@ export function splitStringIntoCommitMessage(original: string): CommitMessage {
     (matching.groups && matching.groups.component) ||
     ''
   ).trim();
+
   const components = componentMatch
     .replace('(', '')
     .replace(')', '')

--- a/tools/pull-request-labeler/tsconfig.spec.json
+++ b/tools/pull-request-labeler/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
+}


### PR DESCRIPTION
The autolabeler had a small bug, where it did not correclty parse the
commit messages and their features, which led the labeler to always add
minor and patch labels as a fallback.

Fixes #478

### <strong>Pull Request</strong>

#### Type of PR

CI fix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
