### PR TITLE
feat(tree-table): Added events for expansion state changes 

### DIFF
--- a/apps/components-e2e/src/app/app.routing.module.ts
+++ b/apps/components-e2e/src/app/app.routing.module.ts
@@ -173,6 +173,13 @@ export const routes: Routes = [
         module => module.DtE2EHighlightModule,
       ),
   },
+  {
+    path: 'tree-table',
+    loadChildren: () =>
+      import('../components/tree-table/tree-table.module').then(
+        module => module.DtE2ETreeTableModule,
+      ),
+  },
 ];
 
 @NgModule({

--- a/apps/components-e2e/src/components/chart/selection-area/selection-area.ts
+++ b/apps/components-e2e/src/components/chart/selection-area/selection-area.ts
@@ -38,6 +38,9 @@ export class DtE2ESelectionArea {
   validRange = false;
 
   options = options;
+  // Added type here due to missing support for type inference on windows with typescript 3.4.5
+  // error TS2742: The inferred type of 'series$' cannot be named without a reference to '...@types/highcharts'.
+  // This is likely not portable. A type annotation is necessary.
   series$: Observable<
     Highcharts.IndividualSeriesOptions[]
   > = this._dataService

--- a/apps/components-e2e/src/components/drawer/drawer.ts
+++ b/apps/components-e2e/src/components/drawer/drawer.ts
@@ -39,6 +39,9 @@ export class DtE2EDrawer {
   lastTimeframe: [number, number];
 
   options = options;
+  // Added type here due to missing support for type inference on windows with typescript 3.4.5
+  // error TS2742: The inferred type of 'series$' cannot be named without a reference to '...@types/highcharts'.
+  // This is likely not portable. A type annotation is necessary.
   series$: Observable<
     Highcharts.IndividualSeriesOptions[]
   > = this._dataService

--- a/apps/components-e2e/src/components/tree-table/tree-table.e2e.ts
+++ b/apps/components-e2e/src/components/tree-table/tree-table.e2e.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  treeTableRows,
+  toggleButtons,
+  expandChangedCount,
+  expandedCount,
+  collapsedCount,
+  expandAllBtn,
+  collapseAllBtn,
+  expandChangedCountWithExpandedTrue,
+  expandChangedCountWithExpandedFalse,
+} from './tree-table.po';
+import { waitForAngular } from '../../utils/wait-for-angular';
+
+fixture('TreeTable')
+  .page('http://localhost:4200/tree-table')
+  .beforeEach(async () => {
+    await waitForAngular();
+  });
+
+test('should execute click handlers when not disabled', async (testController: TestController) => {
+  await testController
+    .expect(treeTableRows.count)
+    .eql(3)
+    .click(toggleButtons.nth(0))
+    .expect(treeTableRows.count)
+    .eql(5)
+    .click(toggleButtons.nth(0))
+    .expect(treeTableRows.count)
+    .eql(3);
+});
+
+test('should increase expand and collapse counters when expandChange event was fired', async (testController: TestController) => {
+  await testController
+    .expect(expandChangedCount.textContent)
+    .eql('0')
+    .expect(expandedCount.textContent)
+    .eql('0')
+    .expect(collapsedCount.textContent)
+    .eql('0')
+    .click(toggleButtons.nth(0))
+    .expect(expandChangedCount.textContent)
+    .eql('1')
+    .expect(expandedCount.textContent)
+    .eql('1')
+    .expect(collapsedCount.textContent)
+    .eql('0')
+    .click(toggleButtons.nth(0))
+    .expect(expandChangedCount.textContent)
+    .eql('2')
+    .expect(expandedCount.textContent)
+    .eql('1')
+    .expect(collapsedCount.textContent)
+    .eql('1');
+});
+
+test('should increase expand counter when expandAll was clicked', async (testController: TestController) => {
+  await testController
+    .expect(expandChangedCount.textContent)
+    .eql('0')
+    .expect(expandChangedCountWithExpandedTrue.textContent)
+    .eql('0')
+    .expect(expandChangedCountWithExpandedFalse.textContent)
+    .eql('0')
+    .expect(expandedCount.textContent)
+    .eql('0')
+    .expect(collapsedCount.textContent)
+    .eql('0')
+    .click(expandAllBtn.nth(0))
+    .expect(expandChangedCount.textContent)
+    .eql('2')
+    .expect(expandChangedCountWithExpandedTrue.textContent)
+    .eql('2')
+    .expect(expandChangedCountWithExpandedFalse.textContent)
+    .eql('0')
+    .expect(expandedCount.textContent)
+    .eql('2')
+    .expect(collapsedCount.textContent)
+    .eql('0')
+    .click(collapseAllBtn.nth(0))
+    .expect(expandChangedCount.textContent)
+    .eql('4')
+    .expect(expandChangedCountWithExpandedTrue.textContent)
+    .eql('2')
+    .expect(expandChangedCountWithExpandedFalse.textContent)
+    .eql('2')
+    .expect(expandedCount.textContent)
+    .eql('2')
+    .expect(collapsedCount.textContent)
+    .eql('2');
+});

--- a/apps/components-e2e/src/components/tree-table/tree-table.html
+++ b/apps/components-e2e/src/components/tree-table/tree-table.html
@@ -1,0 +1,99 @@
+<section>
+  <dt-tree-table
+    [dataSource]="dataSource"
+    [treeControl]="treeControl"
+    interactiveRows
+  >
+    <ng-container dtColumnDef="name">
+      <dt-tree-table-header-cell *dtHeaderCellDef
+        >Name</dt-tree-table-header-cell
+      >
+      <dt-tree-table-toggle-cell
+        *dtCellDef="let row"
+        (expandChange)="expandStateChanged($event)"
+        (expanded)="expanded()"
+        (collapsed)="collapsed()"
+      >
+        {{ row.name }} {{ row.threadlevel }}
+      </dt-tree-table-toggle-cell>
+    </ng-container>
+
+    <ng-container dtColumnDef="total">
+      <dt-tree-table-header-cell *dtHeaderCellDef>
+        Total time consumption
+      </dt-tree-table-header-cell>
+      <dt-cell *dtCellDef="let row">
+        {{row.blocked + "/" + row.totalTimeConsumption}}<br />
+        {{row.waiting + "/" + row.totalTimeConsumption}}<br />
+        {{row.running + "/" + row.totalTimeConsumption}}
+      </dt-cell>
+    </ng-container>
+
+    <ng-container dtColumnDef="blocked" dtColumnAlign="right">
+      <dt-tree-table-header-cell *dtHeaderCellDef>
+        Blocked
+      </dt-tree-table-header-cell>
+      <dt-cell dtIndicator dtIndicatorColor="error" *dtCellDef="let row">
+        {{ row.blocked }}ms
+      </dt-cell>
+    </ng-container>
+
+    <ng-container dtColumnDef="running" dtColumnAlign="center">
+      <dt-tree-table-header-cell *dtHeaderCellDef>
+        Running
+      </dt-tree-table-header-cell>
+      <dt-cell *dtCellDef="let row">{{ row.running }}ms</dt-cell>
+    </ng-container>
+
+    <ng-container dtColumnDef="waiting">
+      <dt-tree-table-header-cell *dtHeaderCellDef>
+        Waiting
+      </dt-tree-table-header-cell>
+      <dt-cell *dtCellDef="let row">{{ row.waiting }}ms</dt-cell>
+    </ng-container>
+
+    <ng-container dtColumnDef="actions">
+      <dt-tree-table-header-cell *dtHeaderCellDef>
+        Actions
+      </dt-tree-table-header-cell>
+      <dt-cell *dtCellDef="let row">
+        buttons...
+      </dt-cell>
+    </ng-container>
+
+    <dt-header-row
+      *dtHeaderRowDef="[
+      'name',
+      'total',
+      'blocked',
+      'running',
+      'waiting',
+      'actions'
+    ]"
+    ></dt-header-row>
+    <dt-tree-table-row
+      *dtRowDef="
+      let row;
+      columns: ['name', 'total', 'blocked', 'running', 'waiting', 'actions']
+    "
+      [data]="row"
+    ></dt-tree-table-row>
+  </dt-tree-table>
+
+  <button class="expand-all-btn" (click)="treeControl.expandAll()">
+    Expand all
+  </button>
+  <button class="collapse-all-btn" (click)="treeControl.collapseAll()">
+    Collapse all
+  </button>
+</section>
+
+<span class="expand-changed">{{ expandChangedCount }}</span>
+<span class="expand-changed-expanded-true"
+  >{{ expandChangedCountWithExpandTrue }}</span
+>
+<span class="expand-changed-expanded-false"
+  >{{ expandChangedCountWithExpandFalse }}</span
+>
+<span class="expanded">{{ expandedCount }}</span>
+<span class="collapsed">{{ collapsedCount }}</span>

--- a/apps/components-e2e/src/components/tree-table/tree-table.module.ts
+++ b/apps/components-e2e/src/components/tree-table/tree-table.module.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { Route, RouterModule } from '@angular/router';
+import { DtTreeTableModule } from '@dynatrace/barista-components/tree-table';
+import { DtE2ETreeTable } from './tree-table';
+
+const routes: Route[] = [{ path: '', component: DtE2ETreeTable }];
+
+@NgModule({
+  declarations: [DtE2ETreeTable],
+  imports: [CommonModule, RouterModule.forChild(routes), DtTreeTableModule],
+  exports: [],
+  providers: [],
+})
+export class DtE2ETreeTableModule {}

--- a/apps/components-e2e/src/components/tree-table/tree-table.po.ts
+++ b/apps/components-e2e/src/components/tree-table/tree-table.po.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Selector } from 'testcafe';
+
+export const toggleButtons = Selector('.dt-tree-table-toggle');
+export const treeTableRows = Selector('dt-tree-table-row');
+export const expandChangedCount = Selector('.expand-changed');
+export const expandChangedCountWithExpandedTrue = Selector(
+  '.expand-changed-expanded-true',
+);
+export const expandChangedCountWithExpandedFalse = Selector(
+  '.expand-changed-expanded-false',
+);
+export const expandedCount = Selector('.expanded');
+export const collapsedCount = Selector('.collapsed');
+export const expandAllBtn = Selector('.expand-all-btn');
+export const collapseAllBtn = Selector('.collapse-all-btn');

--- a/apps/components-e2e/src/components/tree-table/tree-table.ts
+++ b/apps/components-e2e/src/components/tree-table/tree-table.ts
@@ -1,0 +1,227 @@
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, OnDestroy } from '@angular/core';
+import { DtIconType } from '@dynatrace/barista-icons';
+import { FlatTreeControl } from '@angular/cdk/tree';
+import {
+  DtTreeFlattener,
+  DtTreeDataSource,
+  DtTreeControl,
+} from 'components/core/src/tree';
+import { BehaviorSubject, Subscription } from 'rxjs';
+
+const TESTDATA: ThreadNode[] = [
+  {
+    name: 'hz.hzInstance_1_cluster.thread',
+    icon: 'airplane',
+    threadlevel: 'S0',
+    totalTimeConsumption: 150,
+    waiting: 123,
+    running: 20,
+    blocked: 0,
+    children: [
+      {
+        name:
+          'hz.hzInstance_1_cluster.thread_1_hz.hzInstance_1_cluster.thread-1',
+        icon: 'airplane',
+        threadlevel: 'S1',
+        totalTimeConsumption: 150,
+        waiting: 123,
+        running: 20,
+        blocked: 0,
+      },
+      {
+        name: 'hz.hzInstance_1_cluster.thread-2',
+        icon: 'airplane',
+        threadlevel: 'S1',
+        totalTimeConsumption: 150,
+        waiting: 130,
+        running: 0,
+        blocked: 0,
+      },
+    ],
+  },
+  {
+    name: 'jetty',
+    icon: 'airplane',
+    threadlevel: 'S0',
+    totalTimeConsumption: 150,
+    waiting: 123,
+    running: 20,
+    blocked: 0,
+    children: [
+      {
+        name: 'jetty-422',
+        icon: 'airplane',
+        threadlevel: 'S1',
+        totalTimeConsumption: 150,
+        waiting: 123,
+        running: 20,
+        blocked: 0,
+      },
+      {
+        name: 'jetty-423',
+        icon: 'airplane',
+        threadlevel: 'S1',
+        totalTimeConsumption: 150,
+        waiting: 130,
+        running: 0,
+        blocked: 0,
+      },
+      {
+        name: 'jetty-424',
+        icon: 'airplane',
+        threadlevel: 'S1',
+        totalTimeConsumption: 150,
+        waiting: 130,
+        running: 0,
+        blocked: 0,
+      },
+    ],
+  },
+  {
+    name: 'Downtime timer',
+    icon: 'airplane',
+    threadlevel: 'S0',
+    totalTimeConsumption: 150,
+    waiting: 123,
+    running: 20,
+    blocked: 0,
+  },
+];
+
+export class ThreadNode {
+  name: string;
+  threadlevel: string;
+  totalTimeConsumption: number;
+  blocked: number;
+  running: number;
+  waiting: number;
+  icon: DtIconType;
+  children?: ThreadNode[];
+}
+
+export class ThreadFlatNode {
+  name: string;
+  threadlevel: string;
+  totalTimeConsumption: number;
+  blocked: number;
+  running: number;
+  waiting: number;
+  icon: DtIconType;
+  level: number;
+  expandable: boolean;
+}
+
+@Component({
+  selector: 'dt-e2e-tree-table',
+  templateUrl: 'tree-table.html',
+})
+export class DtE2ETreeTable implements OnDestroy {
+  expandChangedCount = 0;
+  expandChangedCountWithExpandTrue = 0;
+  expandChangedCountWithExpandFalse = 0;
+  expandedCount = 0;
+  collapsedCount = 0;
+  /** Map from flat node to nested node. This helps us finding the nested node to be modified */
+  flatNodeMap = new Map<ThreadFlatNode, ThreadNode>();
+
+  /** Map from nested node to flattened node. This helps us to keep the same object for selection */
+  nestedNodeMap = new Map<ThreadNode, ThreadFlatNode>();
+
+  treeControl: FlatTreeControl<ThreadFlatNode>;
+  treeFlattener: DtTreeFlattener<ThreadNode, ThreadFlatNode>;
+  dataSource: DtTreeDataSource<ThreadNode, ThreadFlatNode>;
+
+  get data(): ThreadNode[] {
+    return this.dataChange.value;
+  }
+
+  dataChange = new BehaviorSubject<ThreadNode[]>([]);
+
+  _dataChangeSub: Subscription;
+
+  constructor() {
+    this.treeControl = new DtTreeControl<ThreadFlatNode>(
+      this._getLevel,
+      this._isExpandable,
+    );
+    this.treeFlattener = new DtTreeFlattener(
+      this.transformer,
+      this._getLevel,
+      this._isExpandable,
+      this._getChildren,
+    );
+    this.dataSource = new DtTreeDataSource(
+      this.treeControl,
+      this.treeFlattener,
+    );
+    this.dataChange.next(TESTDATA);
+
+    this._dataChangeSub = this.dataChange.subscribe(data => {
+      this.dataSource.data = data;
+    });
+  }
+
+  expandStateChanged(state: boolean): void {
+    this.expandChangedCount++;
+    if (state) {
+      this.expandChangedCountWithExpandTrue++;
+    } else {
+      this.expandChangedCountWithExpandFalse++;
+    }
+  }
+  collapsed(): void {
+    this.collapsedCount++;
+  }
+  expanded(): void {
+    this.expandedCount++;
+  }
+
+  hasChild = (_: number, _nodeData: ThreadFlatNode) => _nodeData.expandable;
+
+  transformer = (node: ThreadNode, level: number): ThreadFlatNode => {
+    const existingNode = this.nestedNodeMap.get(node);
+    const flatNode =
+      existingNode && existingNode.name === node.name
+        ? existingNode
+        : new ThreadFlatNode();
+    flatNode.name = node.name;
+    flatNode.level = level;
+    flatNode.threadlevel = node.threadlevel;
+    flatNode.expandable = !!node.children;
+    flatNode.blocked = node.blocked;
+    flatNode.running = node.running;
+    flatNode.waiting = node.waiting;
+    flatNode.totalTimeConsumption = node.totalTimeConsumption;
+    flatNode.icon = node.icon;
+    this.flatNodeMap.set(flatNode, node);
+    this.nestedNodeMap.set(node, flatNode);
+    return flatNode;
+  };
+
+  private _getLevel = (node: ThreadFlatNode) => node.level;
+
+  private _isExpandable = (node: ThreadFlatNode) => node.expandable;
+
+  private _getChildren = (node: ThreadNode): ThreadNode[] =>
+    node.children || [];
+
+  ngOnDestroy(): void {
+    this._dataChangeSub.unsubscribe();
+  }
+}

