### PR TITLE
fix(filter-field): Fixes an issue with the free-text submission.

### DIFF
--- a/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
@@ -176,7 +176,7 @@ test('should choose a freetext node with the mouse and submit the correct value 
     // Wait for a certain amout fo time to let the filterfield refresh
     .wait(250)
     // Send the correct value into the input field
-    .typeText(input, 'Custom selection', { speed: 0.7 });
+    .typeText(input, 'Custom selection');
 
   // Focus the filter field
   await focusFilterFieldInput();

--- a/libs/barista-components/filter-field/src/filter-field.ts
+++ b/libs/barista-components/filter-field/src/filter-field.ts
@@ -496,16 +496,16 @@ export class DtFilterField<T>
     // Using fromEvent instead of an html binding so we get a stream and can easily do a debounce
     merge(
       fromEvent(this._inputEl.nativeElement, 'input').pipe(
+        tap(() => (this._inputValue = this._inputEl.nativeElement.value)),
         debounceTime(DT_FILTER_FIELD_TYPING_DEBOUNCE),
       ),
-      this._inputReset$,
+      this._inputReset$.pipe(
+        tap(() => (this._inputValue = this._inputEl.nativeElement.value)),
+      ),
     )
       .pipe(
-        map(() => this._inputEl.nativeElement.value),
+        map(() => this._inputValue),
         distinctUntilChanged(),
-        tap(value => {
-          this._inputValue = value;
-        }),
         takeUntil(this._destroy$),
       )
       .subscribe(() => {


### PR DESCRIPTION

### <strong>Pull Request</strong>
Quickly input free text submissions were ignored if the user was submitting the filter under the
defined debounceTime as we were only updating the value after the debounceTime.
We are now updating the value immediately, but we are handling the submission and necessary updates
to the component after the debounceTime expired.

Fixes #726

#### Type of PR

Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
