### PR TITLE
barista(search): Fixes an issue with search on overview pages.

### DIFF
--- a/apps/barista-design-system/src/app/components/search/search.ts
+++ b/apps/barista-design-system/src/app/components/search/search.ts
@@ -48,9 +48,12 @@ export class BaSearch implements OnInit {
   ngOnInit(): void {
     this.searchResults$ = fromEvent(
       this._searchInput.nativeElement,
-      'input',
+      'keyup',
     ).pipe(
-      map(() => this._searchInput.nativeElement.value),
+      map((event: KeyboardEvent) => {
+        event.stopPropagation();
+        return this._searchInput.nativeElement.value;
+      }),
       distinctUntilChanged(),
       debounceTime(150),
       switchMap(query => this._searchService.search(query)),

--- a/apps/barista-design-system/src/pages/overview-page/overview-page.ts
+++ b/apps/barista-design-system/src/pages/overview-page/overview-page.ts
@@ -75,7 +75,7 @@ export class BaOverviewPage implements AfterViewInit, OnDestroy {
    */
   ngAfterViewInit(): void {
     this._prepareItems();
-    this._keyUpSubscription = fromEvent(document, 'keyup').subscribe(
+    this._keyUpSubscription = fromEvent(this._document, 'keyup').subscribe(
       (evt: KeyboardEvent) => {
         const keyCode = _readKeyCode(evt);
         if (keyCode >= A && keyCode <= Z) {

--- a/apps/barista-design-system/src/shared/services/search.service.ts
+++ b/apps/barista-design-system/src/shared/services/search.service.ts
@@ -19,6 +19,7 @@ import { HttpClient } from '@angular/common/http';
 import { BaSearchResult } from '@dynatrace/shared/barista-definitions';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
+import { catchError } from 'rxjs/operators';
 
 interface BaSearchServiceInterface {
   search(query: string): Observable<BaSearchResult[]>;
@@ -29,9 +30,11 @@ export class BaSearchService implements BaSearchServiceInterface {
   constructor(private readonly _http: HttpClient) {}
 
   search(searchString: string): Observable<BaSearchResult[]> {
-    return this._http.get<BaSearchResult[]>(
-      `${environment.searchEndpoint}search?q=${searchString}`,
-    );
+    return this._http
+      .get<BaSearchResult[]>(
+        `${environment.searchEndpoint}search?q=${searchString}`,
+      )
+      .pipe(catchError(() => []));
   }
 }
 


### PR DESCRIPTION

### <strong>Pull Request</strong>

The focuspulling of keyInputs on overview pages, which should help you find things faster on
overview pages, was interfering with the input in the search.
To prevent this, we have moved them to the same keyboardEvent (keyup instead of input), and added a
propagation blocker to the search.

Also added an error handler for the rest call to the search, which was breaking the subscription.

#### Type of PR

Documentation 

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
