### PR TITLE
barista: Fixes an issue where not all fills were removed from icon strings.

### DIFF
--- a/libs/tools/barista/src/builder/icons.ts
+++ b/libs/tools/barista/src/builder/icons.ts
@@ -130,7 +130,8 @@ function getSvgWithoutFill(filePath: string): string {
   const cheerioIcon = loadWithCheerio(iconSvg);
   const svg = cheerioIcon('svg');
   svg.removeAttr('fill');
-  svg.children().removeAttr('fill');
+  svg.find('[fill]').removeAttr('fill');
+
   return html(svg) || '';
 }
 


### PR DESCRIPTION
### <strong>Pull Request</strong>

the previous logic did only work for root level fills and it's direct children elements. 
The fix provides a deep removal of all fills that are set within the svg code to ensure color-ability.

#### Type of PR
Other / Documentation 

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
