### PR TITLE
barista: Fix links to contributors github pages on strapi pages.

### DIFF
--- a/apps/barista/src/layout/contributors/contributors.html
+++ b/apps/barista/src/layout/contributors/contributors.html
@@ -6,8 +6,8 @@
     *ngFor="let contributor of contributors"
     class="ba-contributors-list-item"
   >
-    <a [href]="_profileUrl(contributor.gitHubUser)">
-      <img [src]="_imageUrl(contributor.gitHubUser)" [alt]="contributor.name" />
+    <a [href]="_profileUrl(contributor.githubuser)">
+      <img [src]="_imageUrl(contributor.githubuser)" [alt]="contributor.name" />
       <span>{{ contributor.name }}</span>
     </a>
   </li>

--- a/libs/shared/barista-definitions/src/lib/barista-definitions.ts
+++ b/libs/shared/barista-definitions/src/lib/barista-definitions.ts
@@ -141,7 +141,7 @@ export interface BaIcon {
 
 export interface BaContributor {
   name: string;
-  gitHubUser: string;
+  githubuser: string;
 }
 
 export interface BaContributors {

--- a/tools/barista/src/builder/strapi.ts
+++ b/tools/barista/src/builder/strapi.ts
@@ -120,13 +120,13 @@ function strapiMetaData(page: BaStrapiPage): BaSinglePageMeta {
       .filter(c => !c.developer)
       .map(c => ({
         name: c.name,
-        gitHubUser: c.gitHubUser,
+        githubuser: c.githubuser,
       }));
     const devSupport = page.contributors
       .filter(c => c.developer)
       .map(c => ({
         name: c.name,
-        gitHubUser: c.gitHubUser,
+        githubuser: c.githubuser,
       }));
 
     if (uxSupport.length > 0) {


### PR DESCRIPTION
### <strong>Pull Request</strong>

Currently github handles are not fetched from Strapi and therefore `undefined`, because we have a naming-mismatch here: `gitHubUser` vs. `githubuser`.

As the property is called `githubuser` (all lowercase) in Strapi, we have to rename it as I don't want to change this field in Strapi. (I crashed the database once when I removed and added a field again and the only difference were lower/uppercase characters...)

#### Type of PR

Barista bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
