### PR TITLE
Barista/fix color grid and toc

### DIFF
--- a/apps/barista/src/components/components.module.ts
+++ b/apps/barista/src/components/components.module.ts
@@ -29,6 +29,11 @@ import { BaLayoutGrid } from './layout-grid/layout-grid';
 import { BaColor } from './color-component/color';
 import { BaLayoutGridItem } from './layout-grid/layout-grid-item';
 
+/**
+ * The order of the following components is relevant in case they are nested.
+ * Inner components must be instantiated first. This is why the grid-item
+ * comes before the grid and the grid before the color-grid.
+ */
 // tslint:disable-next-line: no-any
 export const BA_CONTENT_COMPONENTS: any[] = [
   BaIconColorWheel,
@@ -36,9 +41,9 @@ export const BA_CONTENT_COMPONENTS: any[] = [
   BaLazyIcon,
   BaHeadlineLink,
   BaColor,
-  BaColorGrid,
-  BaLayoutGrid,
   BaLayoutGridItem,
+  BaLayoutGrid,
+  BaColorGrid,
 ];
 
 @NgModule({

--- a/tools/barista/src/builder/strapi.ts
+++ b/tools/barista/src/builder/strapi.ts
@@ -138,7 +138,7 @@ function strapiMetaData(page: BaStrapiPage): BaSinglePageMeta {
     }
   }
 
-  if (page.toc) {
+  if (page.toc !== null) {
     metaData.toc = page.toc;
   }
 


### PR DESCRIPTION
### <strong>Pull Request</strong>

This PR contains 2 small fixes for Barista:
1) The order of content components is relevant in case they are nested; this is the case with the color-grid / grid / grid-item components.
2) The check for the TOC property had to be fixed to set the toc-metadata entry correctly.

#### Type of PR

Barista

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
