### PR TITLE
chore(release): On stage release, bump package lock version as well.

### DIFF
--- a/tools/release/src/stage-release/stage-release.ts
+++ b/tools/release/src/stage-release/stage-release.ts
@@ -16,6 +16,7 @@
 
 import {
   PackageJson,
+  PackageLockJson,
   tryJsonParse,
 } from '@dynatrace/barista-components/tools/shared';
 import * as OctokitApi from '@octokit/rest';
@@ -65,6 +66,10 @@ export async function stageRelease(
   const currentVersion = await parsePackageVersion(workspaceRoot);
   const packageJsonPath = join(workspaceRoot, 'package.json');
   const packageJson = await tryJsonParse<PackageJson>(packageJsonPath);
+  const packageLockJsonPath = join(workspaceRoot, 'package-lock.json');
+  const packageLockJson = await tryJsonParse<PackageLockJson>(
+    packageLockJsonPath,
+  );
 
   const newVersion = await promptForNewVersion(currentVersion);
   const newVersionName = newVersion.raw!;
@@ -88,6 +93,12 @@ export async function stageRelease(
     await updatePackageJsonVersion(
       packageJson,
       packageJsonPath,
+      newVersionName,
+    );
+
+    await updatePackageJsonVersion(
+      packageLockJson,
+      packageLockJsonPath,
       newVersionName,
     );
 
@@ -206,7 +217,7 @@ function switchToPublishBranch(git: GitClient, newVersion: SemVer): string {
  * writes the changes to disk.
  */
 async function updatePackageJsonVersion(
-  packageJson: PackageJson,
+  packageJson: PackageJson | PackageLockJson,
   packageJsonPath: string,
   newVersionName: string,
 ): Promise<void> {

--- a/tools/shared/src/interfaces/package-lock-json.ts
+++ b/tools/shared/src/interfaces/package-lock-json.ts
@@ -14,5 +14,18 @@
  * limitations under the License.
  */
 
-export * from './package-json';
-export * from './package-lock-json';
+interface PackageLockDependencyJson {
+  version: string;
+  resolved: string;
+  integrity: string;
+  dev: boolean;
+  requires: { [key: string]: string };
+  dependencies: { [key: string]: PackageLockDependencyJson };
+}
+
+export interface PackageLockJson {
+  name?: string;
+  version?: string;
+  lockfileVersion?: number;
+  dependencies: { [key: string]: PackageLockDependencyJson };
+}


### PR DESCRIPTION
When starting a stage release, we can also update the version in the
package-lock.json file.

Fixes #533

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
