### PR TITLE
feat(event-chart): Use duration pipe in axis

### DIFF
--- a/libs/barista-components/event-chart/src/event-chart-module.ts
+++ b/libs/barista-components/event-chart/src/event-chart-module.ts
@@ -28,6 +28,10 @@ import {
   DtEventChartOverlay,
 } from './event-chart-directives';
 import { DtEventChartLegend } from './event-chart-legend';
+import {
+  DtFormattersModule,
+  DtDuration,
+} from '@dynatrace/barista-components/formatters';
 
 export const DT_EVENT_CHART_DIRECTIVES = [
   DtEventChart,
@@ -39,7 +43,8 @@ export const DT_EVENT_CHART_DIRECTIVES = [
 
 @NgModule({
   exports: DT_EVENT_CHART_DIRECTIVES,
-  imports: [CommonModule, DtLegendModule, DtOverlayModule],
+  imports: [CommonModule, DtLegendModule, DtOverlayModule, DtFormattersModule],
   declarations: [DtEventChartLegend, ...DT_EVENT_CHART_DIRECTIVES],
+  providers: [DtDuration],
 })
 export class DtEventChartModule {}

--- a/libs/barista-components/event-chart/src/event-chart.spec.ts
+++ b/libs/barista-components/event-chart/src/event-chart.spec.ts
@@ -25,7 +25,7 @@ import { By } from '@angular/platform-browser';
 import { DtEventChartModule } from '@dynatrace/barista-components/event-chart';
 
 import { dispatchFakeEvent } from '@dynatrace/testing/browser';
-import { DtEventChart, roundUp, formatRelativeTimestamp } from './event-chart';
+import { DtEventChart } from './event-chart';
 import { DtEventChartSelectedEvent } from './event-chart-directives';
 import {
   DT_UI_TEST_CONFIG,
@@ -674,37 +674,24 @@ describe('DtEventChart', () => {
       );
       expect(selectedEvent).toBeNull();
     });
-  });
 
