### PR TITLE
Expandable-text: Set default background

### DIFF
--- a/libs/barista-components/expandable-text/src/expandable-text.scss
+++ b/libs/barista-components/expandable-text/src/expandable-text.scss
@@ -9,6 +9,7 @@
 .dt-expandable-text-trigger {
   @include dt-link-base();
   @include dt-custom-font-styles($turquoise-600, $default-font-weight, 100%);
+  background-color: transparent;
 
   &:focus {
     outline: 0;


### PR DESCRIPTION
Fixes an issue that the default background for the trigger was not set and firefox painted it in a nice gray :D