### PR TITLE
Removed Table in use headline

### DIFF
--- a/libs/barista-components/table/README.md
+++ b/libs/barista-components/table/README.md
@@ -578,6 +578,4 @@ simpleColumn could look like this (example from the `dt-simple-number-column`).
 </ng-container>
 ```
 
-## Tables in use
-
 <ba-ux-snippet name="table-in-use"></ba-ux-snippet>


### PR DESCRIPTION
Removed `Table in use` headline from the table component readme and moved it into database