### PR TITLE
Fixes an issue where the internal icon pack was not displayed in barista

### DIFF
--- a/.deployment/barista/Jenkinsfile
+++ b/.deployment/barista/Jenkinsfile
@@ -64,18 +64,24 @@ pipeline {
                 writeFile(file: "${ENVIRONMENT_FILE}",  text: text)
               }
             }
-
-            dir(WORKSPACE_DIR) {
-              sh '''
-                rm -rf ./node_modules/@dynatrace/barista-icons
-                cp -R ./dist/tmp/barista-icons ./node_modules/@dynatrace/barista-icons
-              '''
-            }
           }
         }
 
         stage("Prepare Workspace") {
           steps {
+
+            script {
+              if (!(params.INTERNAL_VERSION ==~ /(?i)(Y|YES|T|TRUE|ON|RUN)/ )) {
+                echo "Public build - Replace internal iconpack with public ones."
+                dir(WORKSPACE_DIR) {
+                  sh '''
+                    rm -rf ./node_modules/@dynatrace/barista-icons
+                    cp -R ./dist/tmp/barista-icons ./node_modules/@dynatrace/barista-icons
+                  '''
+                 }
+              }
+            }
+
             sh'''
               files="node_modules package-lock.sha1"
 
@@ -83,8 +89,23 @@ pipeline {
               do
                 ln -s "$WORKSPACE_DIR/$file" "$PWD/$BARISTA_PATH/$file"
               done
-
             '''
+
+            dir(BARISTA_PATH) {
+
+              script {
+                def oldsha = readFile(file: "package-lock.sha1").replace('./package-lock.json', '').trim()
+                def sha1sum = sha1(file: "package-lock.json")
+
+                if (!oldsha.equals(sha1sum)) {
+                  echo "⚠️ Need to install packages due to updated package-lock.json"
+
+                  sh '''
+                    npm ci --ignore-scripts
+                  '''
+                }
+              }
+            }
 
             dir(BARISTA_PATH) {
               configFileProvider([


### PR DESCRIPTION
The internal icons were not found in the assets of the internal design system due to the wrong installed icon pack. Now it replaces the internal icons only with the public ones if the build parameter is set. 

Furthermore, I added the sha1sum check for the package-lock and added an npm ci to run always with the same dependencies as on the branch.

### <strong>Pull Request</strong>

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
