### PR TITLE
fix(core): Fixes issue with the `isNumber` util function

### DIFF
--- a/libs/barista-components/core/src/util/platform-util.ts
+++ b/libs/barista-components/core/src/util/platform-util.ts
@@ -114,7 +114,7 @@ export function _parseCssValue(
   input: any,
 ): { value: number; unit: string } | null {
   if (isNumber(input)) {
-    return { value: parseFloat(input), unit: 'px' };
+    return { value: input, unit: 'px' };
   }
   if (isString(input)) {
     const result = input.match(/^[\d\.]+/);

--- a/libs/barista-components/core/src/util/type-util.spec.ts
+++ b/libs/barista-components/core/src/util/type-util.spec.ts
@@ -17,7 +17,13 @@
 // tslint:disable no-lifecycle-call no-use-before-declare no-magic-numbers
 // tslint:disable no-any max-file-line-count no-unbound-method use-component-selector
 
-import { isDefined, isEmpty, isNumber, isObject } from './type-util';
+import {
+  isDefined,
+  isEmpty,
+  isNumber,
+  isObject,
+  isNumberLike,
+} from './type-util';
 
 describe('TypeUtil', () => {
   describe('isDefined', () => {
@@ -107,8 +113,8 @@ describe('TypeUtil', () => {
     it('should be false if the value is a string that cannot be converted', () => {
       expect(isNumber('random')).toBeFalsy();
     });
-    it('should be true if the value is a string can be converted', () => {
-      expect(isNumber('123')).toBeTruthy();
+    it('should be false if the value is a string can be converted', () => {
+      expect(isNumber('123')).toBeFalsy();
     });
     it('should be false if the value is a boolean', () => {
       expect(isNumber(true)).toBeFalsy();
@@ -124,6 +130,46 @@ describe('TypeUtil', () => {
       expect(isNumber(() => {})).toBeFalsy();
       expect(isNumber(A)).toBeFalsy();
       expect(isNumber(new A())).toBeFalsy();
+    });
+  });
+
+  describe('isNumberLike', () => {
+    it('should be false if the value is undefined or null', () => {
+      expect(isNumberLike(void 0)).toBeFalsy();
+      expect(isNumberLike(undefined)).toBeFalsy();
+      expect(isNumberLike(null)).toBeFalsy();
+    });
+    it('should be false if the value is an empty string', () => {
+      expect(isNumberLike('')).toBeFalsy();
+    });
+    it('should be true if the value is a number', () => {
+      expect(isNumberLike(-1)).toBeTruthy();
+      expect(isNumberLike(0)).toBeTruthy();
+      expect(isNumberLike(1)).toBeTruthy();
+    });
+    it('should be false if the value is a string containing numbers', () => {
+      expect(isNumberLike('123test')).toBeFalsy();
+    });
+    it('should be false if the value is a string that cannot be converted', () => {
+      expect(isNumberLike('random')).toBeFalsy();
+    });
+    it('should be true if the value is a string can be converted', () => {
+      expect(isNumberLike('123')).toBeTruthy();
+    });
+    it('should be false if the value is a boolean', () => {
+      expect(isNumberLike(true)).toBeFalsy();
+      expect(isNumberLike(false)).toBeFalsy();
+    });
+    it('should be false if the value is a symbol', () => {
+      expect(isNumberLike(Symbol('foo'))).toBeFalsy();
+    });
+    it('should be false if the value is a complex object or function', () => {
+      class A {}
+      expect(isNumberLike({})).toBeFalsy();
+      expect(isNumberLike([])).toBeFalsy();
+      expect(isNumberLike(() => {})).toBeFalsy();
+      expect(isNumberLike(A)).toBeFalsy();
+      expect(isNumberLike(new A())).toBeFalsy();
     });
   });
 

--- a/libs/barista-components/core/src/util/type-util.ts
+++ b/libs/barista-components/core/src/util/type-util.ts
@@ -15,26 +15,33 @@
  */
 
 /** Checks if the provided value is defined and not null */
-// tslint:disable-next-line:no-any
-export function isDefined(value: any): boolean {
-  return value !== void 0 && value !== null;
+export function isDefined<T>(value: T): value is NonNullable<T> {
+  return value !== null && value !== undefined;
 }
 
 /** Checks if the provided value is not empty and not null */
 // tslint:disable-next-line:no-any
-export function isEmpty(value: any): boolean {
+export function isEmpty(value: any): value is null | undefined | '' {
   return value === null || value === undefined || value === '';
 }
 
 /**
- * Checks if the provided value is a number
- * this function can be used to check for numbers instead of corceNumberProperty from the cdk
+ * Checks if the provided value is a number.
+ * This function can be used to check for numbers instead of coerceNumberProperty from the cdk
  * because coerceNumberProperty returns 0 for invalid values
  */
 // tslint:disable-next-line:no-any
-export function isNumber(value: any): boolean {
+export function isNumber(value: any): value is number {
+  return Number.isFinite(value);
+}
+
+/**
+ * Checks if the provided value is number like,
+ * which includes numbers or strings that can be easily converted to numbers.
+ */
+// tslint:disable-next-line: no-any
+export function isNumberLike(value: any): boolean {
   // parsefloat handles null, '', NaN, undefined - for everything else we check with Number
-  // tslint:disable-next-line:no-any
   return (
     typeof value !== 'symbol' &&
     !isNaN(parseFloat(value)) &&
@@ -44,12 +51,12 @@ export function isNumber(value: any): boolean {
 
 /** Checks if the provided value is a real object. */
 // tslint:disable-next-line: no-any
-export function isObject(value: any): boolean {
+export function isObject(value: any): value is { [key: string]: any } {
   return isDefined(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
 /** Helper function which evaluates if the passed value is a string. */
 // tslint:disable-next-line: no-any
-export function isString(value: any): boolean {
+export function isString(value: any): value is string {
   return typeof value === 'string';
 }

--- a/libs/barista-components/formatters/src/bits/bits.ts
+++ b/libs/barista-components/formatters/src/bits/bits.ts
@@ -17,7 +17,7 @@
 import { coerceNumberProperty } from '@angular/cdk/coercion';
 import { Pipe, PipeTransform } from '@angular/core';
 
-import { isEmpty, isNumber } from '@dynatrace/barista-components/core';
+import { isEmpty, isNumberLike } from '@dynatrace/barista-components/core';
 
 import { DtFormattedValue, NO_DATA } from '../formatted-value';
 import { KILO_MULTIPLIER } from '../number-formatter';
@@ -46,7 +46,7 @@ export class DtBits implements PipeTransform {
     if (input instanceof DtFormattedValue) {
       return formatBits(input, { factor, inputUnit });
     }
-    if (isNumber(input)) {
+    if (isNumberLike(input)) {
       return formatBits(coerceNumberProperty(input), { factor, inputUnit });
     }
 

--- a/libs/barista-components/formatters/src/bytes/bytes.ts
+++ b/libs/barista-components/formatters/src/bytes/bytes.ts
@@ -17,7 +17,7 @@
 import { coerceNumberProperty } from '@angular/cdk/coercion';
 import { Pipe, PipeTransform } from '@angular/core';
 
-import { isEmpty, isNumber } from '@dynatrace/barista-components/core';
+import { isEmpty, isNumberLike } from '@dynatrace/barista-components/core';
 
 import { DtFormattedValue, NO_DATA } from '../formatted-value';
 import { KILO_MULTIPLIER } from '../number-formatter';
@@ -48,7 +48,7 @@ export class DtBytes implements PipeTransform {
     if (input instanceof DtFormattedValue) {
       return formatBytes(input, { factor, inputUnit });
     }
-    if (isNumber(input)) {
+    if (isNumberLike(input)) {
       return formatBytes(coerceNumberProperty(input), { factor, inputUnit });
     }
 

--- a/libs/barista-components/formatters/src/bytes/kilobytes.ts
+++ b/libs/barista-components/formatters/src/bytes/kilobytes.ts
@@ -16,7 +16,7 @@
 
 import { Pipe, PipeTransform } from '@angular/core';
 
-import { isEmpty, isNumber } from '@dynatrace/barista-components/core';
+import { isEmpty, isNumberLike } from '@dynatrace/barista-components/core';
 
 import { DtFormattedValue, NO_DATA } from '../formatted-value';
 import { KILO_MULTIPLIER } from '../number-formatter';
@@ -51,7 +51,7 @@ export class DtKilobytes implements PipeTransform {
         outputUnit: DtUnit.KILO_BYTES,
       });
     }
-    if (isNumber(input)) {
+    if (isNumberLike(input)) {
       return formatBytes(input, {
         factor,
         inputUnit,

--- a/libs/barista-components/formatters/src/bytes/megabytes.ts
+++ b/libs/barista-components/formatters/src/bytes/megabytes.ts
@@ -17,7 +17,7 @@
 import { coerceNumberProperty } from '@angular/cdk/coercion';
 import { Pipe, PipeTransform } from '@angular/core';
 
-import { isEmpty, isNumber } from '@dynatrace/barista-components/core';
+import { isEmpty, isNumberLike } from '@dynatrace/barista-components/core';
 
 import { DtFormattedValue, NO_DATA } from '../formatted-value';
 import { KILO_MULTIPLIER } from '../number-formatter';
@@ -52,7 +52,7 @@ export class DtMegabytes implements PipeTransform {
         outputUnit: DtUnit.MEGA_BYTES,
       });
     }
-    if (isNumber(input)) {
+    if (isNumberLike(input)) {
       return formatBytes(coerceNumberProperty(input), {
         factor,
         inputUnit,

--- a/libs/barista-components/formatters/src/count/count.ts
+++ b/libs/barista-components/formatters/src/count/count.ts
@@ -17,7 +17,7 @@
 import { coerceNumberProperty } from '@angular/cdk/coercion';
 import { Pipe, PipeTransform } from '@angular/core';
 
-import { isEmpty, isNumber } from '@dynatrace/barista-components/core';
+import { isEmpty, isNumberLike } from '@dynatrace/barista-components/core';
 
 import { DtFormattedValue, NO_DATA } from '../formatted-value';
 import { DtUnit } from '../unit';
@@ -42,7 +42,7 @@ export class DtCount implements PipeTransform {
     if (input instanceof DtFormattedValue) {
       return formatCount(input, inputUnit);
     }
-    if (isNumber(input)) {
+    if (isNumberLike(input)) {
       return formatCount(coerceNumberProperty(input), inputUnit);
     }
 

--- a/libs/barista-components/formatters/src/duration/duration.ts
+++ b/libs/barista-components/formatters/src/duration/duration.ts
@@ -17,7 +17,7 @@
 import { coerceNumberProperty } from '@angular/cdk/coercion';
 import { Pipe, PipeTransform } from '@angular/core';
 
-import { isEmpty, isNumber } from '@dynatrace/barista-components/core';
+import { isEmpty, isNumberLike } from '@dynatrace/barista-components/core';
 
 import { DtFormattedValue, NO_DATA } from '../formatted-value';
 import { DtTimeUnit } from '../unit';
@@ -44,7 +44,7 @@ export class DtDuration implements PipeTransform {
     if (isEmpty(duration)) {
       return NO_DATA;
     }
-    return isNumber(duration)
+    return isNumberLike(duration)
       ? formatDuration(
           coerceNumberProperty(duration),
           formatMethod,

--- a/libs/barista-components/formatters/src/percent/percent.ts
+++ b/libs/barista-components/formatters/src/percent/percent.ts
@@ -16,7 +16,7 @@
 
 import { Pipe, PipeTransform } from '@angular/core';
 
-import { isEmpty, isNumber } from '@dynatrace/barista-components/core';
+import { isEmpty, isNumberLike } from '@dynatrace/barista-components/core';
 
 import { DtFormattedValue, NO_DATA } from '../formatted-value';
 import { formatPercent } from './percent-formatter';
@@ -35,7 +35,7 @@ export class DtPercent implements PipeTransform {
     if (isEmpty(input)) {
       return NO_DATA;
     }
-    if (isNumber(input)) {
+    if (isNumberLike(input)) {
       return formatPercent(input, maxPrecision);
     }
 

--- a/libs/barista-components/formatters/src/rate/rate.ts
+++ b/libs/barista-components/formatters/src/rate/rate.ts
@@ -17,7 +17,7 @@
 import { coerceNumberProperty } from '@angular/cdk/coercion';
 import { Pipe, PipeTransform } from '@angular/core';
 
-import { isEmpty, isNumber } from '@dynatrace/barista-components/core';
+import { isEmpty, isNumberLike } from '@dynatrace/barista-components/core';
 
 import { DtFormattedValue, NO_DATA } from '../formatted-value';
 import { DtRateUnit } from '../unit';
@@ -42,7 +42,7 @@ export class DtRate implements PipeTransform {
     if (input instanceof DtFormattedValue) {
       return formatRate(input, rateUnit);
     }
-    if (isNumber(input)) {
+    if (isNumberLike(input)) {
       return formatRate(coerceNumberProperty(input), rateUnit);
     }
 

--- a/libs/barista-components/pagination/src/pagination.ts
+++ b/libs/barista-components/pagination/src/pagination.ts
@@ -27,7 +27,7 @@ import {
 } from '@angular/core';
 import { AsyncSubject } from 'rxjs';
 
-import { isNumber } from '@dynatrace/barista-components/core';
+import { isNumberLike } from '@dynatrace/barista-components/core';
 
 import { calculatePages } from './pagination-calculate-pages';
 import {
@@ -65,7 +65,7 @@ export class DtPagination implements OnInit {
   }
   set length(value: number) {
     const length = coerceNumberProperty(value);
-    if (isNumber(value) && this._length !== length) {
+    if (isNumberLike(value) && this._length !== length) {
       this._length = length;
       this._updateItems();
       this._changeDetectorRef.markForCheck();
@@ -80,7 +80,7 @@ export class DtPagination implements OnInit {
   }
   set pageSize(value: number) {
     const pageSize = coerceNumberProperty(value);
-    if (isNumber(value) && this._pageSize !== pageSize) {
+    if (isNumberLike(value) && this._pageSize !== pageSize) {
       this._pageSize = pageSize;
       this._updateItems();
       this._changeDetectorRef.markForCheck();
@@ -95,7 +95,7 @@ export class DtPagination implements OnInit {
   }
   set currentPage(value: number) {
     const currentPage = coerceNumberProperty(value);
-    if (isNumber(value) && this._currentPage !== currentPage) {
+    if (isNumberLike(value) && this._currentPage !== currentPage) {
       this._currentPage = currentPage;
       this._updateItems();
       this._changeDetectorRef.markForCheck();

--- a/libs/barista-components/table/src/simple-columns/simple-number-column.ts
+++ b/libs/barista-components/table/src/simple-columns/simple-number-column.ts
@@ -21,7 +21,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 
-import { isDefined, isNumber } from '@dynatrace/barista-components/core';
+import { isDefined, isNumberLike } from '@dynatrace/barista-components/core';
 import { formatCount } from '@dynatrace/barista-components/formatters';
 
 import { DtTable } from '../table';
@@ -58,7 +58,7 @@ export class DtSimpleNumberColumn<T> extends DtSimpleColumnBase<T> {
       ? this.displayAccessor(data, this.name)
       : (data as any)[this.name]; // tslint:disable-line:no-any
 
-    if (isNumber(output) && !isDefined(this.formatter)) {
+    if (isNumberLike(output) && !isDefined(this.formatter)) {
       return formatCount(output);
     }
     return this.formatter ? this.formatter(output) : output;


### PR DESCRIPTION
### <strong>Pull Request</strong>

Fixes issue where the `isNumber` util function also returns true if it is a number-string. Added `isNumberLike` function for these number-string cases.

BREAKING CHANGE: `isNumber` now returns false for number strings like `"12"` as expected. Added `isNumberLike` function for these number-string cases.

#### Type of PR

Breaking change (fix or change that would cause existing functionality to not work as expected)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
