### PR TITLE
ci: Added a release promotion reminder

### DIFF
--- a/.github/workflows/slack-barista-production-promotion.yml
+++ b/.github/workflows/slack-barista-production-promotion.yml
@@ -1,0 +1,16 @@
+name: "Slack"
+
+on: [release]
+
+jobs:
+  barista-public-notification:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: 8398a7/action-slack@v2.7.0
+      with:
+        status: custom
+        author_name: FriendlyReminderBot
+        payload: |
+          { text: "Please check the Barista public deployment on https://zeit.co/dynatrace-oss/barista and promote the new release to production if everything works!" }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_TEAM_CHANNEL }}


### PR DESCRIPTION
Added an action that triggers a webhook to post a message on slack after a release.

Since we don't want to promote barista instantly to production - this action is a reminder to do this after a release is done