### PR TITLE
baritsa(live-examples): Added SCSS to live examples.

### DIFF
--- a/apps/barista/src/components/live-example/live-example.html
+++ b/apps/barista/src/components/live-example/live-example.html
@@ -27,6 +27,15 @@
     >
       TS
     </button>
+    <button
+      *ngIf="stylesSource"
+      class="ba-live-example-tab"
+      [class.ba-live-example-tab-active]="_activeTab === 'scss'"
+      [disabled]="_sourceHidden"
+      (click)="_setActiveTab('scss')"
+    >
+      SCSS
+    </button>
   </nav>
   <div class="ba-live-example-controls">
     <button
@@ -72,4 +81,8 @@
     class="ba-live-example-class-source"
     *ngIf="classSource && _activeTab === 'ts'"
   ><code [innerHTML]="_enhancedClassSource"></code></pre>
+  <pre
+    class="ba-live-example-class-source"
+    *ngIf="classSource && _activeTab === 'scss'"
+  ><code [innerHTML]="_enhancedStylesSource"></code></pre>
 </div>

--- a/apps/barista/src/components/live-example/live-example.ts
+++ b/apps/barista/src/components/live-example/live-example.ts
@@ -37,6 +37,7 @@ import {
   process,
   TypeScript,
   XML,
+  SCSS,
 } from 'highlight-ts';
 
 import { createComponent } from '../../utils/create-component';
@@ -115,6 +116,20 @@ export class BaLiveExample implements OnDestroy {
   }
   private _classSource: string;
 
+  /** The encoded styles source of the given example. */
+  @Input()
+  get stylesSource(): string {
+    return this._stylesSource;
+  }
+  set stylesSource(value: string) {
+    this._stylesSource = value;
+    if (!this._activeTabChanged && !this._activeTab) {
+      this._activeTab = 'scss';
+    }
+    this._enhancedStylesSource = this._enhanceCode(value, 'scss');
+  }
+  private _stylesSource: string;
+
   /**
    * @internal
    * The placeholder element that will be replaced with
@@ -147,6 +162,9 @@ export class BaLiveExample implements OnDestroy {
   /** @internal Enhanced class source with line wrappers and code highlighting. */
   _enhancedClassSource: string;
 
+  /** @internal Enhanced styles source with line wrappers and code highlighting. */
+  _enhancedStylesSource: string;
+
   private _timerSubscription = Subscription.EMPTY;
 
   /** Whether the user has changed the active tab. */
@@ -162,7 +180,7 @@ export class BaLiveExample implements OnDestroy {
     private _platform: Platform,
     private _ctcService: BaCopyToClipboardService,
   ) {
-    registerLanguages(TypeScript, XML);
+    registerLanguages(TypeScript, XML, SCSS);
     this._highlighter = init(htmlRender);
   }
 
@@ -196,7 +214,7 @@ export class BaLiveExample implements OnDestroy {
           copySucceeded = this._ctcService.copy(this._classSource, true);
           break;
         case 'scss':
-          // TODO: copySucceeded = this._ctcService.copy(this._scssSource, true)
+          copySucceeded = this._ctcService.copy(this._stylesSource, true);
           break;
       }
 

--- a/libs/shared/barista-definitions/src/lib/example-definitions.ts
+++ b/libs/shared/barista-definitions/src/lib/example-definitions.ts
@@ -18,6 +18,7 @@ export interface BaExampleMetadata {
   name: string;
   templateSource: string;
   classSource: string;
+  stylesSource: string;
 }
 
 export interface BaAllExamplesMetadata {

--- a/tools/barista/src/transform.ts
+++ b/tools/barista/src/transform.ts
@@ -204,6 +204,9 @@ export function exampleInlineSourcesTransformerFactory(
         if (demoMetadata.classSource) {
           $(element).attr('classSource', demoMetadata.classSource);
         }
+        if (demoMetadata.stylesSource) {
+          $(element).attr('stylesSource', demoMetadata.stylesSource);
+        }
       });
     });
     return source;

--- a/tools/examples/src/generate-examples-lib-metadata.ts
+++ b/tools/examples/src/generate-examples-lib-metadata.ts
@@ -32,6 +32,7 @@ export async function generateExamplesLibMetadataFile(
         name: exampleMeta.className,
         templateSource: exampleMeta.templateSource,
         classSource: exampleMeta.classSource,
+        stylesSource: exampleMeta.stylesSource ? exampleMeta.stylesSource : '',
       };
     }
   }


### PR DESCRIPTION
Added the SCSS content to the examples metadata if it is present.
Extended the metadata generation and the ba-live-example component to be
able to deal with extra SCSS added to the example.

Fixes #285

### <strong>Pull Request</strong>
#### Type of PR
Documentation update

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
