### PR TITLE
fix(table): Fixes an issue where the sorting did not update when active binding was updated.

### DIFF
--- a/components/table/src/sort/sort.spec.ts
+++ b/components/table/src/sort/sort.spec.ts
@@ -166,6 +166,17 @@ describe('DtSort', () => {
       expect(checkCellsSorted(component.cells, true, 'column_a')).toBeTruthy();
     });
 
+    it('should sort the correct column when active is being changed dynamically', () => {
+      component.dataSource = DATA_SOURCE;
+      component.start = 'asc';
+      component.active = 'column_a';
+      fixture.detectChanges();
+
+      component.active = 'column_b';
+      fixture.detectChanges();
+      expect(checkCellsSorted(component.cells, true, 'column_b')).toBeTruthy();
+    });
+
     it('should keep all cells sorted if there are new rows added dynamically', () => {
       component.dataSource = DATA_SOURCE;
       component.start = 'asc';

--- a/components/table/src/sort/sort.ts
+++ b/components/table/src/sort/sort.ts
@@ -156,6 +156,12 @@ export class DtSort extends _DtSortMixinBase
     ) {
       this.direction = this.start;
     }
+
+    // If active is bound and being changed after initialization
+    // we need to update the sorter.
+    if (isDefined(changes.active) && !changes.active.firstChange) {
+      this.sort(this.active, this.direction);
+    }
     this._stateChanges.next();
   }
 


### PR DESCRIPTION
### <strong>Pull Request</strong>

When the active input for the `[dtSort]` was bound to a member, and this
member was updated, the table did not react to the sorting.

Fixes #619

#### Type of PR

Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
