### PR TITLE
test(drawer): Fixes flaky drawer e2e tests.

### DIFF
--- a/apps/components-e2e/src/utils/wait-for-angular.ts
+++ b/apps/components-e2e/src/utils/wait-for-angular.ts
@@ -19,7 +19,7 @@ declare const window: Window & { ng: any; getAllAngularRootElements: any };
 
 export const waitForAngular = ClientFunction((waitTimeout = 10000) => {
   /** Interval in milliseconds where to ping angular */
-  const PING_INTERVAL = 100;
+  const PING_INTERVAL = 500;
 
   return new Promise((resolve, reject) => {
     let pingIntervalId: number;


### PR DESCRIPTION
### <strong>Pull Request</strong>

Fixed flaky drawer tests by using the chaing of testcafe and reducing the click and hovering speed to a human-like level. Furthermore, increase the initial retry timeout for the ng probe check of the `waitForAngular` function.

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

Improved stability of our e2e tests

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
