### PR TITLE
feat(filter-field): Types

### DIFF
--- a/apps/components-e2e/src/components/filter-field/filter-field.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.ts
@@ -44,18 +44,14 @@ const DATA = [FILTER_FIELD_TEST_DATA_VALIDATORS, FILTER_FIELD_TEST_DATA];
 export class DtE2EFilterField implements OnDestroy {
   destroy$ = new Subject<void>();
 
-  _dataSource = new DtFilterFieldDefaultDataSource<
-    DtFilterFieldDefaultDataSourceType
-  >(DATA[0]);
+  _dataSource = new DtFilterFieldDefaultDataSource(DATA[0]);
 
   @ViewChild(DtFilterField, { static: true }) _filterfield: DtFilterField<
     DtFilterFieldDefaultDataSourceType
   >;
 
   switchToDatasource(targetIndex: number): void {
-    this._dataSource = new DtFilterFieldDefaultDataSource<
-      DtFilterFieldDefaultDataSourceType
-    >(DATA[targetIndex]);
+    this._dataSource = new DtFilterFieldDefaultDataSource(DATA[targetIndex]);
   }
 
   constructor(private _changeDetectorRef: ChangeDetectorRef) {}

--- a/apps/dev/src/filter-field/filter-field-demo.component.ts
+++ b/apps/dev/src/filter-field/filter-field-demo.component.ts
@@ -132,7 +132,7 @@ export class FilterFieldDemo implements AfterViewInit, OnDestroy {
   private _timerHandle: number;
   _firstTag: DtFilterFieldTag;
 
-  _dataSource = new DtFilterFieldDefaultDataSource<any>(TEST_DATA);
+  _dataSource = new DtFilterFieldDefaultDataSource(TEST_DATA);
   _loading = false;
   _disabled = false;
 

--- a/libs/barista-components/experimental/quick-filter/src/quick-filter-data-source.ts
+++ b/libs/barista-components/experimental/quick-filter/src/quick-filter-data-source.ts
@@ -21,13 +21,13 @@ import {
 } from '@dynatrace/barista-components/filter-field';
 
 export abstract class DtQuickFilterDataSource<T = any>
-  implements DtFilterFieldDataSource {
+  implements DtFilterFieldDataSource<T> {
   /**
    * Used by the DtFilterFieldControl. Called when it connects to the data source.
    * Should return a stream of data that will be transformed, filtered and
    * displayed by the DtFilterField and the DtFilterFieldControl.
    */
-  abstract connect(): Observable<DtNodeDef | null>;
+  abstract connect(): Observable<DtNodeDef<T> | null>;
 
   /** Used by the DtFilterField. Called when it is destroyed. */
   abstract disconnect(): void;
@@ -55,42 +55,42 @@ export abstract class DtQuickFilterDataSource<T = any>
     data: T,
     parent: DtNodeDef | null,
     existingDef: DtNodeDef | null,
-  ): DtNodeDef;
+  ): DtNodeDef<T>;
 
   /** Transforms the provided data into a DtNodeDef which contains a DtOptionDef. */
   abstract transformOption(
     data: T,
     parentAutocompleteOrOption: DtNodeDef | null,
     existingDef: DtNodeDef | null,
-  ): DtNodeDef;
+  ): DtNodeDef<T>;
 
   /** Transforms the provided data into a DtNodeDef which contains a DtGroupDef. */
   abstract transformGroup(
     data: T,
     parentAutocomplete: DtNodeDef | null,
     existingDef: DtNodeDef | null,
-  ): DtNodeDef;
+  ): DtNodeDef<T>;
 
   /** Transforms the provided data into a DtNodeDef which contains a DtFreeTextDef. */
   abstract transformFreeText(
     data: T,
     parent: DtNodeDef | null,
     existingDef: DtNodeDef | null,
-  ): DtNodeDef;
+  ): DtNodeDef<T>;
 
   /** Transforms the provided data into a DtNodeDef which contains a DtRangeDef. */
   abstract transformRange(
     data: T,
     parent: DtNodeDef | null,
     existingDef: DtNodeDef | null,
-  ): DtNodeDef;
+  ): DtNodeDef<T>;
 
   /** Transforms the provided data into a DtNodeDef. */
   abstract transformObject(
     data: T | null,
     parent: DtNodeDef | null,
-  ): DtNodeDef | null;
+  ): DtNodeDef<T> | null;
 
   /** Transforms the provided list of data objects into an array of DtNodeDefs. */
-  abstract transformList(list: T[], parent: DtNodeDef | null): DtNodeDef[];
+  abstract transformList(list: T[], parent: DtNodeDef | null): DtNodeDef<T>[];
 }

