### PR TITLE
barista: Insert internal content when not wrapped in tags and add tests.

### DIFF
--- a/libs/tools/barista/src/transform.spec.ts
+++ b/libs/tools/barista/src/transform.spec.ts
@@ -20,6 +20,7 @@ import {
   extractH1ToTitleTransformer,
   internalLinksTransformerFactory,
   headingIdTransformer,
+  internalContentTransformerFactory,
 } from './transform';
 
 describe('Barista transformers', () => {
@@ -138,6 +139,50 @@ describe('Barista transformers', () => {
       });
       expect(transformed.content).toBe(
         '<h2 id="h1-definitions">1. Definitions.</h2>',
+      );
+    });
+  });
+
+  describe('internalContentTransformer', () => {
+    it('should remove internal content on public build', async () => {
+      const content =
+        '<h1>Fonts</h1><ba-internal-content><h2>Download fonts</h2><p>To download our font, click here.</p></ba-internal-content><p>Some more public content.</p>';
+      const transformContent = internalContentTransformerFactory(true); // true = public build
+      const transformed = await transformContent({
+        title: 'Fonts',
+        layout: BaPageLayoutType.Default,
+        content,
+      });
+      expect(transformed.content).toBe(
+        '<h1>Fonts</h1>\n\n\n\n<p>Some more public content.</p>',
+      );
+    });
+
+    it('should remove internal-content tags but not the HTML content itself on internal build', async () => {
+      const content =
+        '<h1>Fonts</h1><ba-internal-content><h2>Download fonts</h2><p>To download our font, click here.</p></ba-internal-content><p>Some more public content.</p>';
+      const transformContent = internalContentTransformerFactory(false); // false = internal build
+      const transformed = await transformContent({
+        title: 'Fonts',
+        layout: BaPageLayoutType.Default,
+        content,
+      });
+      expect(transformed.content).toBe(
+        '<h1>Fonts</h1>\n\n\n\n<h2>Download fonts</h2><p>To download our font, click here.</p>\n\n\n\n<p>Some more public content.</p>',
+      );
+    });
+
+    it('should wrap internal strings with <p> tags', async () => {
+      const content =
+        '<h1>Fonts</h1><ba-internal-content>This is just a simple internal string</ba-internal-content><p>Some more public content.</p>';
+      const transformContent = internalContentTransformerFactory(false); // false = internal build
+      const transformed = await transformContent({
+        title: 'Fonts',
+        layout: BaPageLayoutType.Default,
+        content,
+      });
+      expect(transformed.content).toBe(
+        '<h1>Fonts</h1>\n\n<p>\n\nThis is just a simple internal string\n\n</p>\n\n<p>Some more public content.</p>',
       );
     });
   });

--- a/libs/tools/barista/src/transform.ts
+++ b/libs/tools/barista/src/transform.ts
@@ -282,7 +282,13 @@ export function internalContentTransformerFactory(
             $(content).remove();
           } else {
             const innerHtml = $(content).html();
-            $(content).replaceWith($(innerHtml));
+            if (innerHtml) {
+              // If the innerHtml starts with < we can assume that it's HTML content.
+              // If not it's probably a string that can be wrapped in a paragraph.
+              innerHtml.trim().startsWith('<')
+                ? $(content).replaceWith($(innerHtml))
+                : $(content).replaceWith($(`<p>${innerHtml}</p>`));
+            }
           }
         });
       },


### PR DESCRIPTION
### <strong>Pull Request</strong>

Now content is re-inserted when `innerHtml` is "just" a string without wrapping HTML tags (because otherwise Cheerio can't handle the replacement).

And: added tests.

#### Type of PR

Barista tools

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
