### PR TITLE
ci: Add stale issue workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,16 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale, because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
+        stale-issue-label: 'no-issue-activity' 
+        days-before-stale: 30
+        days-before-close: 5


### PR DESCRIPTION
### <strong>Pull Request</strong>

We have a lot of issues that seem to be lying around for a while without activity. I want to have a bot do the housekeeping and mark stale issues for us. After 30 days without activity, an issue will be marked as stale and after 5 more days without activity or removal of the label the issue gets closed automatically. 
