### PR TITLE
Fixes an issue where the range could not be re-opened after closing.

### DIFF
--- a/apps/components-e2e/src/components/chart/selection-area/selection-area.module.ts
+++ b/apps/components-e2e/src/components/chart/selection-area/selection-area.module.ts
@@ -24,6 +24,7 @@ import { DtChartModule } from '@dynatrace/barista-components/chart';
 import { DtE2ESelectionArea } from './selection-area';
 import { DtE2ERange } from './range/range';
 import { DataService } from '../../../services/data.service';
+import { DtE2ETimestamp } from './timestamp/timestamp';
 
 const routes: Route[] = [
   {
@@ -34,10 +35,14 @@ const routes: Route[] = [
     path: 'range',
     component: DtE2ERange,
   },
+  {
+    path: 'timestamp',
+    component: DtE2ETimestamp,
+  },
 ];
 
 @NgModule({
-  declarations: [DtE2ESelectionArea, DtE2ERange],
+  declarations: [DtE2ESelectionArea, DtE2ERange, DtE2ETimestamp],
   imports: [
     CommonModule,
     DtChartModule,

--- a/apps/components-e2e/src/components/chart/selection-area/selection-area.po.ts
+++ b/apps/components-e2e/src/components/chart/selection-area/selection-area.po.ts
@@ -64,7 +64,7 @@ export function createRange(
   return controller.drag(plotBackground, width, 0, {
     offsetX: start.x,
     offsetY: start.y,
-    speed: 0.01,
+    speed: 0.05,
   });
 }
 

--- a/apps/components-e2e/src/components/chart/selection-area/timestamp/timestamp.e2e.ts
+++ b/apps/components-e2e/src/components/chart/selection-area/timestamp/timestamp.e2e.ts
@@ -17,60 +17,72 @@
 import { Selector } from 'testcafe';
 import { waitForAngular } from '../../../../utils';
 import {
-  createRange,
+  chartClickTargets,
+  closeButton,
+  createTimestamp,
+  overlayText,
   rangeSelection,
   selection,
-  overlayText,
-  closeButton,
+  timestampSelection,
+  createRange,
 } from '../selection-area.po';
 
 const closeCounter = Selector('.closed-counter');
 
-fixture('Selection Area Range Only')
-  .page('http://localhost:4200/chart/selection-area/range')
+fixture('Selection Area Timestamp Only')
+  .page('http://localhost:4200/chart/selection-area/timestamp')
   .beforeEach(async (testController: TestController) => {
     await testController.resizeWindow(1200, 800);
     await waitForAngular();
   });
 
-test('should not have an initial range selection', async (testController: TestController) => {
+test('should not have an initial timestamp selection', async (testController: TestController) => {
   await testController
     .expect(selection.exists)
     .notOk()
-    .expect(rangeSelection.exists)
+    .expect(timestampSelection.exists)
     .notOk()
     .expect(closeCounter.textContent)
     .eql('0');
 });
 
-test('should not close the range when a click is performed somewhere else in the chart', async () => {
-  await createRange(520, { x: 310, y: 100 })
-    .expect(rangeSelection.exists)
-    .ok()
+test('should create a timestamp close it and reopen it', async (testController: TestController) => {
+  await createTimestamp(
+    { x: 450, y: 100 },
+    chartClickTargets[1],
+    testController,
+  )
     .expect(overlayText.textContent)
-    .match(/Jul 31 \d{2}:17 — \d{2}:23/g)
-    .click(Selector('.highcharts-plot-background'), {
-      speed: 0.3,
-      offsetX: 10,
-      offsetY: 10,
-    })
-    .expect(rangeSelection.exists)
-    .ok()
-    .expect(overlayText.textContent)
-    .match(/Jul 31 \d{2}:17 — \d{2}:23/g);
-});
-
-test('should be possible to create a range again after it was closed', async () => {
-  await createRange(520, { x: 310, y: 100 })
-    .expect(rangeSelection.exists)
-    .ok()
+    .match(/Jul 31, \d{2}:19/g)
     .click(closeButton, { speed: 0.3 })
     .expect(rangeSelection.exists)
     .notOk();
 
-  await createRange(520, { x: 310, y: 100 })
-    .expect(rangeSelection.exists)
+  await createTimestamp(
+    { x: 450, y: 100 },
+    chartClickTargets[1],
+    testController,
+  )
+    .expect(timestampSelection.exists)
     .ok()
     .expect(overlayText.textContent)
-    .match(/Jul 31 \d{2}:17 — \d{2}:23/g);
+    .match(/Jul 31, \d{2}:19/g);
+});
+
+test('should leave the timestamp untouched if a range is created in a timestamp only mode', async (testController: TestController) => {
+  await createTimestamp(
+    { x: 450, y: 100 },
+    chartClickTargets[1],
+    testController,
+  )
+    .expect(timestampSelection.exists)
+    .ok();
+
+  await createRange(520, { x: 310, y: 100 })
+    .expect(rangeSelection.exists)
+    .notOk()
+    .expect(timestampSelection.exists)
+    .ok()
+    .expect(overlayText.textContent)
+    .match(/Jul 31, \d{2}:19/g);
 });

--- a/apps/components-e2e/src/components/chart/selection-area/timestamp/timestamp.html
+++ b/apps/components-e2e/src/components/chart/selection-area/timestamp/timestamp.html
@@ -1,0 +1,10 @@
+<dt-chart [options]="options" [series]="series$ | async">
+  <dt-chart-timestamp
+    aria-label-close="Close the selection"
+    (closed)="closed()"
+    (valueChanges)="valueChanges($event)"
+  ></dt-chart-timestamp>
+</dt-chart>
+
+<div class="closed-counter">{{ closedCounter }}</div>
+<div class="current-value">{{ currentValue }}</div>

--- a/apps/components-e2e/src/components/chart/selection-area/timestamp/timestamp.ts
+++ b/apps/components-e2e/src/components/chart/selection-area/timestamp/timestamp.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component } from '@angular/core';
+import { DtE2EChartBase } from '../../chart-base';
+import { DataService } from '../../../../services/data.service';
+
+@Component({
+  selector: 'dt-e2e-timestamp',
+  templateUrl: './timestamp.html',
+  styles: [
+    `
+      :host {
+        display: block;
+        width: 1200px;
+      }
+    `,
+  ],
+})
+export class DtE2ETimestamp extends DtE2EChartBase {
+  closedCounter = 0;
+  currentValue;
+
+  constructor(dataService: DataService) {
+    super(dataService);
+  }
+
+  closed(): void {
+    this.closedCounter++;
+  }
+
+  valueChanges(_value: number): void {
+    this.currentValue = _value;
+  }
+}


### PR DESCRIPTION
Fixed a regression that was introduced in version 5.1.0 where range could not be
re-opened in a range only mode after it was closed once.

### <strong>Pull Request</strong>

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
