### PR TITLE
ci: Change labeler to run on merge-ready instead of lgtm.

### DIFF
--- a/tools/pull-request-labeler/src/main.ts
+++ b/tools/pull-request-labeler/src/main.ts
@@ -21,7 +21,7 @@ import { processCommitMessages } from './utils/process-commit-messages';
 import { getCommitMessagesInPullRequest } from './utils/get-commit-messages-in-pull-request';
 import { getPullRequestDetails } from './utils/get-pull-request-details';
 import { isMasterTarget } from './utils/is-master-target';
-import { hasLgtmLabel } from './utils/has-lgtm-label';
+import { hasMergeReadyLabel } from './utils/has-merge-ready-label';
 import { addRebaseLabel } from './utils/add-rebase-label';
 
 function getPrNumber(): number | undefined {
@@ -48,9 +48,9 @@ async function run() {
   // Get the pull request target
   const pullRequestDetails = await getPullRequestDetails(client, prNumber);
 
-  if (!hasLgtmLabel(pullRequestDetails)) {
+  if (!hasMergeReadyLabel(pullRequestDetails)) {
     console.log(
-      'Not ready to label just yet, add pr: lgtm label to it to start the process.',
+      'Not ready to label just yet, add pr: merge-ready label to it to start the process.',
     );
     process.exit(1);
     return;

--- a/tools/pull-request-labeler/src/utils/has-merge-ready-label.ts
+++ b/tools/pull-request-labeler/src/utils/has-merge-ready-label.ts
@@ -17,8 +17,8 @@
 import { PullsGetResponse } from '@octokit/rest';
 
 /**
- * Checks if the pull request is already labeled with pr: lgtm
+ * Checks if the pull request is already labeled with pr: merge-ready
  */
-export function hasLgtmLabel(pullRequest: PullsGetResponse): boolean {
-  return pullRequest.labels.some(label => label.name === 'pr: lgtm');
+export function hasMergeReadyLabel(pullRequest: PullsGetResponse): boolean {
+  return pullRequest.labels.some(label => label.name === 'pr: merge-ready');
 }


### PR DESCRIPTION
### <strong>Pull Request</strong>

Adjusts labeler to run on `pr: merge-ready` instead of `pr: lgtm` as part of our change in the pr workflow (See #494).

#### Type of PR
Other (if none of the above apply)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
