### PR TITLE
fix(chart): Fixes an issue where the tooltip stayed open when the chart was destroyed.

### DIFF
--- a/components/chart/src/chart.ts
+++ b/components/chart/src/chart.ts
@@ -459,6 +459,11 @@ export class DtChart
   }
 
   ngOnDestroy(): void {
+    // Next and complete the highChartsTooltipClosed observable
+    // to clear off any tooltips, that would still be open.
+    this._highChartsTooltipClosed$.next();
+    this._highChartsTooltipClosed$.complete();
+
     this._destroy$.next();
     this._destroy$.complete();
     if (this._chartObject) {


### PR DESCRIPTION
### <strong>Pull Request</strong>

Fire the tooltipClose event when the chart is destroyed, so any open
tooltip will close when the parent chart component is destroyed.

Fixes #579
Please choose the type appropriate for the changes below: <br>

#### Type of PR
Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
