### PR TITLE
chore(bundle): Add linting back to the bundle

### DIFF
--- a/libs/tools/linting/tsconfig.json
+++ b/libs/tools/linting/tsconfig.json
@@ -7,5 +7,6 @@
     "rootDir": ".",
     "resolveJsonModule": true
   },
-  "files": ["tslint.json"]
+  "files": ["tslint.json"],
+  "include": ["**/*.ts"]
 }


### PR DESCRIPTION
### <strong>Pull Request</strong>

Adds the linting rules back to the bundle. 
Any ideas how to validate this constantly? Maybe we should have checks after building the library to verify the built output even on PRs. Since the checks on the release scripts might be too late or insufficient