### PR TITLE
test(release): Fixes testing issues on windows with wrong root path expectations

### DIFF
--- a/tools/release/src/publish-release/publish-release.spec.ts
+++ b/tools/release/src/publish-release/publish-release.spec.ts
@@ -40,6 +40,11 @@ import * as utils from '../utils';
 import * as prompts from '../prompts';
 import { publishRelease } from './publish-release';
 import axios from 'axios';
+import { sep } from 'path';
+import { cwd } from 'process';
+import { platform } from 'os';
+
+const root = platform() === 'win32' ? `${cwd().split(sep)[0]}${sep}` : '/';
 
 beforeEach(() => {
   // Mock console logs away we don't want to bloat the output
@@ -57,7 +62,9 @@ test('Should throw an error when no package.json is found', async () => {
   try {
     await parsePackageVersion(process.cwd());
   } catch (err) {
-    expect(err.message).toBe('Error while parsing json file at /package.json');
+    expect(err.message).toBe(
+      `Error while parsing json file at ${root}package.json`,
+    );
   }
 });
 

--- a/tools/release/src/utils/publish-package.spec.ts
+++ b/tools/release/src/utils/publish-package.spec.ts
@@ -18,9 +18,14 @@ import { vol } from 'memfs';
 import { parse } from 'semver';
 import { publishPackage, npmPublish, yarnPublish } from './publish-package';
 import axios from 'axios';
+import { sep } from 'path';
+import { cwd } from 'process';
+import { platform } from 'os';
 
 const VERSION = parse('5.0.0')!;
 let processSpy: jest.SpyInstance;
+
+const root = platform() === 'win32' ? `${cwd().split(sep)[0]}${sep}` : '/';
 
 beforeEach(() => {
   process.chdir('/');
@@ -58,7 +63,7 @@ test('should call the npm and yarn publish commands with the right arguments', a
     2,
     'yarn publish --verbose --new-version=5.0.0 /components',
     // cwd should be the root dir
-    { cwd: '/', maxBuffer: expect.any(Number) },
+    { cwd: root, maxBuffer: expect.any(Number) },
     expect.any(Function),
   );
 


### PR DESCRIPTION
Path expectations were not compatible with windows root path definitions. Provided a  OS agnostic expectation.

Fixes #467

### <strong>Pull Request</strong>
#### Type of PR

Tests fixed for windows. 

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
