### PR TITLE
ci: Increase the time for stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/stale@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is stale, because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
-        stale-issue-label: 'no-issue-activity' 
-        days-before-stale: 30
+        stale-issue-message: 'This issue is stale, because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 5 days'
+        stale-issue-label: 'no-issue-activity'
+        days-before-stale: 90
         days-before-close: 5


### PR DESCRIPTION
I think the time of 30 days was too short especially if issues should be taken by contributors outside the team. I've extended the period to 90 days. Let's see how we cope with this change and watch our issue count over time