### PR TITLE
barista: Replace backslashes when generating the barista examples mod…

### DIFF
--- a/tools/examples/src/util.ts
+++ b/tools/examples/src/util.ts
@@ -19,6 +19,11 @@ import { relative, extname } from 'path';
 import { environment } from 'tools/environments/barista-environment';
 import { ExampleMetadata } from './metadata';
 
+/** Replaces backslashes with forward slashes. */
+function replaceBackslashes(path: string): string {
+  return path.replace(/\\/g, '/');
+}
+
 /**
  * Reads a provided template file, transforms its content
  * by calling a provided transform function,
@@ -64,6 +69,8 @@ export function getExampleImportsFromMetadata(
       importPath = importPath.slice(0, -3);
     }
 
+    // Replace backslashes to also support Windows
+    importPath = replaceBackslashes(importPath);
     let importNames = exampleImports.get(importPath);
     if (!importNames) {
       importNames = [];
@@ -100,5 +107,8 @@ export function getImportExportPath(
   if (!path.startsWith('.') || path.startsWith('/')) {
     path = `./${path}`;
   }
+
+  // Replace backslashes to also support Windows
+  path = replaceBackslashes(path);
   return path;
 }


### PR DESCRIPTION
### <strong>Pull Request</strong>

Some path functions, e.g. `path.relative` introduce backslashes when running on Windows. To not have broken paths in module files, we have to replace them with forward slashes.

#### Type of PR

Other

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