--- a/libs/barista-components/experimental/quick-filter/src/state/actions.ts
+++ b/libs/barista-components/experimental/quick-filter/src/state/actions.ts
@@ -62,8 +62,8 @@ export const updateFilter = (item: DtNodeDef) =>
   action<DtNodeDef>(ActionType.UPDATE_FILTER, item);
 
 /** Action that subscribes to a new data source */
-export const switchDataSource = (item: DtFilterFieldDataSource) =>
-  action<DtFilterFieldDataSource>(ActionType.SWITCH_DATA_SOURCE, item);
+export const switchDataSource = (item: DtFilterFieldDataSource<any>) =>
+  action<DtFilterFieldDataSource<any>>(ActionType.SWITCH_DATA_SOURCE, item);
 
 /** Action that updates the data source */
 export const updateDataSource = (nodeDef: DtNodeDef) =>

--- a/libs/barista-components/experimental/quick-filter/src/state/effects.ts
+++ b/libs/barista-components/experimental/quick-filter/src/state/effects.ts
@@ -38,7 +38,7 @@ export const ofType = <T>(
 /** Connects to a new Data dataSource */
 export const switchDataSourceEffect: Effect = (action$: Observable<Action>) =>
   action$.pipe(
-    ofType<DtFilterFieldDataSource>(ActionType.SWITCH_DATA_SOURCE),
+    ofType<DtFilterFieldDataSource<any>>(ActionType.SWITCH_DATA_SOURCE),
     switchMap((action) => action.payload!.connect()),
     map((nodeDef: DtNodeDef) => updateDataSource(nodeDef)),
   );

--- a/libs/barista-components/experimental/quick-filter/src/state/selectors.ts
+++ b/libs/barista-components/experimental/quick-filter/src/state/selectors.ts
@@ -22,6 +22,7 @@ import { Observable } from 'rxjs';
 import { filter, map, pluck, tap, withLatestFrom } from 'rxjs/operators';
 import { DtQuickFilterDataSource } from '../quick-filter-data-source';
 import { QuickFilterState } from './store';
+import { isDefined } from '@dynatrace/barista-components/core';
 
 /** @internal Select all autocompletes from the root Node Def from the store */
 export const getAutocompletes = (
@@ -35,13 +36,15 @@ export const getAutocompletes = (
       }
     }),
     pluck('nodeDef'),
-    filter(isDtAutocompleteDef),
+    filter((state) => isDefined(state) && isDtAutocompleteDef(state)),
     withLatestFrom(
       getDataSource(state$).pipe(filter<DtQuickFilterDataSource>(Boolean)),
     ),