--- a/components/tree-table/README.md
+++ b/components/tree-table/README.md
@@ -210,6 +210,20 @@ It is obligatory to provide either an `aria-label` or `aria-labelledby`.
 | ------ | ---- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `data` | `T`  | The data for the row. Note that this might be removed rather soon and made obsolete due to a feature request on the underlying cdk table |
 
+## DtTreeTableToggleCell inputs
+
+| Name       | Type      | Default | Description                                              |
+| ---------- | --------- | ------- | -------------------------------------------------------- |
+| `expanded` | `boolean` | `false` | Sets or gets the DtTreeTableToggleCell's expanded state. |
+
+## DtTreeTableToggleCell outputs
+
+| Name           | Type                    | Description                                                                                            |
+| -------------- | ----------------------- | ------------------------------------------------------------------------------------------------------ |
+| `expandChange` | `EventEmitter<boolean>` | Emits an event when the expanded state changes. The event parameter is set to true when it is expanded |
+| `expanded`     | `EventEmitter<void>`    | Event emitted when the DtTreeTableToggleCell is expanded.                                              |
+| `collapsed`    | `EventEmitter<void>`    | Event emitted when the DtTreeTableToggleCell is collapsed.                                             |
+
 ## DtTreeControl
 
 | Name             | Type                                                     | Default | Description                                                                                      |

