### PR TITLE
style: Adjust styling to respect disabled semantics.

### DIFF
--- a/libs/barista-components/autocomplete/src/autocomplete.scss
+++ b/libs/barista-components/autocomplete/src/autocomplete.scss
@@ -7,7 +7,7 @@ $dt-autocomplete-panel-min-width: 112px !default;
   width: 100%;
   background: #ffffff;
   box-sizing: border-box;
-  border: 1px solid $disabledcolor;
+  border: 1px solid $gray-300;
   border-radius: 0 0 3px 3px;
   max-height: $dt-autocomplete-panel-max-height;
   min-width: $dt-autocomplete-panel-min-width;

--- a/libs/barista-components/core/src/style/_form-control.scss
+++ b/libs/barista-components/core/src/style/_form-control.scss
@@ -2,7 +2,7 @@
 // Mixin to create the border and spacings for inputs, form-fields, ...
 @mixin dt-form-control() {
   box-sizing: border-box;
-  border: 1px solid $disabledcolor;
+  border: 1px solid $gray-300;
   border-radius: 3px;
   min-height: 32px;
   background-color: #ffffff;
@@ -36,7 +36,7 @@
   top: 0;
   left: 0;
   right: 0;
-  border: 1px solid $disabledcolor;
+  border: 1px solid $gray-300;
   background-color: $gray-100;
   padding: 8px 12px;
   border-bottom-left-radius: 3px;

--- a/libs/barista-components/core/src/style/_variables.scss
+++ b/libs/barista-components/core/src/style/_variables.scss
@@ -15,7 +15,7 @@ $cta-color-active: $green-700;
 $textcolor: $gray-700;
 $focuscolor: $gray-300;
 $linkcolor: $turquoise-600;
-$disabledcolor: $gray-600;
+$disabledcolor: $gray-300;
 
 $border-radius: 3px;
 $focus-outline-width: 2px;

--- a/libs/barista-components/filter-field/src/filter-field-range/filter-field-range.scss
+++ b/libs/barista-components/filter-field/src/filter-field-range/filter-field-range.scss
@@ -5,7 +5,7 @@
   width: 100%;
   background: #ffffff;
   box-sizing: border-box;
-  border: 1px solid $disabledcolor;
+  border: 1px solid $gray-300;
   border-radius: 0 0 3px 3px;
   padding: 8px;
   min-width: 200px;

--- a/libs/barista-components/filter-field/src/filter-field.scss
+++ b/libs/barista-components/filter-field/src/filter-field.scss
@@ -152,7 +152,7 @@ button.dt-filter-field-clear-all-button-hidden {
   top: 0;
   left: 0;
   right: 0;
-  border: 1px solid $disabledcolor;
+  border: 1px solid $gray-300;
   background-color: $gray-100;
   padding: 8px 12px;
   border-bottom-left-radius: 3px;

--- a/libs/barista-components/form-field/src/form-field.scss
+++ b/libs/barista-components/form-field/src/form-field.scss
@@ -109,7 +109,7 @@
   top: 0;
   left: 0;
   right: 0;
-  border: 1px solid $disabledcolor;
+  border: 1px solid $gray-300;
   background-color: $gray-100;
   padding: 8px 12px;
   border-bottom-left-radius: 3px;


### PR DESCRIPTION
### <strong>Pull Request</strong>
Reverted the disabledColor to gray-300, as this caused more sideeffects.
There are only browser-default stylings applied to the placeholder texts in our
form and input fields that support them. We should investigate to enhance this in the future.

Fixes #998