### PR TITLE
barista: Create missing snippets in Strapi when component pages are b…

### DIFF
--- a/tools/barista/src/builder/components.ts
+++ b/tools/barista/src/builder/components.ts
@@ -16,6 +16,8 @@
 
 import { existsSync, lstatSync, readFileSync, readdirSync } from 'fs';
 import { basename, dirname, extname, join } from 'path';
+import { load as loadWithCheerio } from 'cheerio';
+import Axios from 'axios';
 
 import {
   BaPageBuildResult,
@@ -50,6 +52,37 @@ const TRANSFORMERS: BaPageTransformer[] = [
   uxSlotTransformer,
   copyHeadlineTransformer,
 ];
+
+/** Creates snippets in Strapi that do not exist already. */
+async function createStrapiSnippets(content: string): Promise<void> {
+  const $ = loadWithCheerio(content);
+  // Get all snippet names that can be found within the content.
+  const snippetNames = $('ba-ux-snippet')
+    .map((_, el) => $(el).attr('name'))
+    .get();
+  if (snippetNames.length) {
+    const host = `http://${environment.strapiEndpoint}:5100/snippets`;
+    for (const name of snippetNames) {
+      // Check if entry with given slotId already exists.
+      try {
+        const exists = (await Axios.get(`${host}?slotId=${name}`)).data.length;
+        if (!exists) {
+          // Create new entry for given slotId
+          Axios.post(host, {
+            title: '',
+            slotId: name,
+            content: '',
+            public: false,
+          });
+        }
+      } catch (e) {
+        console.log(
+          `There has been an error creating a snippet (slotId: ${name}) in Strapi: ${e}`,
+        );
+      }
+    }
+  }
+}
 
 /** Returns all markdown files of a given path. */
 function getMarkdownFilesByPath(rootPath: string): string[] {
@@ -145,6 +178,10 @@ export const componentsBuilder: BaPageBuilder = async (
         [...TRANSFORMERS, ...globalTransformers],
       );
       transformed.push({ pageContent, relativeOutFile });
+
+      // Look for <ba-ux-snippet> placeholders within the content and create
+      // snippets in Strapi for those slots.
+      await createStrapiSnippets(pageContent.content);
     }
   }
 


### PR DESCRIPTION
…uilt.

### <strong>Pull Request</strong>

When component pages are built, the content is searched for `<ba-ux-snippet>` tags. If a snippet with the given name does not yet exist in Strapi, a new entry is created.

#### Type of PR

Barista page builder

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
