### PR TITLE
fix(table): Fixed invalid fill color for favorite-column icon

### DIFF
--- a/components/table/src/simple-columns/favorite-column.scss
+++ b/components/table/src/simple-columns/favorite-column.scss
@@ -6,5 +6,5 @@
 }
 
 ::ng-deep .dt-favorite-column-filled-star svg {
-  fill: $yellow-500 !important;
+  fill: $turquoise-800 !important;
 }


### PR DESCRIPTION
After consulting UX, the color of the favorite star on the table should be torquise-800.