-    map(([{ autocomplete }, { showInSidebarFunction }]) =>
-      autocomplete.optionsOrGroups.filter(
-        (node) => isDtAutocompleteDef(node) && showInSidebarFunction(node.data),
+    map(([nodeDef, dataSource]) =>
+      nodeDef!.autocomplete!.optionsOrGroups.filter(
+        (node) =>
+          isDtAutocompleteDef(node) &&
+          dataSource.showInSidebarFunction(node.data),
       ),
     ),
   );

--- a/libs/barista-components/filter-field/src/filter-field-data-source.ts
+++ b/libs/barista-components/filter-field/src/filter-field-data-source.ts
@@ -17,13 +17,13 @@
 import { Observable } from 'rxjs';
 import { DtNodeDef } from './types';
 
-export abstract class DtFilterFieldDataSource {
+export abstract class DtFilterFieldDataSource<T> {
   /**
    * Used by the DtFilterFieldControl. Called when it connects to the data source.
    * Should return a stream of data that will be transformed, filtered and
    * displayed by the DtFilterField and the DtFilterFieldControl.
    */
-  abstract connect(): Observable<DtNodeDef | null>;
+  abstract connect(): Observable<DtNodeDef<T> | null>;
 
   /** Used by the DtFilterField. Called when it is destroyed. */
   abstract disconnect(): void;
@@ -50,55 +50,48 @@ export abstract class DtFilterFieldDataSource {
 
   /** Transforms the provided data into a DtNodeDef which contains a DtAutocompleteDef. */
   abstract transformAutocomplete(
-    // tslint:disable-next-line: no-any
-    data: any,
-    parent: DtNodeDef | null,
-    existingDef: DtNodeDef | null,
-  ): DtNodeDef;
+    data: T,
+    parent: DtNodeDef<T> | null,
+    existingDef: DtNodeDef<T> | null,
+  ): DtNodeDef<T>;
 
   /** Transforms the provided data into a DtNodeDef which contains a DtOptionDef. */
   abstract transformOption(
-    // tslint:disable-next-line: no-any
-    data: any,
-    parentAutocompleteOrOption: DtNodeDef | null,
-    existingDef: DtNodeDef | null,
-  ): DtNodeDef;
+    data: T,
+    parentAutocompleteOrOption: DtNodeDef<T> | null,
+    existingDef: DtNodeDef<T> | null,
+  ): DtNodeDef<T>;
 
   /** Transforms the provided data into a DtNodeDef which contains a DtGroupDef. */
   abstract transformGroup(
-    // tslint:disable-next-line: no-any
-    data: any,
-    parentAutocomplete: DtNodeDef | null,
-    existingDef: DtNodeDef | null,
-  ): DtNodeDef;
+    data: T,
+    parentAutocomplete: DtNodeDef<T> | null,
+    existingDef: DtNodeDef<T> | null,
+  ): DtNodeDef<T>;
 
   /** Transforms the provided data into a DtNodeDef which contains a DtFreeTextDef. */
   abstract transformFreeText(
-    // tslint:disable-next-line: no-any
-    data: any,
-    parent: DtNodeDef | null,
-    existingDef: DtNodeDef | null,
+    data: T,
+    parent: DtNodeDef<T> | null,
+    existingDef: DtNodeDef<T> | null,
   ): DtNodeDef;
 
   /** Transforms the provided data into a DtNodeDef which contains a DtRangeDef. */
   abstract transformRange(
-    // tslint:disable-next-line: no-any
     data: any,
-    parent: DtNodeDef | null,
-    existingDef: DtNodeDef | null,
+    parent: DtNodeDef<T> | null,
+    existingDef: DtNodeDef<T> | null,
   ): DtNodeDef;
 
   /** Transforms the provided data into a DtNodeDef. */
   abstract transformObject(
-    // tslint:disable-next-line: no-any
-    data: any | null,
-    parent: DtNodeDef | null,
-  ): DtNodeDef | null;
+    data: T | null,
+    parent: DtNodeDef<T> | null,
+  ): DtNodeDef<T> | null;
 
   /** Transforms the provided list of data objects into an array of DtNodeDefs. */
   abstract transformList(
-    // tslint:disable-next-line: no-any
     list: any[],
-    parent: DtNodeDef | null,
-  ): DtNodeDef[];
+    parent: DtNodeDef<T> | null,
+  ): DtNodeDef<T>[];
 }

--- a/libs/barista-components/filter-field/src/filter-field-default-data-source.ts
+++ b/libs/barista-components/filter-field/src/filter-field-default-data-source.ts
@@ -160,21 +160,22 @@ export type DtFilterFieldDefaultDataSourceType =
  *   }
  * }
  */
