### PR TITLE
feat: Removes Renderer2 to be compatible with ivy.

### DIFF
--- a/apps/barista/src/pages/overview-page/overview-page.ts
+++ b/apps/barista/src/pages/overview-page/overview-page.ts
@@ -27,7 +27,7 @@ import { Subscription, fromEvent } from 'rxjs';
 import { BaCategoryNavigationContents } from '@dynatrace/barista-components/barista-definitions';
 import { BaPage } from '../../pages/page-outlet';
 import { BaTile } from '../../layout/tile/tile';
-import { readKeyCode } from '@dynatrace/barista-components/core';
+import { _readKeyCode } from '@dynatrace/barista-components/core';
 
 const LOCALSTORAGEKEY = 'baristaGridview';
 
@@ -70,7 +70,7 @@ export class BaOverviewPage implements AfterViewInit, BaPage, OnDestroy {
 
     this._keyUpSubscription = fromEvent(document, 'keyup').subscribe(
       (evt: KeyboardEvent) => {
-        const keyCode = readKeyCode(evt);
+        const keyCode = _readKeyCode(evt);
         if (keyCode >= A && keyCode <= Z) {
           this._focusItem(evt.key.toLowerCase());
         }

--- a/components/autocomplete/src/autocomplete-trigger.ts
+++ b/components/autocomplete/src/autocomplete-trigger.ts
@@ -74,7 +74,7 @@ import {
   _countGroupLabelsBeforeOption,
   _getOptionScrollPosition,
   isDefined,
-  readKeyCode,
+  _readKeyCode,
   stringify,
   DtFlexibleConnectedPositionStrategy,
 } from '@dynatrace/barista-components/core';
@@ -393,7 +393,7 @@ export class DtAutocompleteTrigger<T>
 
   /** @internal Handler for the users key down events. */
   _handleKeydown(event: KeyboardEvent): void {
-    const keyCode = readKeyCode(event);
+    const keyCode = _readKeyCode(event);
 
     // Prevent the default action on all escape key presses. This is here primarily to bring IE
     // in line with other browsers. By default, pressing escape on IE will cause it to revert
@@ -435,7 +435,7 @@ export class DtAutocompleteTrigger<T>
       this._overlayRef = this._overlay.create(this._getOverlayConfig());
 
       this._overlayRef.keydownEvents().subscribe(event => {
-        const keyCode = readKeyCode(event);
+        const keyCode = _readKeyCode(event);
         // Close when pressing ESCAPE or ALT + UP_ARROW, based on the a11y guidelines.
         // See: https://www.w3.org/TR/wai-aria-practices-1.1/#textbox-keyboard-interaction
         if (keyCode === ESCAPE || (keyCode === UP_ARROW && event.altKey)) {

--- a/components/breadcrumbs/src/breadcrumbs-item.ts
+++ b/components/breadcrumbs/src/breadcrumbs-item.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Directive, ElementRef, Renderer2 } from '@angular/core';
+import { Directive, ElementRef } from '@angular/core';
 
 /**
  * A breadcrumbs item that can be used within the `<dt-breadcrumbs>`.
@@ -30,24 +30,17 @@ import { Directive, ElementRef, Renderer2 } from '@angular/core';
   },
 })
 export class DtBreadcrumbsItem2 {
-  constructor(
-    private readonly _elementRef: ElementRef<HTMLAnchorElement>,
-    private readonly _renderer: Renderer2,
-  ) {}
+  constructor(private readonly _elementRef: ElementRef<HTMLAnchorElement>) {}
 
   /** @internal */
   _setCurrent(current: boolean): void {
-    if (current) {
-      this._renderer.setAttribute(
-        this._elementRef.nativeElement,
-        'aria-current',
-        'page',
-      );
-    } else {
-      this._renderer.removeAttribute(
-        this._elementRef.nativeElement,
-        'aria-current',
-      );
+    const element: Element = this._elementRef.nativeElement;
+    if (element && element.setAttribute) {
+      if (current) {
+        element.setAttribute('aria-current', 'page');
+      } else {
+        element.removeAttribute('aria-current');
+      }
     }
   }
 }

--- a/components/button-group/src/button-group.ts
+++ b/components/button-group/src/button-group.ts
@@ -40,7 +40,7 @@ import {
   HasTabIndex,
   mixinColor,
   mixinTabIndex,
-  readKeyCode,
+  _readKeyCode,
 } from '@dynatrace/barista-components/core';
 
 export class DtButtonGroupBase {
@@ -281,7 +281,7 @@ export class DtButtonGroupItem<T> extends _DtButtonGroupItem
 
   /** @internal Ensures the option is selected when activated from the keyboard. */
   _handleKeydown(event: KeyboardEvent): void {
-    const keyCode = readKeyCode(event);
+    const keyCode = _readKeyCode(event);
     if (keyCode === ENTER || keyCode === SPACE) {
       this._onSelect(event);
 

--- a/components/button/src/button.ts
+++ b/components/button/src/button.ts
@@ -25,7 +25,6 @@ import {
   Input,
   OnDestroy,
   QueryList,
-  Renderer2,
   ViewEncapsulation,
 } from '@angular/core';
 import { NEVER, Subscription } from 'rxjs';
@@ -111,7 +110,6 @@ export class DtButton extends _DtButtonMixinBase
   constructor(
     elementRef: ElementRef,
     private _focusMonitor: FocusMonitor,
-    private _renderer: Renderer2,
     private _changeDetectorRef: ChangeDetectorRef,
   ) {
     super(elementRef);
@@ -153,7 +151,6 @@ export class DtButton extends _DtButtonMixinBase
       this._elementRef,
       `dt-button-${oldClass}`,
       `dt-button-${newClass}`,
-      this._renderer,
     );
   }
 }
@@ -185,10 +182,9 @@ export class DtAnchor extends DtButton {
   constructor(
     elementRef: ElementRef,
     focusMonitor: FocusMonitor,
-    renderer: Renderer2,
     changeDetectorRef: ChangeDetectorRef,
   ) {
-    super(elementRef, focusMonitor, renderer, changeDetectorRef);
+    super(elementRef, focusMonitor, changeDetectorRef);
   }
 
   /**

--- a/components/button/src/button.ts
+++ b/components/button/src/button.ts
@@ -36,7 +36,7 @@ import {
   HasElementRef,
   mixinColor,
   mixinDisabled,
-  replaceCssClass,
+  _replaceCssClass,
 } from '@dynatrace/barista-components/core';
 import { DtIcon } from '@dynatrace/barista-components/icon';
 
@@ -94,7 +94,7 @@ export class DtButton extends _DtButtonMixinBase
   set variant(value: ButtonVariant) {
     const variant = value || defaultVariant;
     if (variant !== this._variant) {
-      this._replaceCssClass(variant, this._variant);
+      this.__replaceCssClass(variant, this._variant);
       this._variant = variant;
     }
   }
@@ -146,8 +146,8 @@ export class DtButton extends _DtButtonMixinBase
     return this._elementRef.nativeElement;
   }
 
-  private _replaceCssClass(newClass?: string, oldClass?: string): void {
-    replaceCssClass(
+  private __replaceCssClass(newClass?: string, oldClass?: string): void {
+    _replaceCssClass(
       this._elementRef,
       `dt-button-${oldClass}`,
       `dt-button-${newClass}`,

--- a/components/chart/src/heatfield/chart-heatfield.ts
+++ b/components/chart/src/heatfield/chart-heatfield.ts
@@ -34,7 +34,7 @@ import {
   Constructor,
   isDefined,
   mixinColor,
-  readKeyCode,
+  _readKeyCode,
 } from '@dynatrace/barista-components/core';
 import { clamp, round } from 'lodash';
 import { Subject } from 'rxjs';
@@ -241,7 +241,7 @@ export class DtChartHeatfield extends _DtHeatfieldMixinBase
    * @internal
    */
   _handleKeydown(event: KeyboardEvent): void {
-    if (readKeyCode(event) === ENTER) {
+    if (_readKeyCode(event) === ENTER) {
       this._toggleActive();
     }
   }

--- a/components/chart/src/range/range.ts
+++ b/components/chart/src/range/range.ts
@@ -41,11 +41,11 @@ import { BehaviorSubject, Subject } from 'rxjs';
 import { startWith, takeUntil } from 'rxjs/operators';
 
 import {
-  addCssClass,
-  getElementBoundingClientRect,
+  _addCssClass,
+  _getElementBoundingClientRect,
   isNumber,
-  readKeyCode,
-  removeCssClass,
+  _readKeyCode,
+  _removeCssClass,
 } from '@dynatrace/barista-components/core';
 import { dtFormatDateRange } from '@dynatrace/barista-components/formatters';
 
@@ -314,7 +314,7 @@ export class DtChartRange implements AfterViewInit, OnDestroy {
   /** @internal Reflects styles, value and validity to the dom. */
   _reflectToDom(): void {
     this._maxWidth =
-      this._maxWidth || getElementBoundingClientRect(this._elementRef).width;
+      this._maxWidth || _getElementBoundingClientRect(this._elementRef).width;
     this._reflectStyleToDom();
     this._reflectValueToDom();
     this._reflectRangeValid();
@@ -375,12 +375,12 @@ export class DtChartRange implements AfterViewInit, OnDestroy {
    * @param handle indicates whether the left or the right handle triggered the event
    */
   _handleKeyDown(event: KeyboardEvent, handle: string): void {
-    if (readKeyCode(event) === TAB) {
+    if (_readKeyCode(event) === TAB) {
       // we want to stay in our focus trap so continue
       return;
     }
 
-    if ([BACKSPACE, DELETE].includes(readKeyCode(event))) {
+    if ([BACKSPACE, DELETE].includes(_readKeyCode(event))) {
       // if the backspace or delete is pressed on the selected area we want to close it
       if (handle === DtSelectionAreaEventTarget.SelectedArea) {
         this._handleOverlayClose();
@@ -422,9 +422,9 @@ export class DtChartRange implements AfterViewInit, OnDestroy {
    */
   _reflectRangeReleased(add: boolean): void {
     if (add) {
-      addCssClass(this._elementRef.nativeElement, DT_RANGE_RELEASED_CLASS);
+      _addCssClass(this._elementRef.nativeElement, DT_RANGE_RELEASED_CLASS);
     } else {
-      removeCssClass(this._elementRef.nativeElement, DT_RANGE_RELEASED_CLASS);
+      _removeCssClass(this._elementRef.nativeElement, DT_RANGE_RELEASED_CLASS);
     }
   }
 
@@ -514,9 +514,9 @@ export class DtChartRange implements AfterViewInit, OnDestroy {
    */
   private _reflectRangeValid(): void {
     if (!this._valid) {
-      addCssClass(this._elementRef.nativeElement, DT_RANGE_INVALID_CLASS);
+      _addCssClass(this._elementRef.nativeElement, DT_RANGE_INVALID_CLASS);
     } else {
-      removeCssClass(this._elementRef.nativeElement, DT_RANGE_INVALID_CLASS);
+      _removeCssClass(this._elementRef.nativeElement, DT_RANGE_INVALID_CLASS);
     }
   }
 

--- a/components/chart/src/range/range.ts
+++ b/components/chart/src/range/range.ts
@@ -31,7 +31,6 @@ import {
   OnDestroy,
   Output,
   QueryList,
-  Renderer2,
   TemplateRef,
   ViewChild,
   ViewChildren,
@@ -281,7 +280,6 @@ export class DtChartRange implements AfterViewInit, OnDestroy {
     public _viewContainerRef: ViewContainerRef,
     private _elementRef: ElementRef<HTMLElement>,
     private _changeDetectorRef: ChangeDetectorRef,
-    private _renderer: Renderer2,
   ) {}
 
   ngOnDestroy(): void {
@@ -544,37 +542,23 @@ export class DtChartRange implements AfterViewInit, OnDestroy {
     const displayValue = dtFormatDateRange(this.value[0], this.value[1]);
 
     if (this._rangeElementRef && this._rangeElementRef.first) {
-      this._renderer.setAttribute(
-        this._rangeElementRef.first.nativeElement,
-        'aria-valuenow',
-        `${this.value.join('-')}`,
-      );
-      this._renderer.setAttribute(
-        this._rangeElementRef.first.nativeElement,
-        'aria-valuetext',
-        displayValue,
-      );
+      const element: Element = this._rangeElementRef.first.nativeElement;
+      if (element && element.setAttribute) {
+        element.setAttribute('aria-valuenow', `${this.value.join('-')}`);
+        element.setAttribute('aria-valuetext', displayValue);
+      }
     }
   }
 
   /** Updates the selection area styling according to the actual range */
   private _reflectStyleToDom(): void {
     if (this._rangeElementRef && this._rangeElementRef.first) {
-      this._renderer.setStyle(
-        this._rangeElementRef.first.nativeElement,
-        'opacity',
-        `${+!this._rangeHidden}`,
-      );
-      this._renderer.setStyle(
-        this._rangeElementRef.first.nativeElement,
-        'left',
-        `${this._rangeArea.left}px`,
-      );
-      this._renderer.setStyle(
-        this._rangeElementRef.first.nativeElement,
-        'width',
-        `${this._rangeArea.width}px`,
-      );
+      const element: HTMLElement = this._rangeElementRef.first.nativeElement;
+      if (element && element.style) {
+        element.style.opacity = `${+!this._rangeHidden}`;
+        element.style.left = `${this._rangeArea.left}px`;
+        element.style.width = `${this._rangeArea.width}px`;
+      }
     }
   }
 }

--- a/components/chart/src/range/update-range-with-keyboard-event.ts
+++ b/components/chart/src/range/update-range-with-keyboard-event.ts
@@ -16,7 +16,7 @@
 
 import { END, HOME } from '@angular/cdk/keycodes';
 
-import { readKeyCode } from '@dynatrace/barista-components/core';
+import { _readKeyCode } from '@dynatrace/barista-components/core';
 
 import { DtSelectionAreaEventTarget } from '../selection-area/position-utils';
 import { getKeyboardNavigationOffset } from '../utils';
@@ -38,7 +38,7 @@ export function updateRangeWithKeyboardEvent(
   const offset = getKeyboardNavigationOffset(event);
   let { left, width } = currentRange;
 
-  if (readKeyCode(event) === HOME) {
+  if (_readKeyCode(event) === HOME) {
     switch (handle) {
       case DtSelectionAreaEventTarget.LeftHandle:
         left = 0;
@@ -52,7 +52,7 @@ export function updateRangeWithKeyboardEvent(
         left = 0;
         width = currentRange.width;
     }
-  } else if (readKeyCode(event) === END) {
+  } else if (_readKeyCode(event) === END) {
     switch (handle) {
       case DtSelectionAreaEventTarget.LeftHandle:
         left = currentRange.left + currentRange.width;

--- a/components/chart/src/selection-area/selection-area.ts
+++ b/components/chart/src/selection-area/selection-area.ts
@@ -42,12 +42,12 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import {
-  addCssClass,
+  _addCssClass,
   DtFlexibleConnectedPositionStrategy,
   DtViewportResizer,
-  getElementBoundingClientRect,
-  readKeyCode,
-  removeCssClass,
+  _getElementBoundingClientRect,
+  _readKeyCode,
+  _removeCssClass,
   ViewportBoundaries,
 } from '@dynatrace/barista-components/core';
 import {
@@ -216,7 +216,7 @@ export class DtChartSelectionArea implements AfterContentInit, OnDestroy {
 
     // get the BCR of the selection Area
     this._selectionAreaBcr$ = this._plotBackground$.pipe(
-      map(plotBackground => getElementBoundingClientRect(plotBackground)),
+      map(plotBackground => _getElementBoundingClientRect(plotBackground)),
       share(),
     );
 
@@ -224,7 +224,7 @@ export class DtChartSelectionArea implements AfterContentInit, OnDestroy {
     // initial selection area.´
     fromEvent<KeyboardEvent>(this._elementRef.nativeElement, 'keydown')
       .pipe(
-        filter(event => readKeyCode(event) === ENTER),
+        filter(event => _readKeyCode(event) === ENTER),
         withLatestFrom(this._selectionAreaBcr$),
         takeUntil(this._destroy$),
       )
@@ -255,7 +255,7 @@ export class DtChartSelectionArea implements AfterContentInit, OnDestroy {
             range._pixelsToValue = xAxis.toValue.bind(xAxis);
             range._maxValue = xAxis.dataMax;
             range._minValue = xAxis.dataMin;
-            range._maxWidth = getElementBoundingClientRect(
+            range._maxWidth = _getElementBoundingClientRect(
               plotBackground,
             ).width;
             range._reflectToDom();
@@ -583,7 +583,7 @@ export class DtChartSelectionArea implements AfterContentInit, OnDestroy {
       // dragHandleStart$ stream to notify when a drag on a handle happens.
       const dragHandleStart$ = this._chart._range._handleDragStarted.pipe(
         tap(() => {
-          removeCssClass(
+          _removeCssClass(
             this._elementRef.nativeElement,
             NO_POINTER_EVENTS_CLASS,
           );
@@ -711,9 +711,9 @@ export class DtChartSelectionArea implements AfterContentInit, OnDestroy {
 
           // every drag regardless of if it is a handle or initial drag should have the grab cursors
           if (resize >= 0) {
-            addCssClass(this._elementRef.nativeElement, GRAB_CURSOR_CLASS);
+            _addCssClass(this._elementRef.nativeElement, GRAB_CURSOR_CLASS);
           } else {
-            removeCssClass(this._elementRef.nativeElement, GRAB_CURSOR_CLASS);
+            _removeCssClass(this._elementRef.nativeElement, GRAB_CURSOR_CLASS);
           }
         });
     }
@@ -983,8 +983,8 @@ export class DtChartSelectionArea implements AfterContentInit, OnDestroy {
   private _updateSelectionAreaSize(plotBackground: SVGRectElement): void {
     // get Bounding client Rects of the plot background and the host to calculateRelativeXPos
     // a relative offset.
-    const hostBCR = getElementBoundingClientRect(this._chart._elementRef);
-    const plotBCR = getElementBoundingClientRect(plotBackground);
+    const hostBCR = _getElementBoundingClientRect(this._chart._elementRef);
+    const plotBCR = _getElementBoundingClientRect(plotBackground);
 
     const topOffset = plotBCR.top - hostBCR.top;
     const leftOffset = plotBCR.left - hostBCR.left;

--- a/components/chart/src/selection-area/selection-area.ts
+++ b/components/chart/src/selection-area/selection-area.ts
@@ -35,7 +35,6 @@ import {
   NgZone,
   OnDestroy,
   Optional,
-  Renderer2,
   SkipSelf,
   TemplateRef,
   ViewChild,
@@ -181,7 +180,6 @@ export class DtChartSelectionArea implements AfterContentInit, OnDestroy {
     @SkipSelf() private _chart: DtChart,
     private _elementRef: ElementRef<HTMLElement>,
     private _focusTrapFactory: FocusTrapFactory,
-    private _renderer: Renderer2,
     private _overlay: Overlay,
     private _zone: NgZone,
     private _viewportRuler: ViewportRuler,
@@ -945,8 +943,10 @@ export class DtChartSelectionArea implements AfterContentInit, OnDestroy {
 
   /** Function that toggles the visibility of the hairline (line that follows the mouses) */
   private _toggleHairline(show: boolean): void {
-    const display = show ? 'inherit' : 'none';
-    this._renderer.setStyle(this._hairline.nativeElement, 'display', display);
+    const element: HTMLElement = this._hairline.nativeElement;
+    if (element && element.style) {
+      element.style.display = show ? 'inherit' : 'none';
+    }
   }
 
   /** Function that safely toggles the visible state of the range */
@@ -973,11 +973,10 @@ export class DtChartSelectionArea implements AfterContentInit, OnDestroy {
 
   /** reflects the position of the timestamp to the element */
   private _reflectHairlinePositionToDom(x: number): void {
-    this._renderer.setStyle(
-      this._hairline.nativeElement,
-      'transform',
-      `translateX(${x}px)`,
-    );
+    const element: HTMLElement = this._hairline.nativeElement;
+    if (element && element.style) {
+      element.style.transform = `translateX(${x}px)`;
+    }
   }
 
   /** Set the position of the select-able area to the size of the Highcharts plot background */

--- a/components/chart/src/selection-area/streams.spec.ts
+++ b/components/chart/src/selection-area/streams.spec.ts
@@ -134,7 +134,7 @@ describe('Selection Area Streams', () => {
     const captureSpy = jest
       .spyOn(utils, 'captureAndMergeEvents')
       .mockReturnValue(of(fakeMouseDown));
-    const coreSpy = jest.spyOn(core, 'removeCssClass');
+    const coreSpy = jest.spyOn(core, '_removeCssClass');
 
     testScheduler.run(({ expectObservable, flush }) => {
       expectObservable(getMouseDownStream(selectionArea, [selectionArea])).toBe(
@@ -144,8 +144,8 @@ describe('Selection Area Streams', () => {
       // need to execute all side effects before expecting
       flush();
 
-      expect(core.removeCssClass).toHaveBeenCalledTimes(1);
-      expect(core.removeCssClass).toHaveBeenCalledWith(
+      expect(core._removeCssClass).toHaveBeenCalledTimes(1);
+      expect(core._removeCssClass).toHaveBeenCalledWith(
         selectionArea,
         NO_POINTER_EVENTS_CLASS,
       );
@@ -161,7 +161,7 @@ describe('Selection Area Streams', () => {
   it('should create a mouseup stream that triggers a side effect', () => {
     const fakeMouseUp = createMouseEvent('mouseup');
 
-    const coreSpy = jest.spyOn(core, 'addCssClass');
+    const coreSpy = jest.spyOn(core, '_addCssClass');
 
     testScheduler.run(({ expectObservable, flush }) => {
       expectObservable(getMouseUpStream(selectionArea, of(fakeMouseUp))).toBe(
@@ -171,8 +171,8 @@ describe('Selection Area Streams', () => {
       // need to execute all side effects before expecting
       flush();
 
-      expect(core.addCssClass).toHaveBeenCalledTimes(1);
-      expect(core.addCssClass).toHaveBeenCalledWith(
+      expect(core._addCssClass).toHaveBeenCalledTimes(1);
+      expect(core._addCssClass).toHaveBeenCalledWith(
         selectionArea,
         NO_POINTER_EVENTS_CLASS,
       );
@@ -206,7 +206,7 @@ describe('Selection Area Streams', () => {
     const captureSpy = jest
       .spyOn(utils, 'captureAndMergeEvents')
       .mockReturnValue(of(fakeMouseDown));
-    const cssClassSpy = jest.spyOn(core, 'removeCssClass');
+    const cssClassSpy = jest.spyOn(core, '_removeCssClass');
 
     testScheduler.run(({ expectObservable, flush }) => {
       expectObservable(getMouseDownStream(selectionArea, [selectionArea])).toBe(
@@ -215,7 +215,7 @@ describe('Selection Area Streams', () => {
       // need to execute all side effects before expecting
       flush();
 
-      expect(core.removeCssClass).not.toHaveBeenCalled();
+      expect(core._removeCssClass).not.toHaveBeenCalled();
       expect(utils.captureAndMergeEvents).toHaveBeenCalledWith('mousedown', [
         selectionArea,
       ]);

--- a/components/chart/src/selection-area/streams.ts
+++ b/components/chart/src/selection-area/streams.ts
@@ -40,8 +40,8 @@ import {
 } from 'rxjs/operators';
 
 import {
-  addCssClass,
-  removeCssClass,
+  _addCssClass,
+  _removeCssClass,
   runInsideZone,
 } from '@dynatrace/barista-components/core';
 
@@ -69,7 +69,7 @@ export function getMouseDownStream(
   return captureAndMergeEvents('mousedown', mousedownElements).pipe(
     filter(event => event.button === 0), // only emit left mouse
     tap(() => {
-      removeCssClass(target, NO_POINTER_EVENTS_CLASS);
+      _removeCssClass(target, NO_POINTER_EVENTS_CLASS);
     }),
     share(),
   );
@@ -92,7 +92,7 @@ export function getMouseUpStream(
 
   return mouseUp$.pipe(
     tap(() => {
-      addCssClass(target, NO_POINTER_EVENTS_CLASS);
+      _addCssClass(target, NO_POINTER_EVENTS_CLASS);
     }),
     share(),
   );
@@ -110,7 +110,7 @@ export function getTouchStartStream(
 ): Observable<TouchEvent> {
   return captureAndMergeEvents('touchstart', mousedownElements).pipe(
     tap(() => {
-      removeCssClass(target, NO_POINTER_EVENTS_CLASS);
+      _removeCssClass(target, NO_POINTER_EVENTS_CLASS);
     }),
     share(),
   );
@@ -133,7 +133,7 @@ export function getTouchEndStream(
 
   return touchEndStream$.pipe(
     tap(() => {
-      addCssClass(target, NO_POINTER_EVENTS_CLASS);
+      _addCssClass(target, NO_POINTER_EVENTS_CLASS);
     }),
     share(),
   );

--- a/components/chart/src/timestamp/timestamp.ts
+++ b/components/chart/src/timestamp/timestamp.ts
@@ -35,7 +35,6 @@ import {
   OnDestroy,
   Output,
   QueryList,
-  Renderer2,
   TemplateRef,
   ViewChild,
   ViewChildren,
@@ -208,7 +207,6 @@ export class DtChartTimestamp implements AfterViewInit, OnDestroy {
 
   constructor(
     public _viewContainerRef: ViewContainerRef,
-    private _renderer: Renderer2,
     private _changeDetectorRef: ChangeDetectorRef,
     private _elementRef: ElementRef<HTMLElement>,
   ) {}
@@ -334,11 +332,11 @@ export class DtChartTimestamp implements AfterViewInit, OnDestroy {
   /** Reflects the position of the timestamp to the element */
   private _reflectStyleToDom(): void {
     if (this._timestampElementRef && this._timestampElementRef.first) {
-      this._renderer.setStyle(
-        this._timestampElementRef.first.nativeElement,
-        'transform',
-        `translateX(${this._positionX}px)`,
-      );
+      const element: HTMLElement = this._timestampElementRef.first
+        .nativeElement;
+      if (element.style) {
+        element.style.transform = `translateX(${this._positionX}px)`;
+      }
     }
   }
 }

--- a/components/chart/src/timestamp/timestamp.ts
+++ b/components/chart/src/timestamp/timestamp.ts
@@ -44,7 +44,7 @@ import {
 import { Subject } from 'rxjs';
 import { startWith, takeUntil } from 'rxjs/operators';
 
-import { isNumber, readKeyCode } from '@dynatrace/barista-components/core';
+import { isNumber, _readKeyCode } from '@dynatrace/barista-components/core';
 
 import { updateTimestampWithKeyboardEvent } from './update-timestamp-with-keyboard-event';
 
@@ -290,19 +290,19 @@ export class DtChartTimestamp implements AfterViewInit, OnDestroy {
    * @param event Keyboard event that provides information how to move the timestamp
    */
   _handleKeyUp(event: KeyboardEvent): void {
-    if (readKeyCode(event) === TAB) {
+    if (_readKeyCode(event) === TAB) {
       // we want to stay in our focus trap so continue
       return;
     }
 
-    if ([BACKSPACE, DELETE].includes(readKeyCode(event))) {
+    if ([BACKSPACE, DELETE].includes(_readKeyCode(event))) {
       // reset the timestamp
       this._handleOverlayClose();
       this._emitStateChanges();
     }
 
     const arrowKeys = [DOWN_ARROW, UP_ARROW, LEFT_ARROW, RIGHT_ARROW];
-    if (!!event.shiftKey && arrowKeys.includes(readKeyCode(event))) {
+    if (!!event.shiftKey && arrowKeys.includes(_readKeyCode(event))) {
       this._switchToRange.next(this._positionX);
     }
 

--- a/components/chart/src/timestamp/update-timestamp-with-keyboard-event.ts
+++ b/components/chart/src/timestamp/update-timestamp-with-keyboard-event.ts
@@ -16,7 +16,7 @@
 
 import { END, HOME } from '@angular/cdk/keycodes';
 
-import { readKeyCode } from '@dynatrace/barista-components/core';
+import { _readKeyCode } from '@dynatrace/barista-components/core';
 
 import { getKeyboardNavigationOffset } from '../utils';
 import { clampTimestamp } from './clamp-timestamp';
@@ -35,11 +35,11 @@ export function updateTimestampWithKeyboardEvent(
   maxWidth: number,
   minWidth: number = 0,
 ): number {
-  if (readKeyCode(event) === END) {
+  if (_readKeyCode(event) === END) {
     return maxWidth;
   }
 
-  if (readKeyCode(event) === HOME) {
+  if (_readKeyCode(event) === HOME) {
     return minWidth;
   }
 

--- a/components/chart/src/utils.ts
+++ b/components/chart/src/utils.ts
@@ -27,7 +27,7 @@ import { ElementRef, QueryList } from '@angular/core';
 import { Observable, OperatorFunction, fromEvent, merge } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
-import { readKeyCode } from '@dynatrace/barista-components/core';
+import { _readKeyCode } from '@dynatrace/barista-components/core';
 
 /** @internal Highcharts plot background dimensions */
 export interface PlotBackgroundInfo {
@@ -47,7 +47,7 @@ const KEYBOARD_NAVIGATION_LARGE_OFFSET = 10;
  * or a small one.
  */
 export function getKeyboardNavigationOffset(event: KeyboardEvent): number {
-  switch (readKeyCode(event)) {
+  switch (_readKeyCode(event)) {
     case RIGHT_ARROW:
     case UP_ARROW:
       return 1;

--- a/components/checkbox/src/checkbox.ts
+++ b/components/checkbox/src/checkbox.ts
@@ -31,7 +31,6 @@ import {
   OnInit,
   Output,
   Provider,
-  Renderer2,
   ViewChild,
   ViewEncapsulation,
   forwardRef,
@@ -247,7 +246,6 @@ export class DtCheckbox<T> extends _DtCheckboxMixinBase
     private _elementRef: ElementRef,
     private _focusMonitor: FocusMonitor,
     private _platform: Platform,
-    private _renderer: Renderer2,
     @Attribute('tabindex') tabIndex: string,
   ) {
     super();
@@ -264,7 +262,6 @@ export class DtCheckbox<T> extends _DtCheckboxMixinBase
       addCssClass(
         this._elementRef.nativeElement,
         'dt-checkbox-animation-fallback',
-        this._renderer,
       );
     }
   }

--- a/components/checkbox/src/checkbox.ts
+++ b/components/checkbox/src/checkbox.ts
@@ -45,7 +45,7 @@ import {
 import {
   CanDisable,
   HasTabIndex,
-  addCssClass,
+  _addCssClass,
   mixinDisabled,
   mixinTabIndex,
 } from '@dynatrace/barista-components/core';
@@ -259,7 +259,7 @@ export class DtCheckbox<T> extends _DtCheckboxMixinBase
     // We need to do the user agent check on JS side
     // because there is no css specific solution for EDGE
     if (this._platform.TRIDENT || this._platform.EDGE) {
-      addCssClass(
+      _addCssClass(
         this._elementRef.nativeElement,
         'dt-checkbox-animation-fallback',
       );

--- a/components/consumption/src/consumption.ts
+++ b/components/consumption/src/consumption.ts
@@ -41,7 +41,7 @@ import {
   Constructor,
   isDefined,
   mixinColor,
-  readKeyCode,
+  _readKeyCode,
 } from '@dynatrace/barista-components/core';
 
 import { DtConsumptionOverlay } from './consumption-directives';
@@ -197,7 +197,7 @@ export class DtConsumption extends _DtConsumption
    * @internal Toggles the overlay.
    */
   _toggleOverlay(keyEvent: KeyboardEvent): void {
-    if (readKeyCode(keyEvent) === KEY_RETURN) {
+    if (_readKeyCode(keyEvent) === KEY_RETURN) {
       if (this._overlayRef) {
         this._destroyOverlay();
       } else {

--- a/components/context-dialog/src/context-dialog.ts
+++ b/components/context-dialog/src/context-dialog.ts
@@ -53,7 +53,7 @@ import {
   HasTabIndex,
   mixinDisabled,
   mixinTabIndex,
-  readKeyCode,
+  _readKeyCode,
 } from '@dynatrace/barista-components/core';
 
 import { DtContextDialogTrigger } from './context-dialog-trigger';
@@ -324,7 +324,7 @@ export class DtContextDialog extends _DtContextDialogMixinBase
       .keydownEvents()
       .pipe(takeUntil(this._destroy))
       .subscribe((event: KeyboardEvent) => {
-        if (readKeyCode(event) === ESCAPE && this._overlayRef) {
+        if (_readKeyCode(event) === ESCAPE && this._overlayRef) {
           this.close();
         }
       });

--- a/components/copy-to-clipboard/src/copy-to-clipboard.ts
+++ b/components/copy-to-clipboard/src/copy-to-clipboard.ts
@@ -31,8 +31,8 @@ import {
 import { Subscription, timer } from 'rxjs';
 
 import {
-  addCssClass,
-  removeCssClass,
+  _addCssClass,
+  _removeCssClass,
 } from '@dynatrace/barista-components/core';
 import { DtInput } from '@dynatrace/barista-components/input';
 import { ButtonVariant } from '@dynatrace/barista-components/button';
@@ -96,9 +96,9 @@ export class DtCopyToClipboard implements AfterContentInit, OnDestroy {
         return;
       }
       this._showIcon = true;
-      addCssClass(this._input.nativeElement, DT_COPY_TO_CLIPBOARD_SUCCESSFUL);
+      _addCssClass(this._input.nativeElement, DT_COPY_TO_CLIPBOARD_SUCCESSFUL);
       if (this._copyButton) {
-        addCssClass(
+        _addCssClass(
           this._copyButton.nativeElement,
           DT_COPY_TO_CLIPBOARD_SUCCESSFUL,
         );
@@ -116,9 +116,9 @@ export class DtCopyToClipboard implements AfterContentInit, OnDestroy {
 
   private _resetCopyState(): void {
     this._showIcon = false;
-    removeCssClass(this._input.nativeElement, DT_COPY_TO_CLIPBOARD_SUCCESSFUL);
+    _removeCssClass(this._input.nativeElement, DT_COPY_TO_CLIPBOARD_SUCCESSFUL);
     if (this._copyButton) {
-      removeCssClass(
+      _removeCssClass(
         this._copyButton.nativeElement,
         DT_COPY_TO_CLIPBOARD_SUCCESSFUL,
       );

--- a/components/core/src/common-behaviours/color.ts
+++ b/components/core/src/common-behaviours/color.ts
@@ -16,7 +16,7 @@
 
 import { Directive, ElementRef, NgModule } from '@angular/core';
 
-import { replaceCssClass } from '../util/platform-util';
+import { _replaceCssClass } from '../util/platform-util';
 import { Constructor } from './constructor';
 
 export interface CanColor<P extends Partial<DtThemePalette>> {
@@ -81,7 +81,7 @@ export function setComponentColorClasses<
   T extends { color?: string } & HasElementRef
 >(component: T, color?: string): void {
   if (color !== component.color) {
-    replaceCssClass(
+    _replaceCssClass(
       component._elementRef,
       component.color ? `dt-color-${component.color}` : null,
       color ? `dt-color-${color}` : null,

--- a/components/core/src/option/option.ts
+++ b/components/core/src/option/option.ts
@@ -32,7 +32,7 @@ import {
 } from '@angular/core';
 import { Subject } from 'rxjs';
 
-import { readKeyCode } from '../util/index';
+import { _readKeyCode } from '../util/index';
 import { DtOptgroup } from './optgroup';
 
 let _uniqueId = 0;
@@ -207,7 +207,7 @@ export class DtOption<T> implements AfterViewChecked, OnDestroy {
 
   /** @internal Ensures the option is selected when activated from the keyboard. */
   _handleKeydown(event: KeyboardEvent): void {
-    const keyCode = readKeyCode(event);
+    const keyCode = _readKeyCode(event);
     if (keyCode === ENTER || keyCode === SPACE) {
       this._selectViaInteraction();
 

--- a/components/core/src/util/platform-util.ts
+++ b/components/core/src/util/platform-util.ts
@@ -15,7 +15,7 @@
  */
 
 import { coerceElement } from '@angular/cdk/coercion';
-import { ElementRef, Renderer2 } from '@angular/core';
+import { ElementRef } from '@angular/core';
 
 import { isNumber, isString } from './type-util';
 
@@ -28,14 +28,13 @@ export function replaceCssClass(
   elOrRef: any, // tslint:disable-line:no-any
   oldClass: string | null,
   newClass: string | null,
-  renderer?: Renderer2,
 ): void {
   const el = elOrRef.nativeElement || elOrRef;
   if (oldClass) {
-    removeCssClass(el, oldClass, renderer);
+    removeCssClass(el, oldClass);
   }
   if (newClass) {
-    addCssClass(el, newClass, renderer);
+    addCssClass(el, newClass);
   }
 }
 
@@ -51,20 +50,17 @@ export function toggleCssClass(
   // tslint:disable-next-line: no-any
   el: any,
   name: string,
-  renderer?: Renderer2,
 ): void {
   if (condition) {
-    addCssClass(el, name, renderer);
+    addCssClass(el, name);
   } else {
-    removeCssClass(el, name, renderer);
+    removeCssClass(el, name);
   }
 }
 
 // tslint:disable-next-line:no-any
-export function addCssClass(el: any, name: string, renderer?: Renderer2): void {
-  if (renderer) {
-    renderer.addClass(el, name);
-  } else {
+export function addCssClass(el: any, name: string): void {
+  if (el.classList) {
     el.classList.add(name);
   }
 }
@@ -72,11 +68,8 @@ export function addCssClass(el: any, name: string, renderer?: Renderer2): void {
 export function removeCssClass(
   el: any, // tslint:disable-line:no-any
   name: string,
-  renderer?: Renderer2,
 ): void {
-  if (renderer) {
-    renderer.removeClass(el, name);
-  } else {
+  if (el.classList) {
     el.classList.remove(name);
   }
 }

--- a/components/core/src/util/platform-util.ts
+++ b/components/core/src/util/platform-util.ts
@@ -20,52 +20,57 @@ import { ElementRef } from '@angular/core';
 import { isNumber, isString } from './type-util';
 
 /**
+ * @internal
+ *
  * Replaces an old class on an element with a new on.
  * Both can also be null. In this case it just adds the new one or removes the old one.
  * If the optional Renderer is not provided it uses the browser specific classList.
  */
-export function replaceCssClass(
+export function _replaceCssClass(
   elOrRef: any, // tslint:disable-line:no-any
   oldClass: string | null,
   newClass: string | null,
 ): void {
   const el = elOrRef.nativeElement || elOrRef;
   if (oldClass) {
-    removeCssClass(el, oldClass);
+    _removeCssClass(el, oldClass);
   }
   if (newClass) {
-    addCssClass(el, newClass);
+    _addCssClass(el, newClass);
   }
 }
 
 /**
+ * @internal
+ *
  * Adds or removes a class based on a provided boolean value
  * @param condition A boolean value that decides whether a class should be added or removed
  * @param el Element where the class should be toggled
  * @param name Class name that should be added or removed
  * @param renderer Optional renderer to set the class.
  */
-export function toggleCssClass(
+export function _toggleCssClass(
   condition: boolean,
   // tslint:disable-next-line: no-any
   el: any,
   name: string,
 ): void {
   if (condition) {
-    addCssClass(el, name);
+    _addCssClass(el, name);
   } else {
-    removeCssClass(el, name);
+    _removeCssClass(el, name);
   }
 }
 
+/** @internal */
 // tslint:disable-next-line:no-any
-export function addCssClass(el: any, name: string): void {
+export function _addCssClass(el: any, name: string): void {
   if (el.classList) {
     el.classList.add(name);
   }
 }
-
-export function removeCssClass(
+/** @internal */
+export function _removeCssClass(
   el: any, // tslint:disable-line:no-any
   name: string,
 ): void {
@@ -75,28 +80,36 @@ export function removeCssClass(
 }
 
 /**
+ * @internal
+ *
  * Helper function to safely check if an element has a class
  * Also works with elements in svgs
  */
 // tslint:disable-next-line:no-any
-export function hasCssClass(el: any, name: string): boolean {
+export function _hasCssClass(el: any, name: string): boolean {
   // classList cant be used safely for elements in svgs - thats why we are using getAttribute
   const classes = el.getAttribute('class') || '';
   return classes.split(' ').includes(name);
 }
 
 /**
+ * @internal
+ *
  * Reads the key code from a keyboard event.
  * It is needed because event.keyCode is deprecated an will lead to multiple tslint errors.
  * This function will move the the event.keyKode to a single point where we disable the tslint rule.
  */
-export function readKeyCode(event: KeyboardEvent): number {
+export function _readKeyCode(event: KeyboardEvent): number {
   // tslint:disable-next-line:deprecation
   return event.keyCode;
 }
 
-/** Parses a value and a unit from a string / number if possible */
-export function parseCssValue(
+/**
+ * @internal
+ *
+ * Parses a value and a unit from a string / number if possible
+ */
+export function _parseCssValue(
   // tslint:disable-next-line: no-any
   input: any,
 ): { value: number; unit: string } | null {
@@ -118,6 +131,8 @@ export function parseCssValue(
 }
 
 /**
+ * @internal
+ *
  * Returns the bounding client rect of an element or element ref.
  * It is shimmed on platforms where this function is not available.
  * In this case a client rect with all properties set to `0` is returned.
@@ -125,7 +140,7 @@ export function parseCssValue(
  * The client rect is also extended with the property `isNativeRect`.
  * This property is set to false, if a shimmed client rect is return.
  */
-export function getElementBoundingClientRect(
+export function _getElementBoundingClientRect(
   el: Element | ElementRef,
 ): ClientRect & {
   /** Whether the returned client rect is provided by the platform or is shimmed. */

--- a/components/core/src/util/platform-utils.spec.ts
+++ b/components/core/src/util/platform-utils.spec.ts
@@ -17,7 +17,7 @@
 // tslint:disable no-lifecycle-call no-use-before-declare no-magic-numbers
 // tslint:disable no-any max-file-line-count no-unbound-method use-component-selector
 
-import { Component, ElementRef, Renderer2 } from '@angular/core';
+import { Component, ElementRef } from '@angular/core';
 import { TestBed, async } from '@angular/core/testing';
 
 import { hasCssClass, parseCssValue, replaceCssClass } from './platform-util';
@@ -32,22 +32,7 @@ describe('PlatformUtil', () => {
   }));
 
   describe('replaceCssClass', () => {
-    it('should replace an old class with a new one using the renderer', () => {
-      const fixture = TestBed.createComponent(TestApp);
-      const testComponent = fixture.debugElement.componentInstance;
-      const renderer = testComponent.renderer;
-      expect(renderer).toBeTruthy();
-      expect(testComponent.testElement.className).toBe('old-class');
-      replaceCssClass(
-        testComponent.testElement,
-        'old-class',
-        'new-class',
-        renderer,
-      );
-      expect(testComponent.testElement.className).toBe('new-class');
-    });
-
-    it('should replace an old class with a new one without using the renderer', () => {
+    it('should replace an old class with a new one', () => {
       const fixture = TestBed.createComponent(TestApp);
       const testComponent = fixture.debugElement.componentInstance;
 
@@ -59,35 +44,27 @@ describe('PlatformUtil', () => {
     it('should remove an old class if no new one has been provided', () => {
       const fixture = TestBed.createComponent(TestApp);
       const testComponent = fixture.debugElement.componentInstance;
-      const renderer = testComponent.renderer;
 
       expect(testComponent.testElement.className).toBe('old-class');
-      replaceCssClass(testComponent.testElement, 'old-class', null, renderer);
+      replaceCssClass(testComponent.testElement, 'old-class', null);
       expect(testComponent.testElement.className).toBe('');
     });
 
     it('should add a new class if no old one has been provided', () => {
       const fixture = TestBed.createComponent(TestApp);
       const testComponent = fixture.debugElement.componentInstance;
-      const renderer = testComponent.renderer;
 
       expect(testComponent.testElement.className).toBe('old-class');
-      replaceCssClass(testComponent.testElement, null, 'new-class', renderer);
+      replaceCssClass(testComponent.testElement, null, 'new-class');
       expect(testComponent.testElement.className).toBe('old-class new-class');
     });
 
     it('should also work with ElementRef', () => {
       const fixture = TestBed.createComponent(TestApp);
       const testComponent = fixture.debugElement.componentInstance;
-      const renderer = testComponent.renderer;
 
       expect(testComponent.testElement.className).toBe('old-class');
-      replaceCssClass(
-        testComponent.elementRef,
-        'old-class',
-        'new-class',
-        renderer,
-      );
+      replaceCssClass(testComponent.elementRef, 'old-class', 'new-class');
       expect(testComponent.testElement.className).toBe('new-class');
     });
   });
@@ -164,7 +141,7 @@ class TestApp {
   );
   elementRef = new ElementRef(this.testElement);
 
-  constructor(public renderer: Renderer2) {
+  constructor() {
     this.testElement.className = 'old-class';
     this.testSvgElement.setAttribute('class', 'old-class');
   }

--- a/components/core/src/util/platform-utils.spec.ts
+++ b/components/core/src/util/platform-utils.spec.ts
@@ -20,7 +20,11 @@
 import { Component, ElementRef } from '@angular/core';
 import { TestBed, async } from '@angular/core/testing';
 
-import { hasCssClass, parseCssValue, replaceCssClass } from './platform-util';
+import {
+  _hasCssClass,
+  _parseCssValue,
+  _replaceCssClass,
+} from './platform-util';
 
 describe('PlatformUtil', () => {
   beforeEach(async(() => {
@@ -37,7 +41,7 @@ describe('PlatformUtil', () => {
       const testComponent = fixture.debugElement.componentInstance;
 
       expect(testComponent.testElement.className).toBe('old-class');
-      replaceCssClass(testComponent.testElement, 'old-class', 'new-class');
+      _replaceCssClass(testComponent.testElement, 'old-class', 'new-class');
       expect(testComponent.testElement.className).toBe('new-class');
     });
 
@@ -46,7 +50,7 @@ describe('PlatformUtil', () => {
       const testComponent = fixture.debugElement.componentInstance;
 
       expect(testComponent.testElement.className).toBe('old-class');
-      replaceCssClass(testComponent.testElement, 'old-class', null);
+      _replaceCssClass(testComponent.testElement, 'old-class', null);
       expect(testComponent.testElement.className).toBe('');
     });
 
@@ -55,7 +59,7 @@ describe('PlatformUtil', () => {
       const testComponent = fixture.debugElement.componentInstance;
 
       expect(testComponent.testElement.className).toBe('old-class');
-      replaceCssClass(testComponent.testElement, null, 'new-class');
+      _replaceCssClass(testComponent.testElement, null, 'new-class');
       expect(testComponent.testElement.className).toBe('old-class new-class');
     });
 
@@ -64,7 +68,7 @@ describe('PlatformUtil', () => {
       const testComponent = fixture.debugElement.componentInstance;
 
       expect(testComponent.testElement.className).toBe('old-class');
-      replaceCssClass(testComponent.elementRef, 'old-class', 'new-class');
+      _replaceCssClass(testComponent.elementRef, 'old-class', 'new-class');
       expect(testComponent.testElement.className).toBe('new-class');
     });
   });
@@ -73,20 +77,20 @@ describe('PlatformUtil', () => {
     it('should return true on html element that has the class', () => {
       const fixture = TestBed.createComponent(TestApp);
       const testComponent = fixture.debugElement.componentInstance;
-      expect(hasCssClass(testComponent.testElement, 'old-class')).toBeTruthy();
+      expect(_hasCssClass(testComponent.testElement, 'old-class')).toBeTruthy();
     });
 
     it('should return false on html element that doesnt the class', () => {
       const fixture = TestBed.createComponent(TestApp);
       const testComponent = fixture.debugElement.componentInstance;
-      expect(hasCssClass(testComponent.testElement, 'new-class')).toBeFalsy();
+      expect(_hasCssClass(testComponent.testElement, 'new-class')).toBeFalsy();
     });
 
     it('should return true on svg element that has the class', () => {
       const fixture = TestBed.createComponent(TestApp);
       const testComponent = fixture.debugElement.componentInstance;
       expect(
-        hasCssClass(testComponent.testSvgElement, 'old-class'),
+        _hasCssClass(testComponent.testSvgElement, 'old-class'),
       ).toBeTruthy();
     });
 
@@ -94,36 +98,36 @@ describe('PlatformUtil', () => {
       const fixture = TestBed.createComponent(TestApp);
       const testComponent = fixture.debugElement.componentInstance;
       expect(
-        hasCssClass(testComponent.testSvgElement, 'new-class'),
+        _hasCssClass(testComponent.testSvgElement, 'new-class'),
       ).toBeFalsy();
     });
   });
 
   describe('parseCssValue', () => {
     it('should return null if undefined is passed', () => {
-      expect(parseCssValue(undefined)).toBeNull();
+      expect(_parseCssValue(undefined)).toBeNull();
     });
     it('should return null if no value is found', () => {
-      expect(parseCssValue('px')).toBeNull();
-      expect(parseCssValue('')).toBeNull();
-      expect(parseCssValue('%23')).toBeNull();
+      expect(_parseCssValue('px')).toBeNull();
+      expect(_parseCssValue('')).toBeNull();
+      expect(_parseCssValue('%23')).toBeNull();
     });
     it('should default to px if no unit is found', () => {
-      expect(parseCssValue('23')).toEqual({ value: 23, unit: 'px' });
-      expect(parseCssValue(23)).toEqual({ value: 23, unit: 'px' });
+      expect(_parseCssValue('23')).toEqual({ value: 23, unit: 'px' });
+      expect(_parseCssValue(23)).toEqual({ value: 23, unit: 'px' });
     });
     it('should use whatever is passed into that is not a number as the unit', () => {
-      expect(parseCssValue('23%')).toEqual({ value: 23, unit: '%' });
-      expect(parseCssValue('23vw')).toEqual({ value: 23, unit: 'vw' });
+      expect(_parseCssValue('23%')).toEqual({ value: 23, unit: '%' });
+      expect(_parseCssValue('23vw')).toEqual({ value: 23, unit: 'vw' });
     });
     it('should trim the unit if spaces are passed', () => {
-      expect(parseCssValue('23 % ')).toEqual({ value: 23, unit: '%' });
-      expect(parseCssValue('23   vw')).toEqual({ value: 23, unit: 'vw' });
-      expect(parseCssValue('23vw  ')).toEqual({ value: 23, unit: 'vw' });
+      expect(_parseCssValue('23 % ')).toEqual({ value: 23, unit: '%' });
+      expect(_parseCssValue('23   vw')).toEqual({ value: 23, unit: 'vw' });
+      expect(_parseCssValue('23vw  ')).toEqual({ value: 23, unit: 'vw' });
     });
     it('should handle integer and floating point numbers', () => {
-      expect(parseCssValue('23.5%')).toEqual({ value: 23.5, unit: '%' });
-      expect(parseCssValue('23vw')).toEqual({ value: 23, unit: 'vw' });
+      expect(_parseCssValue('23.5%')).toEqual({ value: 23.5, unit: '%' });
+      expect(_parseCssValue('23vw')).toEqual({ value: 23, unit: 'vw' });
     });
   });
 });

--- a/components/drawer/src/drawer-container.ts
+++ b/components/drawer/src/drawer-container.ts
@@ -31,9 +31,9 @@ import { Subject } from 'rxjs';
 import { filter, startWith, takeUntil } from 'rxjs/operators';
 
 import {
-  addCssClass,
-  readKeyCode,
-  removeCssClass,
+  _addCssClass,
+  _readKeyCode,
+  _removeCssClass,
 } from '@dynatrace/barista-components/core';
 
 import { DtDrawer } from './drawer';
@@ -158,7 +158,7 @@ export class DtDrawerContainer implements AfterContentInit, OnDestroy {
    * handles the ESC keyboard event to close the drawers.
    */
   _handleKeyboardEvent(event: KeyboardEvent): void {
-    if (readKeyCode(event) === ESCAPE) {
+    if (_readKeyCode(event) === ESCAPE) {
       this.close();
     }
   }
@@ -166,9 +166,9 @@ export class DtDrawerContainer implements AfterContentInit, OnDestroy {
   /** Toggles a class `DT_DRAWER_OPEN_CLASS` when the drawer is open or closed */
   private _toggleOpenClass(isOpen: boolean): void {
     if (isOpen) {
-      addCssClass(this._elementRef.nativeElement, DT_DRAWER_OPEN_CLASS);
+      _addCssClass(this._elementRef.nativeElement, DT_DRAWER_OPEN_CLASS);
     } else {
-      removeCssClass(this._elementRef.nativeElement, DT_DRAWER_OPEN_CLASS);
+      _removeCssClass(this._elementRef.nativeElement, DT_DRAWER_OPEN_CLASS);
     }
   }
 
@@ -202,7 +202,7 @@ export class DtDrawerContainer implements AfterContentInit, OnDestroy {
       )
       .subscribe((event: AnimationEvent) => {
         if (event.toState !== 'open-instant' && this._enableAnimations) {
-          addCssClass(
+          _addCssClass(
             this._elementRef.nativeElement,
             'dt-drawer-content-transition',
           );

--- a/components/empty-state/src/empty-state.ts
+++ b/components/empty-state/src/empty-state.ts
@@ -40,7 +40,7 @@ import { startWith, takeUntil } from 'rxjs/operators';
 
 import {
   DtViewportResizer,
-  toggleCssClass,
+  _toggleCssClass,
 } from '@dynatrace/barista-components/core';
 
 /** The min-width from which empty state items are displayed horizontally. */
@@ -222,12 +222,12 @@ export class DtEmptyState
       const layoutHorizontal =
         this._items.length > 1 && componentWidth > LAYOUT_HORIZONTAL_BREAKPOINT;
 
-      toggleCssClass(
+      _toggleCssClass(
         layoutHorizontal,
         this._elementRef.nativeElement,
         'dt-empty-state-layout-horizontal',
       );
-      toggleCssClass(
+      _toggleCssClass(
         itemLayoutHorizontal && !layoutHorizontal,
         this._elementRef.nativeElement,
         'dt-empty-state-items-horizontal',

--- a/components/event-chart/src/event-chart.ts
+++ b/components/event-chart/src/event-chart.ts
@@ -62,7 +62,7 @@ import {
 import {
   DtViewportResizer,
   isDefined,
-  readKeyCode,
+  _readKeyCode,
 } from '@dynatrace/barista-components/core';
 
 import {
@@ -361,7 +361,7 @@ export class DtEventChart<T> implements AfterContentInit, OnInit, OnDestroy {
     keyEvent: KeyboardEvent,
     renderEvent: RenderEvent<T>,
   ): void {
-    const key = readKeyCode(keyEvent);
+    const key = _readKeyCode(keyEvent);
     if (key === ENTER) {
       keyEvent.preventDefault();
       this._eventSelected(keyEvent, renderEvent);

--- a/components/expandable-panel/src/expandable-panel-trigger.ts
+++ b/components/expandable-panel/src/expandable-panel-trigger.ts
@@ -18,7 +18,7 @@ import { DOWN_ARROW, UP_ARROW } from '@angular/cdk/keycodes';
 import { ChangeDetectorRef, Directive, Input, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 
-import { readKeyCode } from '@dynatrace/barista-components/core';
+import { _readKeyCode } from '@dynatrace/barista-components/core';
 
 import { DtExpandablePanel } from './expandable-panel';
 
@@ -72,7 +72,7 @@ export class DtExpandablePanelTrigger implements OnDestroy {
   /** @internal Handles the trigger's click event. */
   _handleKeydown(event: KeyboardEvent): void {
     if (this.dtExpandablePanel && !this.dtExpandablePanel.disabled) {
-      const keyCode = readKeyCode(event);
+      const keyCode = _readKeyCode(event);
       const isAltKey = event.altKey;
       if (isAltKey && keyCode === DOWN_ARROW) {
         event.preventDefault();

--- a/components/filter-field/src/filter-field-range/filter-field-range-trigger.ts
+++ b/components/filter-field/src/filter-field-range/filter-field-range-trigger.ts
@@ -47,7 +47,7 @@ import {
 import { filter, map, take } from 'rxjs/operators';
 
 import {
-  readKeyCode,
+  _readKeyCode,
   DtFlexibleConnectedPositionStrategy,
 } from '@dynatrace/barista-components/core';
 
@@ -240,7 +240,7 @@ export class DtFilterFieldRangeTrigger implements OnDestroy {
       this._overlayRef = this._overlay.create(this._getOverlayConfig());
 
       this._overlayRef.keydownEvents().subscribe(event => {
-        const keyCode = readKeyCode(event);
+        const keyCode = _readKeyCode(event);
         // Close when pressing ESCAPE or ALT + UP_ARROW, based on the a11y guidelines.
         // See: https://www.w3.org/TR/wai-aria-practices-1.1/#textbox-keyboard-interaction
         if (keyCode === ESCAPE || (keyCode === UP_ARROW && event.altKey)) {

--- a/components/filter-field/src/filter-field.ts
+++ b/components/filter-field/src/filter-field.ts
@@ -83,7 +83,7 @@ import {
   DT_ERROR_ENTER_DELAYED_ANIMATION,
   ErrorStateMatcher,
   isDefined,
-  readKeyCode,
+  _readKeyCode,
 } from '@dynatrace/barista-components/core';
 
 import { DtFilterFieldDataSource } from './filter-field-data-source';
@@ -544,7 +544,7 @@ export class DtFilterField<T> implements AfterViewInit, OnDestroy, OnChanges {
 
   /** @internal */
   _handleInputKeyDown(event: KeyboardEvent): void {
-    const keyCode = readKeyCode(event);
+    const keyCode = _readKeyCode(event);
     if ([BACKSPACE, DELETE].includes(keyCode) && !this._inputValue.length) {
       if (this._currentFilterValues.length) {
         this._removeFilterAndEmit(this._currentFilterValues);

--- a/components/highlight/src/highlight.ts
+++ b/components/highlight/src/highlight.ts
@@ -35,7 +35,7 @@ import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 
 import {
-  addCssClass,
+  _addCssClass,
   createInViewportStream,
 } from '@dynatrace/barista-components/core';
 
@@ -192,7 +192,7 @@ export class DtHighlight
 
           if (token.toLowerCase() === term.toLowerCase()) {
             const span = this._document.createElement(HIGHLIGHTED_ELEMENT);
-            addCssClass(span, HIGHLIGHTED_CLASS);
+            _addCssClass(span, HIGHLIGHTED_CLASS);
             span.appendChild(text);
             transformedEl.appendChild(span);
           } else {

--- a/components/inline-editor/src/inline-editor.ts
+++ b/components/inline-editor/src/inline-editor.ts
@@ -59,7 +59,7 @@ import {
   DT_ERROR_ENTER_DELAYED_ANIMATION,
   ErrorStateMatcher,
   mixinErrorState,
-  readKeyCode,
+  _readKeyCode,
 } from '@dynatrace/barista-components/core';
 import { DtError } from '@dynatrace/barista-components/form-field';
 import { DtInput } from '@dynatrace/barista-components/input';
@@ -339,7 +339,7 @@ export class DtInlineEditor extends _DtInlineEditorMixinBase
 
   /** @internal Keydown handler */
   _onKeyDown(event: KeyboardEvent): void {
-    switch (readKeyCode(event)) {
+    switch (_readKeyCode(event)) {
       case ESCAPE:
         this.cancelAndQuitEditing();
       case ENTER:

--- a/components/overlay/src/overlay-ref.ts
+++ b/components/overlay/src/overlay-ref.ts
@@ -22,9 +22,9 @@ import { Observable, Subject, Subscription } from 'rxjs';
 import { filter, take } from 'rxjs/operators';
 
 import {
-  addCssClass,
-  readKeyCode,
-  removeCssClass,
+  _addCssClass,
+  _readKeyCode,
+  _removeCssClass,
 } from '@dynatrace/barista-components/core';
 
 import { DtMouseFollowPositionStrategy } from './mouse-follow-position-strategy';
@@ -77,7 +77,7 @@ export class DtOverlayRef<T> {
       .pipe(
         filter(
           (event: KeyboardEvent) =>
-            readKeyCode(event) === ESCAPE && !hasModifierKey(event),
+            _readKeyCode(event) === ESCAPE && !hasModifierKey(event),
         ),
       )
       .subscribe(() => {
@@ -94,7 +94,7 @@ export class DtOverlayRef<T> {
     if (this._overlayRef.backdropElement) {
       if (value) {
         this.containerInstance._trapFocus();
-        removeCssClass(
+        _removeCssClass(
           this._overlayRef.backdropElement,
           DT_OVERLAY_NO_POINTER_CLASS,
         );
@@ -102,7 +102,7 @@ export class DtOverlayRef<T> {
           this.dismiss();
         });
       } else {
-        addCssClass(
+        _addCssClass(
           this._overlayRef.backdropElement,
           DT_OVERLAY_NO_POINTER_CLASS,
         );

--- a/components/overlay/src/overlay-trigger.ts
+++ b/components/overlay/src/overlay-trigger.ts
@@ -34,7 +34,7 @@ import {
   HasTabIndex,
   mixinDisabled,
   mixinTabIndex,
-  readKeyCode,
+  _readKeyCode,
 } from '@dynatrace/barista-components/core';
 
 import { DtOverlay } from './overlay';
@@ -194,7 +194,7 @@ export class DtOverlayTrigger<T> extends _DtOverlayTriggerMixin
   /** @internal Ensures the trigger is selected when activated from the keyboard. */
   _handleKeydown(event: KeyboardEvent): void {
     if (!this.disabled) {
-      const keyCode = readKeyCode(event);
+      const keyCode = _readKeyCode(event);
       if (keyCode === ENTER || keyCode === SPACE) {
         event.preventDefault();
         this._createOverlay();

--- a/components/radio/src/radio.ts
+++ b/components/radio/src/radio.ts
@@ -36,9 +36,9 @@ import {
 import {
   CanDisable,
   HasTabIndex,
-  addCssClass,
+  _addCssClass,
   mixinTabIndex,
-  removeCssClass,
+  _removeCssClass,
 } from '@dynatrace/barista-components/core';
 
 import { DtRadioGroup } from './radio-group';
@@ -276,9 +276,9 @@ export class DtRadioButton<T> extends _DtRadioButtonMixinBase
     const element = this._elementRef.nativeElement;
 
     if (focusOrigin === 'keyboard') {
-      addCssClass(element, 'dt-radio-focused');
+      _addCssClass(element, 'dt-radio-focused');
     } else if (!focusOrigin) {
-      removeCssClass(element, 'dt-radio-focused');
+      _removeCssClass(element, 'dt-radio-focused');
       if (this._radioGroup) {
         this._radioGroup._touch();
       }

--- a/components/radio/src/radio.ts
+++ b/components/radio/src/radio.ts
@@ -29,7 +29,6 @@ import {
   OnInit,
   Optional,
   Output,
-  Renderer2,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
@@ -198,7 +197,6 @@ export class DtRadioButton<T> extends _DtRadioButtonMixinBase
     private _changeDetector: ChangeDetectorRef,
     private _radioDispatcher: UniqueSelectionDispatcher,
     private _focusMonitor: FocusMonitor,
-    private _renderer: Renderer2,
     @Optional() private _radioGroup: DtRadioGroup<T>,
   ) {
     super();
@@ -278,9 +276,9 @@ export class DtRadioButton<T> extends _DtRadioButtonMixinBase
     const element = this._elementRef.nativeElement;
 
     if (focusOrigin === 'keyboard') {
-      addCssClass(element, 'dt-radio-focused', this._renderer);
+      addCssClass(element, 'dt-radio-focused');
     } else if (!focusOrigin) {
-      removeCssClass(element, 'dt-radio-focused', this._renderer);
+      removeCssClass(element, 'dt-radio-focused');
       if (this._radioGroup) {
         this._radioGroup._touch();
       }

--- a/components/select/src/select.ts
+++ b/components/select/src/select.ts
@@ -92,7 +92,7 @@ import {
   mixinDisabled,
   mixinErrorState,
   mixinTabIndex,
-  readKeyCode,
+  _readKeyCode,
 } from '@dynatrace/barista-components/core';
 import {
   DtFormField,
@@ -749,7 +749,7 @@ export class DtSelect<T> extends _DtSelectMixinBase
 
   /** Handles keyboard events while the select is closed. */
   private _handleClosedKeydown(event: KeyboardEvent): void {
-    const keyCode = readKeyCode(event);
+    const keyCode = _readKeyCode(event);
     const isArrowKey =
       keyCode === DOWN_ARROW ||
       keyCode === UP_ARROW ||
@@ -768,7 +768,7 @@ export class DtSelect<T> extends _DtSelectMixinBase
 
   /** Handles keyboard events when the selected is open. */
   private _handleOpenKeydown(event: KeyboardEvent): void {
-    const keyCode = readKeyCode(event);
+    const keyCode = _readKeyCode(event);
     const isArrowKey = keyCode === DOWN_ARROW || keyCode === UP_ARROW;
     const manager = this._keyManager;
 

--- a/components/switch/src/switch.ts
+++ b/components/switch/src/switch.ts
@@ -29,7 +29,6 @@ import {
   OnDestroy,
   Output,
   Provider,
-  Renderer2,
   ViewChild,
   ViewEncapsulation,
   forwardRef,
@@ -46,6 +45,8 @@ import {
   HasTabIndex,
   mixinDisabled,
   mixinTabIndex,
+  addCssClass,
+  removeCssClass,
 } from '@dynatrace/barista-components/core';
 
 // Increasing integer for generating unique ids for switch components.
@@ -181,7 +182,6 @@ export class DtSwitch<T> extends _DtSwitchMixinBase
   private _controlValueAccessorChangeFn: (value: boolean) => void = () => {};
 
   constructor(
-    private _renderer: Renderer2,
     private _changeDetectorRef: ChangeDetectorRef,
     private _elementRef: ElementRef,
     private _focusMonitor: FocusMonitor,
@@ -267,9 +267,9 @@ export class DtSwitch<T> extends _DtSwitchMixinBase
     const element = this._elementRef.nativeElement;
 
     if (focusOrigin === 'keyboard') {
-      this._renderer.addClass(element, 'dt-switch-focused');
+      addCssClass(element, 'dt-switch-focused');
     } else if (!focusOrigin) {
-      this._renderer.removeClass(element, 'dt-switch-focused');
+      removeCssClass(element, 'dt-switch-focused');
       this._onTouched();
     }
   }

--- a/components/switch/src/switch.ts
+++ b/components/switch/src/switch.ts
@@ -45,8 +45,8 @@ import {
   HasTabIndex,
   mixinDisabled,
   mixinTabIndex,
-  addCssClass,
-  removeCssClass,
+  _addCssClass,
+  _removeCssClass,
 } from '@dynatrace/barista-components/core';
 
 // Increasing integer for generating unique ids for switch components.
@@ -267,9 +267,9 @@ export class DtSwitch<T> extends _DtSwitchMixinBase
     const element = this._elementRef.nativeElement;
 
     if (focusOrigin === 'keyboard') {
-      addCssClass(element, 'dt-switch-focused');
+      _addCssClass(element, 'dt-switch-focused');
     } else if (!focusOrigin) {
-      removeCssClass(element, 'dt-switch-focused');
+      _removeCssClass(element, 'dt-switch-focused');
       this._onTouched();
     }
   }

--- a/components/table/src/cell.ts
+++ b/components/table/src/cell.ts
@@ -37,10 +37,10 @@ import { filter, startWith, switchMap, takeUntil } from 'rxjs/operators';
 
 import {
   DtIndicator,
-  addCssClass,
+  _addCssClass,
   isDefined,
-  parseCssValue,
-  removeCssClass,
+  _parseCssValue,
+  _removeCssClass,
 } from '@dynatrace/barista-components/core';
 
 import { DtRow } from './row';
@@ -266,14 +266,14 @@ export function _setDtColumnCssClasses(
   const { align, cssClassFriendlyName } = columnDef;
   const cssAlignmentClass = coerceAlignment(align);
 
-  removeCssClass(elementRef.nativeElement, 'dt-table-column-align-left');
-  removeCssClass(elementRef.nativeElement, 'dt-table-column-align-center');
-  removeCssClass(elementRef.nativeElement, 'dt-table-column-align-right');
-  addCssClass(
+  _removeCssClass(elementRef.nativeElement, 'dt-table-column-align-left');
+  _removeCssClass(elementRef.nativeElement, 'dt-table-column-align-center');
+  _removeCssClass(elementRef.nativeElement, 'dt-table-column-align-right');
+  _addCssClass(
     elementRef.nativeElement,
     `dt-table-column-align-${cssAlignmentClass}`,
   );
-  addCssClass(
+  _addCssClass(
     elementRef.nativeElement,
     `dt-table-column-${cssClassFriendlyName}`,
   );
@@ -293,7 +293,7 @@ export function _updateDtColumnStyles(
       element.style.flexGrow = setProportion + '';
       element.style.flexShrink = setProportion + '';
     }
-    const valueAndUnit = parseCssValue(minWidth);
+    const valueAndUnit = _parseCssValue(minWidth);
     if (valueAndUnit !== null) {
       element.style.minWidth = `${valueAndUnit.value}${valueAndUnit.unit}`;
     } else {

--- a/components/table/src/cell.ts
+++ b/components/table/src/cell.ts
@@ -29,7 +29,6 @@ import {
   OnDestroy,
   Optional,
   QueryList,
-  Renderer2,
   SkipSelf,
   ViewEncapsulation,
 } from '@angular/core';
@@ -159,7 +158,6 @@ export class DtCell implements AfterContentInit, OnDestroy {
   constructor(
     public _columnDef: DtColumnDef,
     public _changeDetectorRef: ChangeDetectorRef,
-    renderer: Renderer2,
     elem: ElementRef,
     @Optional() @SkipSelf() dtSortable?: DtSort,
   ) {
@@ -180,7 +178,7 @@ export class DtCell implements AfterContentInit, OnDestroy {
         takeUntil(this._destroy),
       )
       .subscribe(() => {
-        _updateDtColumnStyles(this._columnDef, elem, renderer);
+        _updateDtColumnStyles(this._columnDef, elem);
       });
 
     if (DtRow._mostRecentRow) {
@@ -285,23 +283,21 @@ export function _setDtColumnCssClasses(
 export function _updateDtColumnStyles(
   columnDef: DtColumnDef,
   elementRef: ElementRef,
-  renderer: Renderer2,
 ): void {
   _setDtColumnCssClasses(columnDef, elementRef);
-  const { proportion, minWidth } = columnDef;
-  const setProportion = coerceNumberProperty(proportion);
-  if (setProportion > 0) {
-    renderer.setStyle(elementRef.nativeElement, 'flex-grow', setProportion);
-    renderer.setStyle(elementRef.nativeElement, 'flex-shrink', setProportion);
-  }
-  const valueAndUnit = parseCssValue(minWidth);
-  if (valueAndUnit !== null) {
-    renderer.setStyle(
-      elementRef.nativeElement,
-      'min-width',
-      `${valueAndUnit.value}${valueAndUnit.unit}`,
-    );
-  } else {
-    renderer.removeStyle(elementRef.nativeElement, 'min-width');
+  const element: HTMLElement = elementRef.nativeElement;
+  if (element && element.style) {
+    const { proportion, minWidth } = columnDef;
+    const setProportion = coerceNumberProperty(proportion);
+    if (setProportion > 0) {
+      element.style.flexGrow = setProportion + '';
+      element.style.flexShrink = setProportion + '';
+    }
+    const valueAndUnit = parseCssValue(minWidth);
+    if (valueAndUnit !== null) {
+      element.style.minWidth = `${valueAndUnit.value}${valueAndUnit.unit}`;
+    } else {
+      element.style.minWidth = '';
+    }
   }
 }

--- a/components/table/src/expandable/expandable-row.ts
+++ b/components/table/src/expandable/expandable-row.ts
@@ -46,8 +46,8 @@ import { Observable, Subscription } from 'rxjs';
 import { filter, startWith } from 'rxjs/operators';
 
 import {
-  addCssClass,
-  removeCssClass,
+  _addCssClass,
+  _removeCssClass,
 } from '@dynatrace/barista-components/core';
 
 import { DtRow } from '../row';
@@ -235,7 +235,7 @@ export class DtExpandableRow extends DtRow
     const cells = (this._rowRef
       .nativeElement as HTMLDivElement).querySelectorAll('dt-expandable-cell');
     [].slice.call(cells).forEach(cell => {
-      (expanded ? addCssClass : removeCssClass)(
+      (expanded ? _addCssClass : _removeCssClass)(
         cell,
         'dt-expandable-cell-expanded',
       );

--- a/components/table/src/expandable/expandable-row.ts
+++ b/components/table/src/expandable/expandable-row.ts
@@ -37,7 +37,6 @@ import {
   OnDestroy,
   Output,
   QueryList,
-  Renderer2,
   TemplateRef,
   ViewChild,
   ViewEncapsulation,
@@ -164,7 +163,6 @@ export class DtExpandableRow extends DtRow
   constructor(
     // tslint:disable-next-line:no-any
     private _table: DtTable<any>,
-    private _renderer2: Renderer2,
     private _changeDetectorRef: ChangeDetectorRef,
     private _expansionDispatcher: UniqueSelectionDispatcher,
     elementRef: ElementRef,
@@ -240,7 +238,6 @@ export class DtExpandableRow extends DtRow
       (expanded ? addCssClass : removeCssClass)(
         cell,
         'dt-expandable-cell-expanded',
-        this._renderer2,
       );
     });
   }

--- a/components/table/src/header/header-cell.ts
+++ b/components/table/src/header/header-cell.ts
@@ -15,7 +15,7 @@
  */
 
 import { CdkHeaderCellDef } from '@angular/cdk/table';
-import { Directive, ElementRef, OnDestroy, Renderer2 } from '@angular/core';
+import { Directive, ElementRef, OnDestroy } from '@angular/core';
 import { Subject } from 'rxjs';
 import { startWith, takeUntil } from 'rxjs/operators';
 
@@ -45,14 +45,14 @@ export class DtHeaderCell implements OnDestroy {
   /** Destroy subject which will fire when the component gets destroyed. */
   private _destroy = new Subject<void>();
 
-  constructor(columnDef: DtColumnDef, renderer: Renderer2, elem: ElementRef) {
+  constructor(columnDef: DtColumnDef, elem: ElementRef) {
     columnDef._stateChanges
       .pipe(
         startWith(null),
         takeUntil(this._destroy),
       )
       .subscribe(() => {
-        _updateDtColumnStyles(columnDef, elem, renderer);
+        _updateDtColumnStyles(columnDef, elem);
       });
   }
 

--- a/components/table/src/row.ts
+++ b/components/table/src/row.ts
@@ -26,9 +26,9 @@ import {
 import { Subscription, merge } from 'rxjs';
 
 import {
-  addCssClass,
-  removeCssClass,
-  replaceCssClass,
+  _addCssClass,
+  _removeCssClass,
+  _replaceCssClass,
 } from '@dynatrace/barista-components/core';
 
 import { DtCell } from './cell';
@@ -121,29 +121,29 @@ export class DtRow extends CdkRow implements OnDestroy {
     const hasWarning = !!cells.find(cell => cell.hasWarning);
     const hasIndicator = hasError || hasWarning;
     if (hasIndicator) {
-      addCssClass(this._elementRef.nativeElement, 'dt-table-row-indicator');
+      _addCssClass(this._elementRef.nativeElement, 'dt-table-row-indicator');
     } else {
-      removeCssClass(this._elementRef.nativeElement, 'dt-table-row-indicator');
+      _removeCssClass(this._elementRef.nativeElement, 'dt-table-row-indicator');
     }
 
     if (hasWarning) {
-      replaceCssClass(
+      _replaceCssClass(
         this._elementRef.nativeElement,
         'dt-color-error',
         'dt-color-warning',
       );
     } else {
-      removeCssClass(this._elementRef.nativeElement, 'dt-color-warning');
+      _removeCssClass(this._elementRef.nativeElement, 'dt-color-warning');
     }
 
     if (hasError) {
-      replaceCssClass(
+      _replaceCssClass(
         this._elementRef.nativeElement,
         'dt-color-warning',
         'dt-color-error',
       );
     } else {
-      removeCssClass(this._elementRef.nativeElement, 'dt-color-error');
+      _removeCssClass(this._elementRef.nativeElement, 'dt-color-error');
     }
   }
 }

--- a/components/table/src/table.spec.ts
+++ b/components/table/src/table.spec.ts
@@ -23,7 +23,6 @@ import {
   Input,
   NgModule,
   QueryList,
-  Renderer2,
   ViewChild,
   ViewChildren,
 } from '@angular/core';
@@ -693,7 +692,7 @@ class TestApp {
     { col1: 'test 1', col2: 'test 2', col3: 'test 3' },
   ];
 
-  constructor(public _renderer: Renderer2) {}
+  constructor() {}
 }
 
 /** Test component that contains a Dynamic DtTable. */

--- a/components/theming/src/theme.ts
+++ b/components/theming/src/theme.ts
@@ -20,7 +20,6 @@ import {
   Input,
   OnDestroy,
   Optional,
-  Renderer2,
   SkipSelf,
   isDevMode,
 } from '@angular/core';
@@ -111,7 +110,6 @@ export class DtTheme implements OnDestroy {
 
   constructor(
     private _elementRef: ElementRef,
-    private _renderer: Renderer2,
     @Optional() @SkipSelf() private _parentTheme: DtTheme,
   ) {
     if (this._parentTheme) {
@@ -144,13 +142,11 @@ export class DtTheme implements OnDestroy {
       this._elementRef,
       currentClassNames.name,
       newClassNames.name,
-      this._renderer,
     );
     replaceCssClass(
       this._elementRef,
       currentClassNames.variant,
       newClassNames.variant,
-      this._renderer,
     );
     this._classNames = newClassNames;
   }

--- a/components/theming/src/theme.ts
+++ b/components/theming/src/theme.ts
@@ -28,7 +28,7 @@ import { NEVER, Subject, Subscription } from 'rxjs';
 import {
   DtLogger,
   DtLoggerFactory,
-  replaceCssClass,
+  _replaceCssClass,
 } from '@dynatrace/barista-components/core';
 
 import {
@@ -138,12 +138,12 @@ export class DtTheme implements OnDestroy {
   private _updateHostClasses(): void {
     const currentClassNames = this._classNames;
     const newClassNames = this._genClassNames();
-    replaceCssClass(
+    _replaceCssClass(
       this._elementRef,
       currentClassNames.name,
       newClassNames.name,
     );
-    replaceCssClass(
+    _replaceCssClass(
       this._elementRef,
       currentClassNames.variant,
       newClassNames.variant,

--- a/components/tree-table/src/tree-table-toggle-cell.ts
+++ b/components/tree-table/src/tree-table-toggle-cell.ts
@@ -23,7 +23,6 @@ import {
   ElementRef,
   Input,
   OnDestroy,
-  Renderer2,
   SkipSelf,
   ViewChild,
   ViewEncapsulation,
@@ -136,11 +135,10 @@ export class DtTreeTableToggleCell<T> extends DtCell
   constructor(
     public _columnDef: DtColumnDef,
     public _changeDetectorRef: ChangeDetectorRef,
-    private _renderer: Renderer2,
     elementRef: ElementRef,
     @SkipSelf() private _treeTable: DtTreeTable<T>,
   ) {
-    super(_columnDef, _changeDetectorRef, _renderer, elementRef);
+    super(_columnDef, _changeDetectorRef, elementRef);
     // subscribe to changes in the expansionmodel and check if rowsData is part of the added or removed
     this._expansionSub = this._treeControl.expansionModel.changed
       .pipe(
@@ -189,10 +187,9 @@ export class DtTreeTableToggleCell<T> extends DtCell
   /** Sets the padding on the cell */
   private _setIndent(): void {
     const padding = this._paddingIndent();
-    this._renderer.setStyle(
-      this._wrapperElement.nativeElement,
-      'padding-left',
-      `${padding}px`,
-    );
+    const element: HTMLElement = this._wrapperElement.nativeElement;
+    if (element && element.style) {
+      element.style.paddingLeft = `${padding}px`;
+    }
   }
 }


### PR DESCRIPTION
### <strong>Pull Request</strong>

Removes Renderer2 to be compatible with ivy.
Closes #518

BREAKING CHANGES: 
* Components that are using the outdated Renderer2, which is removed in this commit, do this by injecting it via DI in their constructor. When removing the renderer constructor param the api changes which leads to a breaking change.
* Changed core platform utils to be internal 
#### Type of PR
Breaking change (fix or change that would cause existing functionality to not work as expected)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
