### PR TITLE
ci: Fix broken barista builder due to update of angular ngcc.

### DIFF
--- a/.deployment/k8s-barista-builder/Dockerfile
+++ b/.deployment/k8s-barista-builder/Dockerfile
@@ -5,12 +5,15 @@ ARG BASE_IMAGE_REGISTRY
 
 FROM designops/workspace-base:${BASE_VERSION} as workspace
 
-COPY .npmrc ./
+COPY .npmrc \
+     package.json \
+     ./
 
 RUN rm -rf entrypoint.sh && \
+    mkdir -p ./dist/tmp && \
     cp -R ./node_modules/@dynatrace/barista-icons ./dist/tmp/barista-icons-public && \
     npm install @dynatrace/barista-icons @dynatrace/barista-fonts && \
-    rm -rf .npmrc
+    rm -rf .npmrc package.json
 
 FROM ${BASE_IMAGE_REGISTRY}/library/jenkins-slave-cluster-docker-image:5.2 as builder
 

--- a/.deployment/k8s-barista-builder/Jenkinsfile
+++ b/.deployment/k8s-barista-builder/Jenkinsfile
@@ -9,9 +9,10 @@ pipeline {
 
   options {
     ansiColor("xterm")
-		buildDiscarder(logRotator(numToKeepStr: '10'))
+    buildDiscarder(logRotator(numToKeepStr: '10'))
     disableConcurrentBuilds()
-		timeout(time: 30, unit: 'MINUTES')
+    skipDefaultCheckout true
+    timeout(time: 30, unit: 'MINUTES')
     timestamps()
   }
 
@@ -23,6 +24,38 @@ pipeline {
   }
 
   stages {
+
+    stage('Checkout Files') {
+      steps {
+        checkout([
+          $class: 'GitSCM',
+          branches: [
+            [name: '*/master']
+          ],
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [
+            [
+              $class: 'CloneOption',
+              depth: 1,
+              noTags: false,
+              reference: '',
+              shallow: true
+            ],
+            [
+              $class: 'SparseCheckoutPaths',
+              sparseCheckoutPaths: [
+                [path: '.deployment/k8s-barista-builder'],
+                [path: 'package.json']
+              ]
+            ]
+          ],
+          submoduleCfg: [],
+          userRemoteConfigs: [
+            [url: 'https://github.com/dynatrace-oss/barista.git']
+          ]
+        ])
+      }
+    }
 
     stage("Add npmrc file for internal registry") {
       steps {


### PR DESCRIPTION
Due to the update of the angular version ngcc is creating a json file in the node_modules,
that gets loaded when no package.json is available in the repo. Because npm is searching for something
similar to the package.json. But the due to the fact that it is no package json the npm install
of the fonts and icons will fail.

Adding a package.json does the trick.
