### PR TITLE
fix(radio, checkbox, switch): Disabled labels have have a higher contrast color now

### DIFF
--- a/libs/barista-components/checkbox/src/_checkbox-theme.scss
+++ b/libs/barista-components/checkbox/src/_checkbox-theme.scss
@@ -28,10 +28,6 @@
       }
 
       &.dt-checkbox-disabled {
-        .dt-checkbox-content {
-          color: $gray-500;
-        }
-
         .dt-checkbox-container {
           background-color: transparent;
           border-color: $gray-500;

--- a/libs/barista-components/checkbox/src/checkbox.scss
+++ b/libs/barista-components/checkbox/src/checkbox.scss
@@ -83,10 +83,6 @@ $dt-checkbox-size: 20px;
       cursor: default;
     }
 
-    .dt-checkbox-content {
-      color: $disabledcolor;
-    }
-
     .dt-checkbox-container {
       border-color: $disabledcolor;
     }

--- a/libs/barista-components/radio/src/_radio-theme.scss
+++ b/libs/barista-components/radio/src/_radio-theme.scss
@@ -29,10 +29,6 @@
       }
 
       &.dt-radio-disabled {
-        .dt-radio-content {
-          color: $gray-500;
-        }
-
         .dt-radio-inner-circle {
           background-color: $gray-500;
         }

--- a/libs/barista-components/radio/src/radio.scss
+++ b/libs/barista-components/radio/src/radio.scss
@@ -104,10 +104,6 @@ $dt-radio-size: 20px;
       cursor: default;
     }
 
-    .dt-radio-content {
-      color: $disabledcolor;
-    }
-
     .dt-radio-outer-circle {
       border-color: $disabledcolor;
     }

--- a/libs/barista-components/switch/src/_switch-theme.scss
+++ b/libs/barista-components/switch/src/_switch-theme.scss
@@ -65,10 +65,6 @@
       }
 
       &.dt-switch-disabled {
-        .dt-switch-content {
-          color: $gray-500;
-        }
-
         .dt-switch-bar::before {
           background-image: radial-gradient(
             circle 5px,

--- a/libs/barista-components/switch/src/switch.scss
+++ b/libs/barista-components/switch/src/switch.scss
@@ -121,10 +121,6 @@
   }
 
   &.dt-switch-disabled {
-    .dt-switch-content {
-      color: $disabledcolor;
-    }
-
     &:hover .dt-switch-label {
       cursor: default;
     }


### PR DESCRIPTION
### <strong>Pull Request</strong>

Due to low contrast ratios on between disabled labels on the radio, checkbox and switch we decided in #684 to use the default text color for the labels. This results in a higher contrast ratio between the label and the background, which improves readability.

Fixes #684

Please choose the type appropriate for the changes below: <br>

#### Type of PR

Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
