### PR TITLE
fix(chart-heatfield): Chart HeatField is shown when start and end are…

### DIFF
--- a/libs/barista-components/chart/src/heatfield/chart-heatfield.html
+++ b/libs/barista-components/chart/src/heatfield/chart-heatfield.html
@@ -1,6 +1,7 @@
 <button
   class="dt-chart-heatfield-marker"
   [class.dt-chart-heatfield-active]="active"
+  [style.visibility]="_isValidStartEndRange ? 'visible' : 'hidden'"
   #marker="cdkOverlayOrigin"
   cdk-overlay-origin
   (click)="_toggleActive()"

--- a/libs/barista-components/chart/src/heatfield/chart-heatfield.spec.ts
+++ b/libs/barista-components/chart/src/heatfield/chart-heatfield.spec.ts
@@ -133,6 +133,14 @@ describe('DtChartHeatfield', () => {
         chart._afterRender.next();
         validatePosition(fixture, 100, 500);
       });
+
+      it('should not render heatfield when start and end are undefined ', () => {
+        instance.start = undefined;
+        instance.end = undefined;
+        fixture.detectChanges();
+        chart._afterRender.next();
+        expect(marker.style.visibility).toEqual('hidden');
+      });
     });
 
     describe('Activation', () => {


### PR DESCRIPTION


### <strong>Pull Request</strong>

- Button/heatfield is now hidden if both start and end are undefined
- Added test to check for start and end being both undefined

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->

#### Checklist
- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
