### PR TITLE
test(drawer): Slow down e2e test to make it more stable.

### DIFF
--- a/apps/components-e2e/src/components/drawer/drawer.e2e.ts
+++ b/apps/components-e2e/src/components/drawer/drawer.e2e.ts
@@ -146,7 +146,7 @@ test('should move selection area overlay with the chart on scroll', async (testC
     .notEql(currPosition)
     .expect(isCloseTo(currPosition, prevPosition - scrollDistance, 10))
     .ok()
-    .click(closeButton)
+    .click(closeButton, { speed: 0.3 })
     .expect(selection.exists)
     .notOk()
     .expect(overlay.exists)


### PR DESCRIPTION
Fixes #445

### <strong>Pull Request</strong>

As suggested by @lukasholzer in #445 we have slowed down the click in the flaky drawer end to end test.
Apperently the speed at which testcafe and browserstack evaluate these test expressions is faster than any angular change detection cycles can keep up with. 


#### Type of PR
Test

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
