### PR TITLE
fix(sidenav): Fixes wrong exportAs property for the sidenav-header

### DIFF
--- a/libs/barista-components/drawer/src/sidenav.ts
+++ b/libs/barista-components/drawer/src/sidenav.ts
@@ -30,7 +30,7 @@ import { dtDrawerAnimation } from './drawer-animation';
 
 @Directive({
   selector: 'dt-sidenav-header',
-  exportAs: 'dtCardTitle',
+  exportAs: 'dtSidenavHeader',
   host: {
     class: 'dt-sidenav-header-title',
   },


### PR DESCRIPTION
Corrects the exportAs property in the decorator for the sidenav header