### PR TITLE
docs(table): Improved observable and responsive examples

### DIFF
--- a/libs/examples/src/table/table-observable-example/table-observable-example.html
+++ b/libs/examples/src/table/table-observable-example/table-observable-example.html
@@ -1,3 +1,19 @@
+<button
+  *ngIf="!isSubscribed; else cancel"
+  class="dt-example-button"
+  dt-button
+  (click)="startSubscription()"
+>
+  Start subscription
+</button>
+<button
+  class="dt-example-button"
+  dt-button
+  variant="secondary"
+  (click)="clearRows()"
+>
+  Clear
+</button>
 <dt-table [dataSource]="dataSource">
   <ng-container dtColumnDef="host" dtColumnAlign="text">
     <dt-header-cell *dtHeaderCellDef>Host</dt-header-cell>
@@ -43,14 +59,8 @@
     </dt-empty-state-item>
   </dt-empty-state>
 </dt-table>
-<button class="dt-example-button" dt-button (click)="startSubscription()">
-  Start subscription
-</button>
-<button
-  class="dt-example-button"
-  dt-button
-  variant="secondary"
-  (click)="clearRows()"
->
-  Clear
-</button>
+<ng-template #cancel>
+  <button class="example-button" dt-button (click)="cancelSubscription()">
+    Cancel subscription
+  </button>
+</ng-template>

--- a/libs/examples/src/table/table-responsive-example/table-responsive-example.html
+++ b/libs/examples/src/table/table-responsive-example/table-responsive-example.html
@@ -20,7 +20,7 @@
       <dt-cell *dtCellDef="let row">{{ row.traffic }}</dt-cell>
     </ng-container>
 
-    <ng-container dtColumnDef="details" dtColumnAlign="number">
+    <ng-container dtColumnDef="details" dtColumnAlign="text">
       <dt-header-cell *dtHeaderCellDef>Details</dt-header-cell>
       <dt-expandable-cell *dtCellDef></dt-expandable-cell>
     </ng-container>

--- a/libs/examples/src/table/table-responsive-example/table-responsive-example.ts
+++ b/libs/examples/src/table/table-responsive-example/table-responsive-example.ts
@@ -63,7 +63,7 @@ export class DtExampleTableResponsive implements OnInit {
     },
   ];
 
-  _headerColumns = new Set(['host', 'cpu']);
+  _headerColumns = new Set();
 
   @ViewChild(DtContainerBreakpointObserver, { static: true })
   _tableBreakpointObserver: DtContainerBreakpointObserver;
@@ -72,6 +72,7 @@ export class DtExampleTableResponsive implements OnInit {
   _table: DtTable<any>; // tslint:disable-line: no-any
 
   private _tableNarrow = false;
+  private _baseColumns = ['host', 'cpu'];
 
   constructor(private _changeDetectorRef: ChangeDetectorRef) {}
 
@@ -84,13 +85,13 @@ export class DtExampleTableResponsive implements OnInit {
         // Show/hide header columns respecting
         // whether the table is in the narrow state
         if (this._tableNarrow) {
-          this._headerColumns.delete('memory');
-          this._headerColumns.delete('traffic');
-          this._headerColumns.add('details');
+          this._headerColumns = new Set(['details', ...this._baseColumns]);
         } else {
-          this._headerColumns.add('memory');
-          this._headerColumns.add('traffic');
-          this._headerColumns.delete('details');
+          this._headerColumns = new Set([
+            ...this._baseColumns,
+            'memory',
+            'traffic',
+          ]);
         }
 
         // Call render because we need to notify


### PR DESCRIPTION
### <strong>Pull Request</strong>
Introduces little improvements in table documentation.

### Responsive example:
This example uses an expandable row. Since the expandable-cell was switched to be shown at the left of the table, this example was showing wrongly the columns, and the example code needed to be adapted
![image](https://user-images.githubusercontent.com/11938799/78987929-bcd55b80-7b2f-11ea-905c-4a95271a1cb1.png)

- Changed Details column alignment to the left (text alignment)
- Changed header columns creation, to put Details column first, in case of expandable rows

### Observable example
This example allows to dynamically add rows from a source. But as the user doesn't know when it was going to finish (in fact in generates a row every second, during 5 seconds), it feels confusing to not be able to stop that subscription.

- Added a button to cancel the subscription, that gets switched when starting a subscription
- Moved buttons to the top, as otherwise the buttons are getting moved every time a row is added (making it more difficult to click them)

#### Type of PR
Documentation update (changes to documentation)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
