### PR TITLE
fix(button): Fixes the regression that button colors changed due to t…

### DIFF
--- a/libs/barista-components/button/src/_button-theme.scss
+++ b/libs/barista-components/button/src/_button-theme.scss
@@ -1,7 +1,7 @@
 .dt-button {
-  --dt-button-default-color: var(--dt-theme-main-default-color);
-  --dt-button-hover-color: var(--dt-theme-main-hover-color);
-  --dt-button-active-color: var(--dt-theme-main-active-color);
+  --dt-button-default-color: #{$turquoise-600};
+  --dt-button-hover-color: #{$turquoise-700};
+  --dt-button-active-color: #{$turquoise-800};
 }
 
 .dt-button.dt-color-warning {


### PR DESCRIPTION
…he theme.

Fixes a regression introduced that caused purple buttons :D
Since all our buttons need to be turquoise if not set to cta or warning we need to use the scss variable in the dt-button-default-color custom property no matter the theme
