### PR TITLE
barista: Remove flat white from the icon color wheel.

### DIFF
--- a/apps/barista-design-system/src/components/icon-color-wheel/icon-color-wheel.ts
+++ b/apps/barista-design-system/src/components/icon-color-wheel/icon-color-wheel.ts
@@ -68,6 +68,8 @@ export class BaIconColorWheel {
 
   constructor(private _sanitizer: DomSanitizer) {
     const groupedBlobs = Object.keys(DtColors)
+      /** breaking-change Can eb removed when flat_white is removed from the color list. 7.0.0 */
+      .filter(key => key !== 'FLAT_WHITE') // no flat white for the color wheel
       .map((key): BaColorWheelBlob | undefined => {
         /* tslint:disable no-magic-numbers */
         const parts = key.split('_');

--- a/libs/barista-components/core/src/style/_colors.scss
+++ b/libs/barista-components/core/src/style/_colors.scss
@@ -1,4 +1,6 @@
 $white: #ffffff;
+/** @breaking-change Flat white will be removed with version 7.0.0 */
+/** @deprecated Use $white instead */
 $flat-white: #ffffff;
 
 $turquoise-100: #e1f7f9;

--- a/libs/barista-components/theming/src/colors.ts
+++ b/libs/barista-components/theming/src/colors.ts
@@ -19,6 +19,8 @@
  */
 export enum DtColors {
   WHITE = '#ffffff',
+  /** @breaking-change Flat white will be removed with version 7.0.0 */
+  /** @deprecated Use DtColors.WHITE instead */
   FLAT_WHITE = '#ffffff',
 
   BLUE_100 = '#e0f4fc',


### PR DESCRIPTION
### <strong>Pull Request</strong>

The newly introduced color-value `FLAT_WHITE` broke the layout of our icons color wheel in Barista. This filter should fix it.

#### Type of PR

Barista bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
