### PR TITLE
Change build target of barista to the server side rendering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,9 @@ jobs:
           command: npx ngcc
       - run:
           name: Generate examples for the demo application
-          command: npm run examples-tools
+          command: |
+            npm run examples-tools
+            npm run barista-tools
       - run: yarn nx affected:build ${AFFECTED_ARGS} --configuration=production --parallel --exclude=examples-tools
       - persist_to_workspace:
           root: ~/barista

--- a/.github/workflows/barista-preview.yml
+++ b/.github/workflows/barista-preview.yml
@@ -8,33 +8,23 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    container: designops/workspace-base:latest
     env:
-      CI: true
+      WORKSPACE_DIR: /dynatrace
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache node modules
-        uses: actions/cache@v1
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Use node 12.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-
-      - name: Install dependencies
-        run:  npm ci
+      - name: Link the node_modules and the builders in the current working directory
+        run : |
+          cp -R "$WORKSPACE_DIR/dist/tmp/workspace" "$WORKSPACE_DIR/node_modules/@dynatrace/workspace"
+          ln -s "$WORKSPACE_DIR/node_modules" "$PWD/node_modules"
 
       - name: Build Barista Design System
         run: |
           npm run examples-tools
           npm run barista-tools
-          npm run ng build workspace
-          npm run ng run barista-design-system:render:production
+
+          npm run ng run barista-design-system:build:production
 
       - name: ZEIT Now Deployment
         id: now-deployment

--- a/angular.json
+++ b/angular.json
@@ -405,6 +405,19 @@
       "projectType": "application",
       "architect": {
         "build": {
+          "builder": "@dynatrace/workspace:build-barista",
+          "options": {
+            "devServerTarget": "barista-design-system:serve-ssr",
+            "outputPath": "dist/apps/barista-design-system/browser",
+            "routesFile": "dist/barista-data/routes.txt"
+          },
+          "configurations": {
+            "production": {
+              "devServerTarget": "barista-design-system:serve-ssr:production"
+            }
+          }
+        },
+        "build-frontend": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
             "outputPath": "dist/apps/barista-design-system/browser",
@@ -517,23 +530,23 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "barista-design-system:build"
+            "browserTarget": "barista-design-system:build-frontend"
           },
           "configurations": {
             "production": {
-              "browserTarget": "barista-design-system:build:production"
+              "browserTarget": "barista-design-system:build-frontend:production"
             }
           }
         },
         "serve-ssr": {
           "builder": "@nguniversal/builders:ssr-dev-server",
           "options": {
-            "browserTarget": "barista-design-system:build",
+            "browserTarget": "barista-design-system:build-frontend",
             "serverTarget": "barista-design-system:build-server"
           },
           "configurations": {
             "production": {
-              "browserTarget": "barista-design-system:build:production",
+              "browserTarget": "barista-design-system:build-frontend:production",
               "serverTarget": "barista-design-system:build-server:production"
             }
           }
@@ -564,19 +577,6 @@
             "tsConfig": "apps/barista-design-system/tsconfig.spec.json",
             "setupFile": "apps/barista-design-system/src/test-setup.ts",
             "passWithNoTests": true
-          }
-        },
-        "render": {
-          "builder": "@dynatrace/workspace:build-barista",
-          "options": {
-            "devServerTarget": "barista-design-system:serve-ssr",
-            "outputPath": "dist/apps/barista-design-system/browser",
-            "routesFile": "dist/barista-data/routes.txt"
-          },
-          "configurations": {
-            "production": {
-              "devServerTarget": "barista-design-system:serve-ssr:production"
-            }
           }
         }
       }


### PR DESCRIPTION
Changes the default `build` target of the barista-design-system to the generating of the static pages to be part of the `nx affected:build` command that is running on the circle ci.
This should prevent us of merging code that is not compatible with the universal rendering.

### <strong>Pull Request</strong>

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
