### PR TITLE
feat(copy-to-clipboard): Added `variant` input to control embedded button variant.

### DIFF
--- a/components/copy-to-clipboard/README.md
+++ b/components/copy-to-clipboard/README.md
@@ -28,6 +28,12 @@ a label ready to be copied to the clipboard.
 Using `<dt-copy-to-clipboard-label>` defines the button content (e.g. text like
 "click here to copy").
 
+## Inputs
+
+| Name      | Type                      | Default   | Description                                                   |
+| --------- | ------------------------- | --------- | ------------------------------------------------------------- |
+| `variant` | `'primary' | 'secondary'` | `primary` | Defines the variant of the embedded copy-to-clipboard button. |
+
 ## Outputs
 
 | Name         | Type                 | Description                                                                                 |

--- a/components/copy-to-clipboard/src/copy-to-clipboard.html
+++ b/components/copy-to-clipboard/src/copy-to-clipboard.html
@@ -5,6 +5,7 @@
 <button
   dt-button
   class="dt-copy-to-clipboard-btn-button"
+  [variant]="variant"
   #copyButton
   (click)="copyToClipboard()"
 >

--- a/components/copy-to-clipboard/src/copy-to-clipboard.ts
+++ b/components/copy-to-clipboard/src/copy-to-clipboard.ts
@@ -26,6 +26,7 @@ import {
   Output,
   ViewChild,
   ViewEncapsulation,
+  Input,
 } from '@angular/core';
 import { Subscription, timer } from 'rxjs';
 
@@ -34,6 +35,7 @@ import {
   removeCssClass,
 } from '@dynatrace/barista-components/core';
 import { DtInput } from '@dynatrace/barista-components/input';
+import { ButtonVariant } from '@dynatrace/barista-components/button';
 
 const DT_COPY_CLIPBOARD_TIMER = 800;
 const DT_COPY_TO_CLIPBOARD_SUCCESSFUL = 'dt-copy-to-clipboard-successful';
@@ -52,6 +54,9 @@ const DT_COPY_TO_CLIPBOARD_SUCCESSFUL = 'dt-copy-to-clipboard-successful';
 })
 export class DtCopyToClipboard implements AfterContentInit, OnDestroy {
   constructor(private _cd: ChangeDetectorRef) {}
+
+  /** Defines the button variant of the copy button. */
+  @Input() variant: ButtonVariant = 'primary';
 
   /** Emits a stream when the content has been copied. */
   @Output() readonly copied: EventEmitter<void> = new EventEmitter();

--- a/libs/examples/src/copy-to-clipboard/copy-to-clipboard-examples.module.ts
+++ b/libs/examples/src/copy-to-clipboard/copy-to-clipboard-examples.module.ts
@@ -26,6 +26,7 @@ import { DtExampleCopyToClipboardDark } from './copy-to-clipboard-dark-example/c
 import { DtExampleCopyToClipboardDefault } from './copy-to-clipboard-default-example/copy-to-clipboard-default-example';
 import { DtExampleCopyToClipboardError } from './copy-to-clipboard-error-example/copy-to-clipboard-error-example';
 import { DtExampleCopyToClipboardTextarea } from './copy-to-clipboard-textarea-example/copy-to-clipboard-textarea-example';
+import { DtExampleCopyToClipboardSecondaryButton } from './copy-to-clipboard-secondary-button-example/copy-to-clipboard-secondary-button-example';
 
 export const DT_COPY_TO_CLIPBOARD_EXAMPLES = [
   DtExampleCopyToClipboardCallback,
@@ -33,6 +34,7 @@ export const DT_COPY_TO_CLIPBOARD_EXAMPLES = [
   DtExampleCopyToClipboardDark,
   DtExampleCopyToClipboardDefault,
   DtExampleCopyToClipboardError,
+  DtExampleCopyToClipboardSecondaryButton,
   DtExampleCopyToClipboardTextarea,
 ];
 

--- a/libs/examples/src/copy-to-clipboard/copy-to-clipboard-secondary-button-example/copy-to-clipboard-secondary-button-example.html
+++ b/libs/examples/src/copy-to-clipboard/copy-to-clipboard-secondary-button-example/copy-to-clipboard-secondary-button-example.html
@@ -1,0 +1,8 @@
+<dt-copy-to-clipboard variant="secondary">
+  <input
+    dtInput
+    value="https://barista.dynatrace.com/"
+    aria-label="The value of this input field will be copied to clipboard."
+  />
+  <dt-copy-to-clipboard-label>Copy</dt-copy-to-clipboard-label>
+</dt-copy-to-clipboard>

--- a/libs/examples/src/copy-to-clipboard/copy-to-clipboard-secondary-button-example/copy-to-clipboard-secondary-button-example.ts
+++ b/libs/examples/src/copy-to-clipboard/copy-to-clipboard-secondary-button-example/copy-to-clipboard-secondary-button-example.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'dt-example-copy-to-clipboard-secondary-button',
+  templateUrl: 'copy-to-clipboard-secondary-button-example.html',
+})
+export class DtExampleCopyToClipboardSecondaryButton {}


### PR DESCRIPTION
We have added an input to the copy-to-clipboard component that is passed
through to the button, which is being used in the copy to clipboard
template. The newly created input controls the variant of the embedded
button.

Fixes #76

### <strong>Pull Request</strong>

#### Type of PR
Feature

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
