### PR TITLE
Fixes an issue where the production internal configuration was missing

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -497,6 +497,19 @@
                   "command": "npx ng run barista-design-system:static-pages:production"
                 }
               ]
+            },
+            "production-internal": {
+              "commands": [
+                {
+                  "command": "npx ng run examples-tools:execute"
+                },
+                {
+                  "command": "npx ng run barista-tools:execute"
+                },
+                {
+                  "command": "npx ng run barista-design-system:static-pages:production-internal"
+                }
+              ]
             }
           }
         },


### PR DESCRIPTION
Ng build had a missing production internal configuration.

Jenkins fails with:

```
12:21:43  node --max_old_space_size=8192 ./node_modules/.bin/ng run barista-design-system:build:production-internal
12:21:43  An unhandled exception occurred: Configuration 'production-internal' is not set in the workspace.
12:21:43  See "/tmp/ng-WcVc4X/angular-errors.log" for further details.
```

### <strong>Pull Request</strong>

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
