### PR TITLE
Copy to clipboard: move to CDK instead of current API

### DIFF
--- a/libs/barista-components/copy-to-clipboard/src/copy-to-clipboard-module.ts
+++ b/libs/barista-components/copy-to-clipboard/src/copy-to-clipboard-module.ts
@@ -16,6 +16,7 @@
 
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { ClipboardModule } from '@angular/cdk/clipboard';
 
 import { DtButtonModule } from '@dynatrace/barista-components/button';
 import { DtIconModule } from '@dynatrace/barista-components/icon';
@@ -24,7 +25,7 @@ import { DtCopyToClipboard } from './copy-to-clipboard';
 import { DtCopyToClipboardLabel } from './copy-to-clipboard-label';
 
 @NgModule({
-  imports: [CommonModule, DtButtonModule, DtIconModule],
+  imports: [CommonModule, ClipboardModule, DtButtonModule, DtIconModule],
   exports: [DtCopyToClipboard, DtCopyToClipboardLabel],
   declarations: [DtCopyToClipboard, DtCopyToClipboardLabel],
 })

--- a/libs/barista-components/copy-to-clipboard/src/copy-to-clipboard.html
+++ b/libs/barista-components/copy-to-clipboard/src/copy-to-clipboard.html
@@ -7,7 +7,8 @@
   class="dt-copy-to-clipboard-btn-button"
   [variant]="variant"
   #copyButton
-  (click)="copyToClipboard()"
+  [cdkCopyToClipboard]="copyToClipboard()"
+  (cdkCopyToClipboardCopied)="_copiedToClipboard()"
 >
   <dt-icon *ngIf="showIcon" name="checkmark"></dt-icon>
   <ng-content

--- a/libs/barista-components/copy-to-clipboard/src/copy-to-clipboard.ts
+++ b/libs/barista-components/copy-to-clipboard/src/copy-to-clipboard.ts
@@ -28,6 +28,7 @@ import {
   ViewEncapsulation,
   Input,
 } from '@angular/core';
+import { Clipboard } from '@angular/cdk/clipboard';
 import { Subscription, timer } from 'rxjs';
 
 import {
@@ -53,7 +54,10 @@ const DT_COPY_TO_CLIPBOARD_SUCCESSFUL = 'dt-copy-to-clipboard-successful';
   encapsulation: ViewEncapsulation.Emulated,
 })
 export class DtCopyToClipboard implements AfterContentInit, OnDestroy {
-  constructor(private _cd: ChangeDetectorRef) {}
+  constructor(
+    private _changeDetectorRef: ChangeDetectorRef,
+    private _cdkClipboard: Clipboard,
+  ) {}
 
   /** Defines the button variant of the copy button. */
   @Input() variant: ButtonVariant = 'primary';
@@ -88,27 +92,27 @@ export class DtCopyToClipboard implements AfterContentInit, OnDestroy {
 
   /** Copies the provided content to the clipboard. */
   copyToClipboard(): void {
-    if (this._input) {
-      this._input.nativeElement.select();
-      const copyResult = document.execCommand('copy');
-      if (!copyResult) {
-        this.copyFailed.emit();
-        return;
-      }
-      this._showIcon = true;
-      _addCssClass(this._input.nativeElement, DT_COPY_TO_CLIPBOARD_SUCCESSFUL);
-      if (this._copyButton) {
-        _addCssClass(
-          this._copyButton.nativeElement,
-          DT_COPY_TO_CLIPBOARD_SUCCESSFUL,
-        );
-        this._copyButton.nativeElement.focus();
-      }
+    if (this._input && this._input.nativeElement.textContent !== null) {
+      this._cdkClipboard.copy(this._input.nativeElement.textContent);
+    } else {
+      this.copyFailed.emit();
+    }
+  }
+
+  /** @internal Resets copy button style and emits a stream when finished */
+  _copiedToClipboard(): void {
+    this._showIcon = true;
+    _addCssClass(this._input.nativeElement, DT_COPY_TO_CLIPBOARD_SUCCESSFUL);
+    if (this._copyButton) {
+      _addCssClass(
+        this._copyButton.nativeElement,
+        DT_COPY_TO_CLIPBOARD_SUCCESSFUL,
+      );
+      this._copyButton.nativeElement.focus();
     }
 
     this._timer = timer(DT_COPY_CLIPBOARD_TIMER).subscribe((): void => {
       this._resetCopyState();
-
       this.afterCopy.emit();
     });
     this.copied.emit();
@@ -123,7 +127,7 @@ export class DtCopyToClipboard implements AfterContentInit, OnDestroy {
         DT_COPY_TO_CLIPBOARD_SUCCESSFUL,
       );
     }
-    this._cd.markForCheck();
+    this._changeDetectorRef.markForCheck();
     this._timer.unsubscribe();
   }
 


### PR DESCRIPTION
Moves copy to clipboard component to Angular's CDK.

Closes. #77 