### PR TITLE
barista: Update exit code when page builder is failing somewhere.

### DIFF
--- a/libs/tools/barista/src/main.ts
+++ b/libs/tools/barista/src/main.ts
@@ -131,4 +131,5 @@ buildPages()
   })
   .catch(err => {
     console.error(err);
+    process.exit(1);
   });


### PR DESCRIPTION
### <strong>Pull Request</strong>

We don't want deployments to pass if the page builder fails somewhere. So we have to exit with 1 here.

#### Type of PR

Barista

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
