### PR TITLE
chore: Bump version to 6.1.1 w/ changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 6.1.1 (2020-03-30)
+
+### Bug Fixes
+
+- **copy-to-clipboard:** Fixes an issue where copied text is undefined
+  ([06dd337](https://github.com/dynatrace-oss/barista/commit/06dd337aa5a896f832ab120ef22eb500ad9a0eca))
+
 ## 6.1.0 (2020-03-24)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynatrace-oss/barista",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynatrace-oss/barista",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "",
   "scripts": {
     "build": "ng build",


### PR DESCRIPTION
Release for the copy to clipboard regression