### PR TITLE
ci: Run the labeler on labeled step only.

### DIFF
--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -1,7 +1,7 @@
 name: "Pull Request Labeler"
 on:
   pull_request:
-    types: [synchronize, labeled]
+    types: [labeled]
 jobs:
   pull_request_labeler:
     runs-on: ubuntu-latest


### PR DESCRIPTION
If we add two types to the actions trigger, like [synchronize, labeled],
github will list it as two actions. One of them fires a little too
early when adding the LGTM label, so the check for its existence fails
and there will be always one failing action on the PR. Only running this
on label, should fix that problem.

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
