### PR TITLE
fix(filter-field): Fixes an issue with filter field usage in forms.

### DIFF
--- a/apps/components-e2e/src/components/filter-field/filter-field.html
+++ b/apps/components-e2e/src/components/filter-field/filter-field.html
@@ -1,11 +1,15 @@
 <button class="outside">Outside</button>
 
-<dt-filter-field
-  id="filter-field"
-  [dataSource]="_dataSource"
-  label="Filter by"
-  clearAllLabel="Clear all"
-></dt-filter-field>
+<form (submit)="onSubmit($event)">
+  <dt-filter-field
+    id="filter-field"
+    [dataSource]="_dataSource"
+    label="Filter by"
+    clearAllLabel="Clear all"
+  ></dt-filter-field>
+</form>
+
+<span id="form-submitted">{{ formSubmitted }}</span>
 
 <button id="switchToFirstDatasource" (click)="switchToDatasource(0)">
   Switch to first datasource

--- a/apps/components-e2e/src/components/filter-field/filter-field.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.ts
@@ -84,4 +84,11 @@ export class DtE2EFilterField implements OnDestroy {
         }
       });
   }
+
+  formSubmitted = false;
+  onSubmit(event: Event): void {
+    event.preventDefault();
+    this.formSubmitted = true;
+    this._changeDetectorRef.markForCheck();
+  }
 }

--- a/libs/barista-components/filter-field/src/filter-field.html
+++ b/libs/barista-components/filter-field/src/filter-field.html
@@ -23,7 +23,7 @@
     dt-button
     variant="secondary"
     class="dt-filter-field-clear-all-button"
-    (click)="_clearAll()"
+    (click)="_clearAll($event)"
     *ngIf="clearAllLabel"
     [class.dt-filter-field-clear-all-button-hidden]="!_showClearAll"
   >

--- a/libs/barista-components/filter-field/src/filter-field.ts
+++ b/libs/barista-components/filter-field/src/filter-field.ts
@@ -616,6 +616,12 @@ export class DtFilterField<T = any>
   /** @internal */
   _handleInputKeyDown(event: KeyboardEvent): void {
     const keyCode = _readKeyCode(event);
+    if (keyCode === ENTER) {
+      // We need to prevent the default here, in case this filter field
+      // is used within a form, we do not want to submit the form at this
+      // point.
+      event.preventDefault();
+    }
     if ([BACKSPACE, DELETE].includes(keyCode) && !this._inputValue.length) {
       if (this._currentFilterValues.length) {
         this._removeFilterAndEmit(this._currentFilterValues);
@@ -707,7 +713,11 @@ export class DtFilterField<T = any>
   }
 
   /** @internal Clears all filters and switch to root def. */
-  _clearAll(): void {
+  _clearAll(event: Event): void {
+    // We need to prevent the default here, in case this filter field
+    // is used within a form, we do not want to submit the form at this
+    // point.
+    event.preventDefault();
     // Only filters that are deletable should be removed
     // We need to aggregate the once that should be removed on the one hand,
     // so we can emit them to the consumer.


### PR DESCRIPTION
### <strong>Pull Request</strong>
This fixes an issue where the keyboard interaction with the filter field submitted a wrapping form,
breaking the filter field behavior, as the native-form tried to submit. The filter field contains a
single input, which the native form picked up.
The same thing happened with the clear-all button, which triggered the native form submission when
clicked.

#### Type of PR
Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
