### PR TITLE
chore(drawer): Removes only

### DIFF
--- a/apps/components-e2e/src/components/drawer/drawer.e2e.ts
+++ b/apps/components-e2e/src/components/drawer/drawer.e2e.ts
@@ -45,7 +45,7 @@ const scrollUp = ClientFunction(distance => {
 });
 
 fixture('Drawer')
-  .only.page('http://localhost:4200/drawer')
+  .page('http://localhost:4200/drawer')
   .beforeEach(async (testController: TestController) => {
     await testController.resizeWindow(1200, 800);
     await waitForAngular();


### PR DESCRIPTION
Removes a missed `.only` in the drawer e2e