### PR TITLE
docs(context-dialog): Fixed a typo in the context dialog readme

### DIFF
--- a/libs/barista-components/context-dialog/README.md
+++ b/libs/barista-components/context-dialog/README.md
@@ -38,9 +38,9 @@ To make our components accessible it is obligatory to provide either an
 
 ## Outputs
 
-| Name            | Type                    | Description                                            |
-| --------------- | ----------------------- | ------------------------------------------------------ |
-| `openedChanged` | `EventEmitter<boolean>` | Event emitted when the context dialog opens or closes. |
+| Name           | Type                    | Description                                            |
+| -------------- | ----------------------- | ------------------------------------------------------ |
+| `openedChange` | `EventEmitter<boolean>` | Event emitted when the context dialog opens or closes. |
 
 ## Methods
 


### PR DESCRIPTION
Fix a typo in the readme

Docs 


Fixes #950
