### PR TITLE
chore(examples): Fixes broken loading-distractor module import.

### DIFF
--- a/libs/examples/src/loading-distractor/loading-distractor-examples.module.ts
+++ b/libs/examples/src/loading-distractor/loading-distractor-examples.module.ts
@@ -20,7 +20,7 @@ import { DtFormFieldModule } from '@dynatrace/barista-components/form-field';
 import { DtExampleLoadingDistractorDefault } from './loading-distractor-default-example/loading-distractor-default-example';
 import { DtExampleLoadingDistractorInput } from './loading-distractor-input-example/loading-distractor-input-example';
 import { DtExampleLoadingDistractorSpinner } from './loading-distractor-spinner-example/loading-distractor-spinner-example';
-import { DtInputModule } from 'components/input/src/input-module';
+import { DtInputModule } from '@dynatrace/barista-components/input';
 
 export const DT_LOADING_DISTRACTOR_EXAMPLES = [
   DtExampleLoadingDistractorDefault,


### PR DESCRIPTION
### <strong>Pull Request</strong>

Fixes the broken `DtInputModule` import in the loading-distractor examples module.

#### Type of PR

Other (if none of the above apply)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
