### PR TITLE
Overlay: Fix mousemove

### DIFF
--- a/libs/barista-components/overlay/src/mouse-follow-position-strategy.ts
+++ b/libs/barista-components/overlay/src/mouse-follow-position-strategy.ts
@@ -26,6 +26,11 @@ import { Platform } from '@angular/cdk/platform';
 
 import { DtOverlayOrigin } from './overlay';
 
+/**
+ * @deprecated This should not be used anymore since the cdk positionstrategy now accepts a point (x, y) value
+ * by setting the origin to the events x & y values and updating the position on each event
+ * the same effect can be achieved
+ */
 export class DtMouseFollowPositionStrategy implements PositionStrategy {
   private _flexiblePositionStrategy: FlexibleConnectedPositionStrategy;
 

--- a/libs/barista-components/overlay/src/overlay-ref.ts
+++ b/libs/barista-components/overlay/src/overlay-ref.ts
@@ -27,7 +27,6 @@ import {
   _removeCssClass,
 } from '@dynatrace/barista-components/core';
 
-import { DtMouseFollowPositionStrategy } from './mouse-follow-position-strategy';
 import { DT_OVERLAY_NO_POINTER_CLASS } from './overlay';
 import { DtOverlayConfig } from './overlay-config';
 import { DtOverlayContainer } from './overlay-container';
@@ -129,16 +128,10 @@ export class DtOverlayRef<T> {
 
   /**
    * Updates the position of the overlay by an offset relative to the top left corner of the origin
+   * NOTE: The parameters are not changing the behavior anymore since
+   * the position can be done without the offset to the left top corner
    */
-  updatePosition(offsetX: number, offsetY: number): void {
-    const config = this._overlayRef.getConfig();
-    if (
-      config.positionStrategy &&
-      config.positionStrategy instanceof DtMouseFollowPositionStrategy
-    ) {
-      config.positionStrategy.withOffset(offsetX, offsetY);
-    }
-
+  updatePosition(_offsetX?: number, _offsetY?: number): void {
     this._overlayRef.updatePosition();
   }
 


### PR DESCRIPTION
This PR fixes some long standing issues that keep popping up.

Fixes #772
Fixes #220

The discussion on what to do with the overlay is already quite long. This is the intermediate step of fixing what we have right now the best way I could. 

Plan for the future: Provide default config that can be used with the cdk overlay service and directives. 
And create a "tooltip" (working title) component that would cover 95% percent of the use cases in the template. More will follow in the #86 