--- a/components/tree-table/src/tree-table-toggle-cell.html
+++ b/components/tree-table/src/tree-table-toggle-cell.html
@@ -4,7 +4,7 @@
     dt-icon-button
     variant="nested"
     [disabled]="!_expandable"
-    (click)="_treeControl.toggle(_rowData);"
+    (click)="_toggle()"
     [attr.aria-label]="ariaLabel"
     [attr.aria-labelledby]="ariaLabelledBy"
   >

--- a/components/tree-table/src/tree-table-toggle-cell.ts
+++ b/components/tree-table/src/tree-table-toggle-cell.ts
@@ -27,15 +27,17 @@ import {
   SkipSelf,
   ViewChild,
   ViewEncapsulation,
+  Output,
 } from '@angular/core';
-import { Subscription } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { Subscription, Observable } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
 
 import { DtTreeControl } from '@dynatrace/barista-components/core';
 import { DtCell, DtColumnDef } from '@dynatrace/barista-components/table';
 
 import { DtTreeTable } from './tree-table';
 import { DtTreeTableRow } from './tree-table-row';
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
 
 /** The indentation in px for a level in the tree-table */
 const DT_TREE_TABLE_INDENT_PX = 16;
@@ -60,6 +62,50 @@ export class DtTreeTableToggleCell<T> extends DtCell
   @Input('aria-label') ariaLabel: string;
   /** Aria reference to a label describing the toggle button. */
   @Input('aria-labelledby') ariaLabelledBy: string;