-export class DtFilterFieldDefaultDataSource<
-  T extends DtFilterFieldDefaultDataSourceType
-> implements DtFilterFieldDataSource {
-  private readonly _data$: BehaviorSubject<T>;
+export class DtFilterFieldDefaultDataSource
+  implements DtFilterFieldDataSource<DtFilterFieldDefaultDataSourceType> {
+  private readonly _data$: BehaviorSubject<DtFilterFieldDefaultDataSourceType>;
 
   /** Structure of data that is used, transformed and rendered by the filter-field. */
-  get data(): T {
+  get data(): DtFilterFieldDefaultDataSourceType {
     return this._data$.value;
   }
-  set data(data: T) {
+  set data(data: DtFilterFieldDefaultDataSourceType) {
     this._data$.next(data);
   }
 
-  constructor(initialData: T = (null as unknown) as T) {
-    this._data$ = new BehaviorSubject<T>(initialData);
+  constructor(initialData: DtFilterFieldDefaultDataSourceType) {
+    this._data$ = new BehaviorSubject<DtFilterFieldDefaultDataSourceType>(
+      initialData,
+    );
   }
 
   /**
@@ -182,7 +183,7 @@ export class DtFilterFieldDefaultDataSource<
    * Should return a stream of data that will be transformed, filtered and
    * displayed by the DtFilterFieldViewer (filter-field)
    */
-  connect(): Observable<DtNodeDef | null> {
+  connect(): Observable<DtNodeDef<DtFilterFieldDefaultDataSourceType> | null> {
     return this._data$.pipe(map((data) => this.transformObject(data)));
   }
 
@@ -230,7 +231,7 @@ export class DtFilterFieldDefaultDataSource<
   /** Transforms the provided data into a DtNodeDef which contains a DtAutocompleteDef. */
   transformAutocomplete(
     data: DtFilterFieldDefaultDataSourceAutocomplete,
-  ): DtNodeDef {
+  ): DtNodeDef<DtFilterFieldDefaultDataSourceAutocomplete> {
     const def = dtAutocompleteDef(
       data,
       null,
@@ -248,19 +249,24 @@ export class DtFilterFieldDefaultDataSource<
   /** Transforms the provided data into a DtNodeDef which contains a DtOptionDef. */
   transformOption(
     data: DtFilterFieldDefaultDataSourceOption,
-    parentAutocompleteOrOption: DtNodeDef | null = null,
-    existingDef: DtNodeDef | null = null,
-  ): DtNodeDef {
-    const parentGroup = isDtGroupDef(parentAutocompleteOrOption)
+    parentAutocompleteOrOption: DtNodeDef<
+      DtFilterFieldDefaultDataSourceType
+    > | null = null,
+    existingDef: DtNodeDef<DtFilterFieldDefaultDataSourceType> | null = null,
+  ): DtNodeDef<DtFilterFieldDefaultDataSourceOption> {
+    const parentGroup = isDtGroupDef<
+      DtFilterFieldDefaultDataSourceGroup,
+      DtFilterFieldDefaultDataSourceOption
+    >(parentAutocompleteOrOption as any)
       ? parentAutocompleteOrOption
       : null;
     const parentAutocomplete =
       parentGroup !== null
-        ? parentGroup.group.parentAutocomplete
+        ? parentGroup.group!.parentAutocomplete
         : isDtAutocompleteDef(parentAutocompleteOrOption)
         ? (parentAutocompleteOrOption as DtNodeDef)
         : null;
-    return dtOptionDef(
+    return dtOptionDef<DtFilterFieldDefaultDataSourceOption>(
       data,
       existingDef,
       data.name,
@@ -273,22 +279,25 @@ export class DtFilterFieldDefaultDataSource<
   /** Transforms the provided data into a DtNodeDef which contains a DtGroupDef. */
   transformGroup(
     data: DtFilterFieldDefaultDataSourceGroup,
-    parentAutocomplete: DtNodeDef | null = null,
-    existingDef: DtNodeDef | null = null,
-  ): DtNodeDef {
-    const def = dtGroupDef(
-      data,
-      existingDef,
-      data.name,
-      [],
-      parentAutocomplete,
-    );
-    def.group!.options = this.transformList(data.options, def);
+    parentAutocomplete: DtNodeDef<
+      DtFilterFieldDefaultDataSourceType
+    > | null = null,
+    existingDef: DtNodeDef<DtFilterFieldDefaultDataSourceType> | null = null,
+  ): DtNodeDef<DtFilterFieldDefaultDataSourceGroup> {
+    const def = dtGroupDef<
+      DtFilterFieldDefaultDataSourceGroup,
+      DtFilterFieldDefaultDataSourceOption
+    >(data, existingDef, data.name, [], parentAutocomplete);
+    def.group.options = this.transformList(data.options, def) as DtNodeDef<
+      DtFilterFieldDefaultDataSourceOption
+    >[];
     return def;
   }
 
   /** Transforms the provided data into a DtNodeDef which contains a DtFreeTextDef. */
-  transformFreeText(data: DtFilterFieldDefaultDataSourceFreeText): DtNodeDef {
+  transformFreeText(
+    data: DtFilterFieldDefaultDataSourceFreeText,
+  ): DtNodeDef<DtFilterFieldDefaultDataSourceFreeText> {
     const def = dtFreeTextDef(
       data,
       null,
@@ -301,7 +310,9 @@ export class DtFilterFieldDefaultDataSource<
   }
 
   /** Transforms the provided data into a DtNodeDef which contains a DtRangeDef. */
-  transformRange(data: DtFilterFieldDefaultDataSourceRange): DtNodeDef {
+  transformRange(
+    data: DtFilterFieldDefaultDataSourceRange,
+  ): DtNodeDef<DtFilterFieldDefaultDataSourceRange> {
     return dtRangeDef(
       data,
       null,
@@ -317,9 +328,9 @@ export class DtFilterFieldDefaultDataSource<
   /** Transforms the provided data into a DtNodeDef. */
   transformObject(
     data: DtFilterFieldDefaultDataSourceType | null,
-    parent: DtNodeDef | null = null,
-  ): DtNodeDef | null {
-    let def: DtNodeDef | null = null;
+    parent: DtNodeDef<DtFilterFieldDefaultDataSourceType> | null = null,
+  ): DtNodeDef<DtFilterFieldDefaultDataSourceType> | null {
+    let def: DtNodeDef<DtFilterFieldDefaultDataSourceType> | null = null;
     if (this.isAutocomplete(data)) {
       def = this.transformAutocomplete(data);
     } else if (this.isFreeText(data)) {
@@ -331,7 +342,11 @@ export class DtFilterFieldDefaultDataSource<
     if (this.isGroup(data)) {
       def = this.transformGroup(data);
     } else if (this.isOption(data)) {
-      def = this.transformOption(data, parent, def);
+      def = this.transformOption(
+        data,
+        parent as DtNodeDef<DtFilterFieldDefaultDataSourceAutocomplete>,
+        def,
+      );
     }
     return def;
   }
@@ -339,10 +354,12 @@ export class DtFilterFieldDefaultDataSource<
   /** Transforms the provided list of data objects into an array of DtNodeDefs. */
   transformList(
     list: Array<DtFilterFieldDefaultDataSourceType>,
-    parent: DtNodeDef | null = null,
-  ): DtNodeDef[] {
+    parent: DtNodeDef<DtFilterFieldDefaultDataSourceType> | null = null,
+  ): DtNodeDef<DtFilterFieldDefaultDataSourceType>[] {
     return list
       .map((item) => this.transformObject(item, parent))
-      .filter((item) => item !== null) as DtNodeDef[];
+      .filter((item) => item !== null) as DtNodeDef<
+      DtFilterFieldDefaultDataSourceType
+    >[];
   }
 }

--- a/libs/barista-components/filter-field/src/filter-field-util.spec.ts
+++ b/libs/barista-components/filter-field/src/filter-field-util.spec.ts
@@ -779,7 +779,7 @@ describe('DtFilterField Util', () => {
           [],
           false,
           false,
-        );
+        ) as any;
         expect(optionSelectedPredicate(optionDef, selectedIds, false)).toBe(
           true,
         );
@@ -806,7 +806,7 @@ describe('DtFilterField Util', () => {
           [],
           false,
           false,
-        );
+        ) as any;
         expect(optionSelectedPredicate(optionDef, selectedIds, true)).toBe(
           false,
         );
@@ -946,21 +946,21 @@ describe('DtFilterField Util', () => {
   describe('defDistinctPredicate', () => {
     it('should return true if an autocomplete is async and also an option; it is not selected and not distinct', () => {
       let def = dtAutocompleteDef({}, null, [], false, true);
-      def = dtOptionDef({}, null, 'foo', 'id0', def, null);
+      def = dtOptionDef({}, null, 'foo', 'id0', def, null) as any;
       const ids = new Set(['id1']);
       expect(defDistinctPredicate(def, ids, false)).toBe(true);
     });
 
     it('should return true if an autocomplete is async and also an option; it is selected but not distinct', () => {
       let def = dtAutocompleteDef({}, null, [], false, true);
-      def = dtOptionDef({}, def, 'foo', 'id0', def, null);
+      def = dtOptionDef({}, def, 'foo', 'id0', def, null) as any;
       const ids = new Set(['id0', 'id1']);
       expect(defDistinctPredicate(def, ids, false)).toBe(true);
     });
 
     it('should return false if an autocomplete is async and also an option; it is selected and distinct', () => {
       let def = dtAutocompleteDef({}, null, [], true, true);
-      def = dtOptionDef({}, null, 'foo', 'id0', def, null);
+      def = dtOptionDef({}, null, 'foo', 'id0', def, null) as any;
       const ids = new Set(['id0', 'id1']);
       expect(defDistinctPredicate(def, ids, false)).toBe(false);
     });
@@ -1196,7 +1196,7 @@ describe('DtFilterField Util', () => {
         null,
         null,
         null,
-      ) as _DtAutocompleteValue;
+      ) as _DtAutocompleteValue<any>;
       const b = dtOptionDef(
         optionSource,
         null,
@@ -1204,7 +1204,7 @@ describe('DtFilterField Util', () => {
         null,
         null,
         null,
-      ) as _DtAutocompleteValue;
+      ) as _DtAutocompleteValue<any>;
       expect(isDtAutocompleteValueEqual(a, b)).toBeTruthy();
       expect(isDtAutocompleteValueEqual(b, a)).toBeTruthy();
     });
@@ -1217,7 +1217,7 @@ describe('DtFilterField Util', () => {
         `${optionSource.name}${DELIMITER}`,
         null,
         null,
-      ) as _DtAutocompleteValue;
+      ) as _DtAutocompleteValue<any>;
       const b = dtOptionDef(
         optionSource,
         null,
@@ -1225,7 +1225,7 @@ describe('DtFilterField Util', () => {
         null,
         null,
         null,
-      ) as _DtAutocompleteValue;
+      ) as _DtAutocompleteValue<any>;
       expect(isDtAutocompleteValueEqual(a, b)).toBeTruthy();
       expect(isDtAutocompleteValueEqual(b, a)).toBeTruthy();
     });
@@ -1240,7 +1240,7 @@ describe('DtFilterField Util', () => {
         `${prefix}${optionSource.name}${DELIMITER}`,
         null,
         null,
-      ) as _DtAutocompleteValue;
+      ) as _DtAutocompleteValue<any>;
       const b = dtOptionDef(
         optionSource,
         null,
@@ -1248,7 +1248,7 @@ describe('DtFilterField Util', () => {
         null,
         null,
         null,
-      ) as _DtAutocompleteValue;
+      ) as _DtAutocompleteValue<any>;
       expect(isDtAutocompleteValueEqual(a, b, prefix)).toBeTruthy();
       expect(isDtAutocompleteValueEqual(b, a, prefix)).toBeTruthy();
     });
@@ -1262,7 +1262,7 @@ describe('DtFilterField Util', () => {
         null,
         null,
         null,
-      ) as _DtAutocompleteValue;
+      ) as _DtAutocompleteValue<any>;
       const optionSourceB = { name: 'Option 2' };
       const b = dtOptionDef(
         optionSourceB,
@@ -1271,7 +1271,7 @@ describe('DtFilterField Util', () => {
         null,
         null,
         null,
-      ) as _DtAutocompleteValue;
+      ) as _DtAutocompleteValue<any>;
       expect(isDtAutocompleteValueEqual(a, b)).toBeFalsy();
       expect(isDtAutocompleteValueEqual(b, a)).toBeFalsy();
     });
@@ -1284,7 +1284,7 @@ describe('DtFilterField Util', () => {
         null,
         null,
         null,
-      ) as _DtAutocompleteValue;
+      ) as _DtAutocompleteValue<any>;
       const optionSourceB = { name: 'Option 2' };
       const b = dtOptionDef(
         optionSourceB,
@@ -1293,7 +1293,7 @@ describe('DtFilterField Util', () => {
         `${optionSourceB.name}${DELIMITER}`,
         null,
         null,
-      ) as _DtAutocompleteValue;
+      ) as _DtAutocompleteValue<any>;
       expect(isDtAutocompleteValueEqual(a, b)).toBeFalsy();
       expect(isDtAutocompleteValueEqual(b, a)).toBeFalsy();
     });

--- a/libs/barista-components/filter-field/src/filter-field.spec.ts
+++ b/libs/barista-components/filter-field/src/filter-field.spec.ts
@@ -2159,9 +2159,7 @@ function isClearAllVisible(fixture: ComponentFixture<any>): boolean {
 })
 export class TestApp {
   // tslint:disable-next-line:no-any
-  dataSource = new DtFilterFieldDefaultDataSource<any>(
-    FILTER_FIELD_TEST_DATA_ASYNC,
-  );
+  dataSource = new DtFilterFieldDefaultDataSource(FILTER_FIELD_TEST_DATA_ASYNC);
 
   label = 'Filter by';
   clearAllLabel = 'Clear all';

--- a/libs/barista-components/filter-field/src/filter-field.ts
+++ b/libs/barista-components/filter-field/src/filter-field.ts
@@ -194,15 +194,15 @@ export class DtFilterField<T = any>
 
   /** The data source instance that should be connected to the filter field. */
   @Input()
-  get dataSource(): DtFilterFieldDataSource {
+  get dataSource(): DtFilterFieldDataSource<T> {
     return this._dataSource;
   }
-  set dataSource(dataSource: DtFilterFieldDataSource) {
+  set dataSource(dataSource: DtFilterFieldDataSource<T>) {
     if (this._dataSource !== dataSource) {
       this._switchDataSource(dataSource);
     }
   }
-  private _dataSource: DtFilterFieldDataSource;
+  private _dataSource: DtFilterFieldDataSource<T>;
   private _dataSubscription: Subscription | null;
   private _stateChanges = new Subject<void>();
   private _outsideClickSubscription: Subscription | null;
@@ -669,9 +669,10 @@ export class DtFilterField<T = any>
     if (!this._currentFilterValues.length && event.data.filterValues.length) {
       const value = event.data.filterValues[0];
       if (
-        (_isDtAutocompleteValue(value) && isDtAutocompleteDef(value)) ||
-        isDtRangeDef(value) ||
-        isDtFreeTextDef(value)
+        _isDtAutocompleteValue(value) &&
+        (isDtAutocompleteDef(value) ||
+          isDtRangeDef(value) ||
+          isDtFreeTextDef(value))
       ) {
         const removed = event.data.filterValues.splice(1);
         // Keep the removed values in the stashed member, to reapply them if necessary.
@@ -859,7 +860,7 @@ export class DtFilterField<T = any>
   private _handleAutocompleteSelected(
     event: DtAutocompleteSelectedEvent<DtNodeDef>,
   ): void {
-    const optionDef = event.option.value as _DtAutocompleteValue;
+    const optionDef = event.option.value as _DtAutocompleteValue<T>;
     this._peekCurrentFilterValues().push(optionDef);
     // Reset input value to empty string after handling the value provided by the autocomplete.
     // Otherwise the value of the autocomplete would be in the input elements and the next options
@@ -1061,7 +1062,7 @@ export class DtFilterField<T = any>
    * Takes a new data source and switches the filter date to the provided one.
    * Handles all the disconnecting and data switching.
    */
-  private _switchDataSource(dataSource: DtFilterFieldDataSource): void {
+  private _switchDataSource(dataSource: DtFilterFieldDataSource<T>): void {
     if (this._dataSource) {
       this._dataSource.disconnect();
     }
@@ -1208,7 +1209,7 @@ export class DtFilterField<T = any>
       currentFilterNodeDefsOrSources &&
       currentFilterNodeDefsOrSources.length
     ) {
-      const def = currentFilterNodeDefsOrSources[0];
+      const def = currentFilterNodeDefsOrSources[0] as _DtAutocompleteValue<T>;
       if (isDtOptionDef(def)) {
         this._filterByLabel = def.option.viewValue;
       }

--- a/libs/examples/src/filter-field/filter-field-async-example/filter-field-async-example.ts
+++ b/libs/examples/src/filter-field/filter-field-async-example/filter-field-async-example.ts
@@ -15,11 +15,9 @@
  */
 
 import { Component } from '@angular/core';
-
 import {
   DtFilterFieldCurrentFilterChangeEvent,
   DtFilterFieldDefaultDataSource,
-  DtFilterFieldDefaultDataSourceType,
 } from '@dynatrace/barista-components/filter-field';
 
 // tslint:disable: no-any
@@ -52,9 +50,7 @@ export class DtExampleFilterFieldAsync {
     autocomplete: [{ name: 'Linz' }, { name: 'Vienna' }, { name: 'Graz' }],
   };
 
-  _dataSource = new DtFilterFieldDefaultDataSource<
-    DtFilterFieldDefaultDataSourceType
-  >(this.DATA);
+  _dataSource = new DtFilterFieldDefaultDataSource(this.DATA);
 
   currentFilterChanged(
     event: DtFilterFieldCurrentFilterChangeEvent<any>,

--- a/libs/examples/src/filter-field/filter-field-clearall-example/filter-field-clearall-example.ts
+++ b/libs/examples/src/filter-field/filter-field-clearall-example/filter-field-clearall-example.ts
@@ -15,11 +15,9 @@
  */
 
 import { Component, ViewChild } from '@angular/core';
-
 import {
   DtFilterField,
   DtFilterFieldDefaultDataSource,
-  DtFilterFieldDefaultDataSourceType,
 } from '@dynatrace/barista-components/filter-field';
 
 @Component({
@@ -64,7 +62,5 @@ export class DtExampleFilterFieldClearall<T> {
   ];
   _filters = [this._linzFilter];
 
-  _dataSource = new DtFilterFieldDefaultDataSource<
-    DtFilterFieldDefaultDataSourceType
-  >(this.DATA);
+  _dataSource = new DtFilterFieldDefaultDataSource(this.DATA);
 }

--- a/libs/examples/src/filter-field/filter-field-default-example/filter-field-default-example.ts
+++ b/libs/examples/src/filter-field/filter-field-default-example/filter-field-default-example.ts
@@ -15,11 +15,7 @@
  */
 
 import { Component } from '@angular/core';
-
-import {
-  DtFilterFieldDefaultDataSource,
-  DtFilterFieldDefaultDataSourceType,
-} from '@dynatrace/barista-components/filter-field';
+import { DtFilterFieldDefaultDataSource } from '@dynatrace/barista-components/filter-field';
 
 @Component({
   selector: 'dt-example-filter-field-default',
@@ -56,7 +52,5 @@ export class DtExampleFilterFieldDefault {
     ],
   };
 
-  _dataSource = new DtFilterFieldDefaultDataSource<
-    DtFilterFieldDefaultDataSourceType
-  >(this.DATA);
+  _dataSource = new DtFilterFieldDefaultDataSource(this.DATA);
 }

--- a/libs/examples/src/filter-field/filter-field-disabled-example/filter-field-disabled-example.ts
+++ b/libs/examples/src/filter-field/filter-field-disabled-example/filter-field-disabled-example.ts
@@ -15,11 +15,7 @@
  */
 
 import { Component } from '@angular/core';
-
-import {
-  DtFilterFieldDefaultDataSource,
-  DtFilterFieldDefaultDataSourceType,
-} from '@dynatrace/barista-components/filter-field';
+import { DtFilterFieldDefaultDataSource } from '@dynatrace/barista-components/filter-field';
 
 @Component({
   selector: 'dt-example-filter-field-disabled',
@@ -60,9 +56,7 @@ export class DtExampleFilterFieldDisabled {
     ],
   };
 
-  _dataSource = new DtFilterFieldDefaultDataSource<
-    DtFilterFieldDefaultDataSourceType
-  >(this.DATA);
+  _dataSource = new DtFilterFieldDefaultDataSource(this.DATA);
 
   _filters = [
     // Filter AUT -> Vienna

--- a/libs/examples/src/filter-field/filter-field-distinct-example/filter-field-distinct-example.ts
+++ b/libs/examples/src/filter-field/filter-field-distinct-example/filter-field-distinct-example.ts
@@ -15,11 +15,7 @@
  */
 
 import { Component } from '@angular/core';
-
-import {
-  DtFilterFieldDefaultDataSource,
-  DtFilterFieldDefaultDataSourceType,
-} from '@dynatrace/barista-components/filter-field';
+import { DtFilterFieldDefaultDataSource } from '@dynatrace/barista-components/filter-field';
 
 @Component({
   selector: 'dt-example-filter-field-distinct',
@@ -44,7 +40,5 @@ export class DtExampleFilterFieldDistinct {
     ],
   };
 
-  _dataSource = new DtFilterFieldDefaultDataSource<
-    DtFilterFieldDefaultDataSourceType
-  >(this.DATA);
+  _dataSource = new DtFilterFieldDefaultDataSource(this.DATA);
 }

--- a/libs/examples/src/filter-field/filter-field-programmatic-filters-example/filter-field-programmatic-filters-example.ts
+++ b/libs/examples/src/filter-field/filter-field-programmatic-filters-example/filter-field-programmatic-filters-example.ts
@@ -15,11 +15,7 @@
  */
 
 import { Component } from '@angular/core';
-
-import {
-  DtFilterFieldDefaultDataSource,
-  DtFilterFieldDefaultDataSourceType,
-} from '@dynatrace/barista-components/filter-field';
+import { DtFilterFieldDefaultDataSource } from '@dynatrace/barista-components/filter-field';
 
 @Component({
   selector: 'dt-example-filter-field-programmatic-filters',
@@ -60,9 +56,7 @@ export class DtExampleFilterFieldProgrammaticFilters {
     ],
   };
 
-  _dataSource = new DtFilterFieldDefaultDataSource<
-    DtFilterFieldDefaultDataSourceType
-  >(this.DATA);
+  _dataSource = new DtFilterFieldDefaultDataSource(this.DATA);
 
   _filters = [
     // Filter AUT -> Vienna

--- a/libs/examples/src/filter-field/filter-field-readonly-non-editable-tags-example/filter-field-readonly-non-editable-tags-example.ts
+++ b/libs/examples/src/filter-field/filter-field-readonly-non-editable-tags-example/filter-field-readonly-non-editable-tags-example.ts
@@ -20,11 +20,9 @@ import {
   Component,
   ViewChild,
 } from '@angular/core';
-
 import {
   DtFilterField,
   DtFilterFieldDefaultDataSource,
-  DtFilterFieldDefaultDataSourceType,
 } from '@dynatrace/barista-components/filter-field';
 
 @Component({
@@ -69,9 +67,7 @@ export class DtExampleFilterFieldReadOnlyTags<T> implements AfterViewInit {
   ];
   _filters = [this._linzFilter];
 
-  _dataSource = new DtFilterFieldDefaultDataSource<
-    DtFilterFieldDefaultDataSourceType
-  >(this.DATA);
+  _dataSource = new DtFilterFieldDefaultDataSource(this.DATA);
 
   constructor(private _changeDetectorRef: ChangeDetectorRef) {}
 

--- a/libs/examples/src/filter-field/filter-field-unique-example/filter-field-unique-example.ts
+++ b/libs/examples/src/filter-field/filter-field-unique-example/filter-field-unique-example.ts
@@ -55,7 +55,5 @@ export class DtExampleFilterFieldUnique {
     ],
   };
 
-  _dataSource = new DtFilterFieldDefaultDataSource<
-    DtFilterFieldDefaultDataSourceType
-  >(this.DATA);
+  _dataSource = new DtFilterFieldDefaultDataSource(this.DATA);
 }


### PR DESCRIPTION
### <strong>Pull Request</strong>

feat(filter-field, quick-filter): Improved typing across the filter-field, it's node definitions, data-sources and the quick-filter component.

BREAKING CHANGE: 

- The filter-field data source as well as the quick-filter data source and their transform methods have Generics in place to define the structure of the passed in data. 
- The filter-fields default data-source no longer takes a generic, as the structure of the data is already defined there. 
- The Node definitions now take optional generics for the consumer to specify the structure of the data.