### PR TITLE
feat(table): Expose currently rendered data from the datasource.

### DIFF
--- a/components/table/src/table-data-source.ts
+++ b/components/table/src/table-data-source.ts
@@ -113,6 +113,9 @@ export class DtTableDataSource<T> extends DataSource<T> {
   private _renderChangesSubscription = Subscription.EMPTY;
   private _searchChangeSubscription = Subscription.EMPTY;
 
+  /** Public stream emitting render data to the table */
+  renderData = this._renderData.asObservable();
+
   /** Array of data that should be rendered by the table, where each object represents one row. */
   get data(): T[] {
     return this._data.value;


### PR DESCRIPTION
### <strong>Pull Request</strong>

In order to give programmatic access to the data that is currently being rendered in the table, we should expose the renderedData BehaviourSubject.

Fixes #497

The question is if we want to expose the renderedData BehaviourSubject directly, or if we shoud introduce an additional member subject. I'm afraid that if we expose the Subject directly used in the table data source, that this could lead to consumers nexting the data in there themselves and therefore removing control from the DtTableDataSource.

#### Type of PR
Feature

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