+
+  /** Event emitted when the cell's expandable state changes. */
+  @Output()
+  readonly expandChange: Observable<
+    boolean
+  > = this._treeControl.expansionModel.changed.pipe(
+    filter(
+      (changed: SelectionChange<T>) =>
+        (changed.added.includes(this._rowData) ||
+          changed.removed.includes(this._rowData)) &&
+        this._treeControl.isExpandable(this._rowData),
+    ),
+    map((changed: SelectionChange<T>) => changed.added.includes(this._rowData)),
+  );
+
+  /** The expanded state of the cell and therefore also of the row */
+  @Input()
+  get expanded(): boolean {
+    return this._isExpanded;
+  }
+  set expanded(value: boolean) {
+    const shouldExpand = coerceBooleanProperty(value);
+
+    // Only update expanded state if it actually changed.
+    if (this._isExpanded !== shouldExpand) {
+      if (shouldExpand) {
+        this._expand();
+      } else {
+        this._collapse();
+      }
+    }
+  }
+
+  /** Event that emits every time the cell/row is expanded */
+  @Output('expanded')
+  readonly treeExpanded: Observable<boolean> = this.expandChange.pipe(
+    filter(v => v),
+  );
+
+  /** Event that emits every time the cell/row is collapsed */
+  @Output()
+  readonly collapsed: Observable<boolean> = this.expandChange.pipe(
+    filter(v => !v),
+  );
 
   /** @internal Wether the row is expanded */
   get _isExpanded(): boolean {
@@ -107,6 +153,21 @@ export class DtTreeTableToggleCell<T> extends DtCell
       .subscribe(() => {
         this._changeDetectorRef.markForCheck();
       });
+  }
+
+  /** @internal triggers the treecontrols toggle method with current rowdata  */
+  _toggle(): void {
+    this._treeControl.toggle(this._rowData);
+  }
+
+  /** @internal triggers the treecontrols expand method with current rowdata  */
+  _expand(): void {
+    this._treeControl.expand(this._rowData);
+  }
+
+  /** @internal triggers the treecontrols toggle method with current rowdata  */
+  _collapse(): void {
+    this._treeControl.collapse(this._rowData);
   }
 
   ngAfterViewInit(): void {


### PR DESCRIPTION
for DtTreeTableToggleCell.

    Previously there was no way to figure out, if a tree has expanded or collapsed.
    So `expandChanged(bool)`, `expanded()`, `collapsed()` events where introduced.
    Expanded can also be bound with two way binding to set the initial state.

Fixes #415
Finalizes external contribution #458 

Thx @gselltho for the contribution! 🎉 