### PR TITLE
chore(stylelint): Remove selector class matching in examples

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -399,7 +399,7 @@
         "lint-styles": {
           "builder": "@dynatrace/barista-builders:stylelint",
           "options": {
-            "stylelintConfig": ".stylelintrc",
+            "stylelintConfig": "libs/examples/.stylelintrc",
             "reportFile": "dist/stylelint/report.xml",
             "exclude": ["**/node_modules/**"],
             "files": ["libs/examples/**/*.scss"]

--- a/libs/examples/.stylelintrc
+++ b/libs/examples/.stylelintrc
@@ -1,0 +1,6 @@
+{
+   "extends": ["../../.stylelintrc"],
+   "rules": {
+     "selector-class-pattern": null
+   }
+}


### PR DESCRIPTION
### <strong>Pull Request</strong>

This loosens the constraints a little and eases the process for contributors. There is no real need for this rule to be enforced in the examples