### PR TITLE
ci: Build and Publish docker image in a separate workflow.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,24 @@ set_env: &set_env
 
 jobs:
 
+# - Builds docker image for workspace
+  build-docker-image:
+    executor: docker-publisher
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Login to Docker Registry
+          command: docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD
+      - run:
+          name: Build Docker Image
+          command: docker build -t $WORKSPACE_IMAGE:latest ./ -f ./.deployment/workspace-base.Dockerfile
+      - run:
+          name: Publish Docker Image to Docker Hub
+          command: |
+            docker push $WORKSPACE_IMAGE:latest
+
 # - install npm dependencies
   install:
     <<: *defaults
@@ -142,31 +160,6 @@ jobs:
           root: ~/barista
           paths:
             - .
-
-# - Builds docker image for workspace
-  build-docker-image:
-    executor: docker-publisher
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run: docker build -t $WORKSPACE_IMAGE:latest ./ -f ./.deployment/workspace-base.Dockerfile
-      - persist_to_workspace:
-          root: .
-          paths:
-            - ./
-
-# - Publishes the built docker image for the workspace
-  publish-docker-image:
-    executor: docker-publisher
-    steps:
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run: docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD
-      - run:
-          name: Publish Docker Image to Docker Hub
-          command: |
-            docker push $WORKSPACE_IMAGE:latest
 
 # - sonar checks
   sonar:
@@ -346,22 +339,23 @@ jobs:
 
 workflows:
   version: 2.1
-# - Runs on every PR check
-  pr-check:
+
+# - Publish the workspace image on every master build
+  workspace-build:
     jobs:
-      - install:
-          <<: *filter_branches
       - build-docker-image:
-          <<: *filter_branches
-      - publish-docker-image:
           filters:
             branches:
               only: master
           # DOCKERHUB_USER is used for publishing
           # DOCKERHUB_PASSWORD is used for publishing
           context: barista
-          requires:
-            - build-docker-image
+
+# - Runs on every PR check
+  pr-check:
+    jobs:
+      - install:
+          <<: *filter_branches
       - check-formatting:
           <<: *filter_branches
           requires:


### PR DESCRIPTION
Somehow the docker layer caching is messing up between the two steps while persisting the image for publishing. Lets put them together in a separate workflow to avoid side effects and publishing old dangling images.

### <strong>Pull Request</strong>

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
