### PR TITLE
build: Cleanup old missing tsconfig paths.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -152,9 +152,6 @@
       "@dynatrace/barista-components/select": [
         "libs/barista-components/select/index.ts"
       ],
-      "@dynatrace/barista-components/selection-area": [
-        "libs/barista-components/selection-area/index.ts"
-      ],
       "@dynatrace/barista-components/slider": [
         "libs/barista-components/slider/index.ts"
       ],
@@ -203,7 +200,6 @@
       "@dynatrace/testing/node": ["libs/testing/node/src/index.ts"],
       "@dynatrace/testing/browser": ["libs/testing/browser/src/index.ts"],
       "@dynatrace/testing/fixtures": ["libs/testing/fixtures/src/index.ts"],
-      "@dynatrace/tools/environments": ["libs/tools/environments/src/index.ts"],
       "@dynatrace/shared/barista-definitions": [
         "libs/shared/barista-definitions/src/index.ts"
       ],


### PR DESCRIPTION
### <strong>Pull Request</strong>

Due to the error warnings when building typescript:

```
WARNING in The basePath "/__w/barista/barista/libs/barista-components/selection-area/index.ts" computed from baseUrl "/__w/barista/barista" and path mapping "libs/barista-components/selection-area/index.ts" does not exist in the file-system.
It will not be scanned for entry-points.

WARNING in The basePath "/__w/barista/barista/libs/tools/environments/src/index.ts" computed from baseUrl "/__w/barista/barista" and path mapping "libs/tools/environments/src/index.ts" does not exist in the file-system.
It will not be scanned for entry-points.
```

The paths are not existing anymore.

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