-  describe('x-axis', () => {
-    describe('formatRelativeTimestamp', () => {
-      it('should return milliseconds', () => {
-        expect(formatRelativeTimestamp(10)).toBe('10 ms');
-      });
+    describe('x-axis', () => {
+      it('should have formatted ticks', () => {
+        const axisLabels = fixture.debugElement
+          .queryAll(By.css('.dt-event-chart-tick-label'))
+          .map((el) => el.nativeElement.textContent.trim());
 
-      it('should return seconds', () => {
-        expect(formatRelativeTimestamp(10_000)).toBe('10 s');
-      });
-
-      it('should return minutes', () => {
-        expect(formatRelativeTimestamp(600_000)).toBe('10 min');
-      });
-
-      it('should return hours', () => {
-        expect(formatRelativeTimestamp(2 * 60 * 60_000)).toBe('2 h');
-      });
-
-      it('should return days', () => {
-        expect(formatRelativeTimestamp(1.5 * 24 * 60 * 60_000)).toBe('1.5 d');
-      });
-    });
-    describe('roundUp', () => {
-      it('should return a rounded up number of 2 decimals', () => {
-        expect(roundUp(1.325, 2)).toBe(1.33);
-      });
-
-      it('should return less decimals if possible', () => {
-        expect(roundUp(1, 2)).toBe(1);
+        expect(axisLabels).toEqual([
+          '0 s',
+          '0.01 s',
+          '0.02 s',
+          '0.03 s',
+          '0.04 s',
+          '0.05 s',
+          '0.06 s',
+          '0.07 s',
+          '0.08 s',
+        ]);
       });
     });
   });

--- a/libs/barista-components/event-chart/src/event-chart.ts
+++ b/libs/barista-components/event-chart/src/event-chart.ts
@@ -81,12 +81,18 @@ import { DtEventChartLegend } from './event-chart-legend';
 import { dtCreateEventPath } from './merge-and-path/create-event-path';
 import { dtEventChartMergeEvents } from './merge-and-path/merge-events';
 import { RenderEvent } from './render-event.interface';
+import {
+  DtDuration,
+  DtTimeUnit,
+  DtFormattedValue,
+} from '@dynatrace/barista-components/formatters';
 
 const EVENT_BUBBLE_SIZE = 16;
 const EVENT_BUBBLE_SPACING = 4;
 
 const EVENT_BUBBLE_OVERLAP_THRESHOLD = EVENT_BUBBLE_SIZE / 2;
 const TICK_HEIGHT = 24;
+const TICK_WIDTH = 100;
 
 const LANE_HEIGHT = EVENT_BUBBLE_SIZE * 3;
 
@@ -212,7 +218,7 @@ export class DtEventChart<T> implements AfterContentInit, OnInit, OnDestroy {
   _renderPath: string | null = null;
 
   /** @internal X axis ticks that are being rendered in the svgCanvas. */
-  _renderTicks: { x: number; value: string }[] = [];
+  _renderTicks: { x: number; value: string | DtFormattedValue }[] = [];
 
   /** @internal The width of the svg. */
   _svgWidth = 0;
@@ -251,6 +257,7 @@ export class DtEventChart<T> implements AfterContentInit, OnInit, OnDestroy {
     private _appRef: ApplicationRef,
     private _injector: Injector,
     private _overlayService: Overlay,
+    private _durationPipe: DtDuration,
     @Inject(DOCUMENT) private _document: any,
     private _platform: Platform,
     /** @breaking-change: `_elementRef` will be mandatory with version 7.0.0 */
@@ -701,14 +708,16 @@ export class DtEventChart<T> implements AfterContentInit, OnInit, OnDestroy {
   /** Generates and updates the ticks for the x-axis. */
   private _updateTicks(min: number, max: number): void {
     const timeScale = this._getTimeScaleForEvents(min, max);
-    const dateTicks = timeScale.ticks();
+
+    const tickAmount = Math.floor(
+      (timeScale.range()[1] - timeScale.range()[0]) / TICK_WIDTH,
+    );
+    const dateTicks = timeScale.ticks(tickAmount);
     this._renderTicks = dateTicks.map((date) => {
       const timestamp = date.getTime();
       return {
         x: timeScale(timestamp),
-        // TODO @thomas.pink, @thomas.heller:
-        // Investigate if we should move the time formatting to a pipe
-        value: formatRelativeTimestamp(timestamp),
+        value: this._formatRelativeTimestamp(timestamp),
       };
     });
   }
@@ -809,39 +818,35 @@ export class DtEventChart<T> implements AfterContentInit, OnInit, OnDestroy {
 
     patternDefsOutlet = outlet;
   }
+
+  /** Formats a relative timestamp into a readable text. */
+  private _formatRelativeTimestamp(
+    timestamp: number,
+  ): string | DtFormattedValue {
+    // TODO: once duration pipe returns a nice value maybe the unit is automatically chosen
+    let outputUnit = DtTimeUnit.SECOND;
+
+    const sec = 1000;
+    const min = sec * 60;
+    const hour = min * 60;
+    const day = hour * 24;
+
+    if (timestamp >= day) {
+      outputUnit = DtTimeUnit.DAY;
+    } else if (timestamp >= hour) {
+      outputUnit = DtTimeUnit.HOUR;
+    } else if (timestamp >= min) {
+      outputUnit = DtTimeUnit.MINUTE;
+    } else if (timestamp >= sec) {
+      outputUnit = DtTimeUnit.SECOND;
+    }
+
+    return this._durationPipe.transform(timestamp, 'PRECISE', outputUnit);
+  }
 }
 
 /** Determines if a passed parameter is part of the DtEventChartColors. */
 // tslint:disable-next-line: no-any
 function isValidColor(color: any): color is DtEventChartColors {
   return isDefined(color) && DT_EVENT_CHART_COLORS.indexOf(color) !== -1;
-}
-
-/** Formats a relative timestamp into a readable text. */
-export function formatRelativeTimestamp(timestamp: number): string {
-  const sec = 1000;
-  const min = sec * 60;
-  const hour = min * 60;
-  const day = hour * 24;
-  const decimals = 2;
-  if (timestamp >= day) {
-    return `${roundUp(timestamp / day, decimals)} d`;
-  } else if (timestamp >= hour) {
-    return `${roundUp(timestamp / hour, decimals)} h`;
-  } else if (timestamp >= min) {
-    return `${roundUp(timestamp / min, decimals)} min`;
-  } else if (timestamp >= sec) {
-    return `${roundUp(timestamp / sec, decimals)} s`;
-  }
-  return `${timestamp} ms`;
-}
-
-/**
- * Rounds the given number to the specified decimals.
- * @param num number to be rounded
- * @param decimals maximum amount of decimals
- * @returns rounded number
- */
-export function roundUp(num: number, decimals: number): number {
-  return Math.round(10 ** decimals * num) / 10 ** decimals;
 }


### PR DESCRIPTION
### <strong>Pull Request</strong>

Add duration pipe to x-axis in Event chart. Make number of ticks dynamic based on width
#940 

#### Type of PR
Feature (non-breaking change which adds functionality)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
