### PR TITLE
Fixes an issue where the live examples where not rendered in AOT

### DIFF
--- a/.github/workflows/barista-preview.yml
+++ b/.github/workflows/barista-preview.yml
@@ -16,7 +16,10 @@ jobs:
       with:
         node-version: '12.x'
     - run: npm ci
-    - run: npm run examples-tools  && npm run ng -- build barista-design-system --progress=false && npm run barista-tools
+    - run: |
+        npm run examples-tools
+        npm run ng run barista-design-system:build:production --progress=false
+        npm run barista-tools
       env:
         CI: true
 

--- a/now-preview.json
+++ b/now-preview.json
@@ -1,8 +1,13 @@
 {
   "version": 2,
+  "github": {
+    "enabled": false
+  },
   "routes": [
     { "src": "/assets/(.*)", "dest": "/assets/$1" },
     { "src": "/(.*).js", "dest": "/$1.js" },
+    { "src": "/(.*).css", "dest": "/$1.css" },
+    { "src": "/(.*).svg", "dest": "/$1.svg" },
     { "src": "/(.*).json", "dest": "/$1.json" },
     { "src": "/(.*)", "dest": "/index.html" }
   ]


### PR DESCRIPTION
…side dynamical in ahead of time compilation.

### <strong>Pull Request</strong>

There was an issue with AOT compilation and the way the live-examples were being loaded and initialized. A change in the LoadModuleFactory was required to get this off the ground.

Please choose the type appropriate for the changes below: <br>

#### Type of PR

Documentation 

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
