### PR TITLE
fix(tag-add): Fixes tag add label when zoom is lower that 100%

### DIFF
--- a/components/tag/src/tag-add/tag-add.scss
+++ b/components/tag/src/tag-add/tag-add.scss
@@ -38,7 +38,6 @@
   }
 
   .dt-tag-add-button-text {
-    width: 44px;
     height: 16px;
     vertical-align: middle;
     line-height: 16px;


### PR DESCRIPTION
Fixes https://github.com/dynatrace-oss/barista/issues/509