### PR TITLE
build(bundle): Fixes asset folder not being there

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -1030,7 +1030,7 @@
               {
                 "glob": "**/*",
                 "input": "libs/barista-components/assets",
-                "output": "dist/libs/components"
+                "output": "dist/libs/components/assets"
               }
             ],
             "additionalTargets": ["schematics:build", "linting:build"]


### PR DESCRIPTION
Fixes an issue that the asset folder was not there anymore in our bundle, instead the fonts & favicons where added to the root of the bundle