### PR TITLE
barista: Simplify breadcrumbs creation.

### DIFF
--- a/apps/barista-design-system/src/app/app.ts
+++ b/apps/barista-design-system/src/app/app.ts
@@ -115,19 +115,14 @@ export class BaApp implements OnInit, OnDestroy {
   _createBreadcrumbs(url: string): BaBreadcrumb[] {
     const urlParts = getUrlPathName(this._document, url).split('/');
 
-    return urlParts.reduce((prev: BaBreadcrumb[], cur: string) => {
-      const currentUrl = `${prev.map(part => part.url).join('/')}/${cur}`;
-      const page = this._pageService._cache.get(
-        getPageKeyFromUrl(this._document, currentUrl),
-      );
-      const label = page ? page.title : cur.replace(/\-/gm, '');
-
-      prev.push({
-        label,
-        url: currentUrl,
-      });
-      return prev;
-    }, [] as BaBreadcrumb[]);
+    let urlPart = '';
+    return urlParts.map((part: string) => {
+      urlPart = `${urlPart}/${part}`;
+      return {
+        label: part.replace(/\-/gm, ' '),
+        url: urlPart,
+      };
+    });
   }
 
   /** Sets all the necessary meta tags to improve our SEO score. */


### PR DESCRIPTION
### <strong>Pull Request</strong>

In the current implementation of the Barista breadcrumbs the label can change during navigation when pages are not in the cache in the first place and the title and URL part are different. So I would suggest to only use the URL part for the breadcrumbs labels to ensure consistency during navigation.