### PR TITLE
ci(barista-preview): Update node_modules if the sha1sum does not match.

### DIFF
--- a/.deployment/entrypoint.sh
+++ b/.deployment/entrypoint.sh
@@ -10,7 +10,7 @@ $(pwd)
 
 "
 
-if [ ! "$(sha1sum -c -s package-lock.sha1)" ]; then
+if [ ! "$(sha1sum -c package-lock.sha1)" ]; then
   echo "⚠️ Need to install packages due to updated package-lock.json"
   # When the checksums are not matching perform an npm install
   npm ci --ignore-scripts

--- a/.github/workflows/barista-preview.yml
+++ b/.github/workflows/barista-preview.yml
@@ -16,8 +16,15 @@ jobs:
 
       - name: Link the node_modules and the builders in the current working directory
         run : |
-          cp -R "$WORKSPACE_DIR/dist/tmp/workspace" "$WORKSPACE_DIR/node_modules/@dynatrace/workspace"
           ln -s "$WORKSPACE_DIR/node_modules" "$PWD/node_modules"
+          ln -s "$WORKSPACE_DIR/package-lock.sha1" "$PWD/package-lock.sha1"
+          ln -s "$WORKSPACE_DIR/entrypoint.sh" "$PWD/entrypoint.sh"
+
+          sh ./entrypoint.sh
+
+          # TODO: saving of the builders can be removed after #844 is merged
+          # THen the builders arn't located in the node modules anymore
+          cp -R "$WORKSPACE_DIR/dist/tmp/workspace" "$WORKSPACE_DIR/node_modules/@dynatrace/workspace"
 
       - name: Build Barista Design System
         run: |


### PR DESCRIPTION
If the sha1sum that is stored in the docker image is not matching the local
package-lock.json sha1sum then perform an npm ci.

### <strong>Pull Request</strong>

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
