### PR TITLE
Build/create docker build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,12 @@ orbs:
 executors:
   # Base image for publishing
   docker-publisher:
+    working_directory: ~/barista
+    environment:
+      WORKSPACE_IMAGE: designops/workspace-base
     docker:
       - image: circleci/buildpack-deps:stretch
+
   # Base image for building node based environments
   node-builder:
     docker:
@@ -138,6 +142,31 @@ jobs:
           root: ~/barista
           paths:
             - .
+
+# - Builds docker image for workspace
+  build-docker-image:
+    executor: docker-publisher
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run: docker build -t $WORKSPACE_IMAGE:latest ./
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./
+
+# - Publishes the built docker image for the workspace
+  publish-docker-image:
+    executor: docker-publisher
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run: docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD
+      - run:
+          name: Publish Docker Image to Docker Hub
+          command: |
+            docker push $WORKSPACE_IMAGE:latest
 
 # - sonar checks
   sonar:
@@ -320,6 +349,17 @@ workflows:
     jobs:
       - install:
           <<: *filter_branches
+      - build-docker-image:
+          <<: *filter_branches
+      - publish-docker-image:
+          filters:
+            branches:
+              only: master
+          # DOCKERHUB_USER is used for publishing
+          # DOCKERHUB_PASSWORD is used for publishing
+          context: barista
+          requires:
+            - build-docker-image
       - check-formatting:
           <<: *filter_branches
           requires:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,20 @@
-node_modules
-.git
-.github
-.circleci
-.vscode
+#--------------------------
+# disallow anything
+#--------------------------
+**
+
+#--------------------------
+# allow explicit
+#--------------------------
+!package.json
+!package-lock.json
+
+# Used by multiple projects:
+# - /Dockerfile
+!tsconfig.json
+!angular.json
+
+
+# Used by: /Dockerfile
+!/libs/tools/builders
+!/entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+FROM node:12-alpine as base
+
+# The root of the monorepo
+WORKDIR /dynatrace
+
+COPY ./package.json ./package.json
+COPY ./package-lock.json ./package-lock.json
+
+# install dependencies without postinstall script
+RUN npm ci --ignore-scripts
+
+COPY ./tsconfig.json ./tsconfig.json
+
+#------------------------------------------------------------
+# Temporary layer to build the workspace builder
+# - Output under: node_modules/@dynatrace/barista-builders
+#------------------------------------------------------------
+FROM base as workspace-builders
+
+COPY ./libs/tools/builders ./libs/tools/builders
+
+# Build our custom angular builders for the workspace
+RUN npm run builders:build
+
+
+#------------------------------------------------------------
+# The base image for the angular workspace with the builted
+# builders for the angular.json
+#------------------------------------------------------------
+FROM base as angular-base
+
+LABEL maintainer="Dynatrace DesignOps Team <designops@dynatrace.com>" \
+      description="This image is used to have a build setup for our monorepo."
+
+# Run the Ivy compatibility compiler for all the depenencies
+RUN ./node_modules/.bin/ngcc \
+    --properties es2015 browser module main \
+    --first-only \
+    --create-ivy-entry-points
+
+COPY --from=workspace-builders \
+     /dynatrace/node_modules/@dynatrace/barista-builders \
+     ./node_modules/@dynatrace/barista-builders
+
+COPY ./angular.json ./angular.json
+
+
+ENTRYPOINT [ "/bin/sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+echo "
+Welcome to the Barista Workspace! 🔥
+
+You are currently working in: $(pwd)
+
+"
+
+echo " Copying files from checkout 🚂"
+tar cf - . | pv | (cd /dynatrace || exit; tar xf -)
+
+# Switch to the workspace repo inside the container
+cd /dynatrace || exit
+export PWD=/dynatrace
+
+if [ ! "$(sha1sum -c -s package-lock.sha1)" ]; then
+  echo "Need to install packages due to updated package-lock.json"
+  # When the checksums are not matching perform an npm install
+  npm ci
+fi
+
+if [ -z "$INTERNAL_ENVIRONMENT" ]; then
+  echo "We are in an internal environment!"
+  npm install @dynatrace/barista-icons @dynatrace/barista-fonts
+fi
+
+
+# Run the command from the docker image
+exec "$@"


### PR DESCRIPTION
### <strong>Pull Request</strong>

Create a workspace build image that can be used for faster CI build times on Jenkins for barista.


In a follow up it can be used on the circleci to skip installing on every build, and use our custom image for building like:

```yml
  build-test:
    working_directory: /dynatrace
    docker:
      - image: designops/workspace-base:latest
    steps:
      - attach_workspace:
          at: /dynatrace
      - run: ./node_modules/.bin/nx workspace-lint
      - run: yarn affected:lint --all --parallel
```