### PR TITLE
barista: Get UX snippet content from Strapi.

### DIFF
--- a/libs/shared/barista-definitions/src/lib/barista-definitions.ts
+++ b/libs/shared/barista-definitions/src/lib/barista-definitions.ts
@@ -151,9 +151,10 @@ export interface BaStrapiPage extends BaStrapiBase {
 
 /** Strapi snippet */
 export interface BaStrapiSnippet extends BaStrapiBase {
-  slotID: string;
+  slotId: string;
   title: string;
   content: string;
+  public: boolean;
 }
 
 /** Strapi content types */

--- a/tools/barista/src/builder/components.ts
+++ b/tools/barista/src/builder/components.ts
@@ -31,7 +31,7 @@ import {
   extractH1ToTitleTransformer,
   markdownToHtmlTransformer,
   transformPage,
-  uxSlotTransformer,
+  uxSnippetTransformer,
   headingIdTransformer,
   copyHeadlineTransformer,
 } from '../transform';
@@ -46,8 +46,8 @@ const TRANSFORMERS: BaPageTransformer[] = [
   componentTagsTransformer,
   markdownToHtmlTransformer,
   extractH1ToTitleTransformer,
+  uxSnippetTransformer,
   headingIdTransformer,
-  uxSlotTransformer,
   copyHeadlineTransformer,
 ];
 

--- a/tools/barista/src/utils/fetch-strapi-content.ts
+++ b/tools/barista/src/utils/fetch-strapi-content.ts
@@ -48,7 +48,7 @@ export async function fetchContentList<
 }
 
 /**
- * Fetches a single item from Strapi CMS.
+ * Fetches a single item from Strapi CMS by ID.
  */
 export async function fetchContentItemById<
   T extends BaStrapiPage | BaStrapiSnippet | BaStrapiPageTeaser | BaStrapiCTA
@@ -62,6 +62,28 @@ export async function fetchContentItemById<
   // Only fetch content set to public when building the public version of Barista
   if (options.publicContent) {
     requestPath = `${requestPath}?public=true`;
+  }
+  const host = `http://${endpoint}:5100${requestPath}`;
+  const strapiResponse = await Axios.get<T>(host);
+  return strapiResponse.data;
+}
+
+/**
+ * Fetches a single item from Strapi CMS by field.
+ */
+export async function fetchContentItemByField<
+  T extends BaStrapiPage | BaStrapiSnippet | BaStrapiPageTeaser | BaStrapiCTA
+>(
+  contentType: BaStrapiContentType,
+  fieldName: string,
+  fieldValue: string,
+  options: FetchContentOptions,
+  endpoint: string,
+): Promise<T> {
+  let requestPath = `/${contentType}/?${fieldName}=${fieldValue}`;
+  // Only fetch content set to public when building the public version of Barista
+  if (options.publicContent) {
+    requestPath = `${requestPath}&public=true`;
   }
   const host = `http://${endpoint}:5100${requestPath}`;
   const strapiResponse = await Axios.get<T>(host);


### PR DESCRIPTION
### <strong>Pull Request</strong>

Added a Strapi snippet transformer that looks for `<ba-ux-snippet>` tags on content pages and replaces it with the snippet content coming from the CMS.

#### Type of PR

Other (if none of the above apply)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
