### PR TITLE
chore(chart): Change DtChartSeries types to match supported chart types

### DIFF
--- a/libs/barista-components/chart/src/chart.ts
+++ b/libs/barista-components/chart/src/chart.ts
@@ -53,9 +53,13 @@ import {
   chart,
   Chart,
   Options as HighchartsOptions,
-  SeriesOptions,
-  SeriesOptionsType,
   setOptions,
+  SeriesBarOptions,
+  SeriesColumnOptions,
+  SeriesLineOptions,
+  SeriesAreaOptions,
+  SeriesArearangeOptions,
+  SeriesPieOptions,
 } from 'highcharts';
 import { merge as lodashMerge } from 'lodash-es';
 import {
@@ -115,7 +119,13 @@ const HIGHCHARTS_PLOT_BACKGROUND = '.highcharts-plot-background';
 export type DtChartOptions = HighchartsOptions & {
   series?: undefined;
 };
-export type DtChartSeries = SeriesOptions;
+export type DtChartSeries =
+  | SeriesBarOptions
+  | SeriesColumnOptions
+  | SeriesLineOptions
+  | SeriesAreaOptions
+  | SeriesArearangeOptions
+  | SeriesPieOptions;
 
 // tslint:disable-next-line:no-any
 declare const window: any;
@@ -279,7 +289,7 @@ export class DtChart
   get seriesIds(): Array<string | undefined> | undefined {
     return (
       this._highchartsOptions.series &&
-      this._highchartsOptions.series.map((s: SeriesOptionsType) => s.id)
+      this._highchartsOptions.series.map((s: DtChartSeries) => s.id)
     );
   }
 

--- a/libs/examples/src/chart/chart-loading-example/chart-loading-example.ts
+++ b/libs/examples/src/chart/chart-loading-example/chart-loading-example.ts
@@ -22,6 +22,7 @@ import { DtChartSeries } from '@dynatrace/barista-components/chart';
 import { DtColors } from '@dynatrace/barista-components/theming';
 
 import { generateData } from '../chart-data-utils';
+import { SeriesLineOptions } from 'highcharts';
 
 @Component({
   selector: 'dt-example-chart-loading',
@@ -46,7 +47,7 @@ export class DtExampleChartLoading {
   series: DtChartSeries[] | null;
 
   toggleData(): void {
-    const dummyData = [
+    const dummyData: SeriesLineOptions[] = [
       {
         name: 'Failure rate',
         type: 'line',

--- a/libs/examples/src/chart/chart-stream-example/chart-stream-example.ts
+++ b/libs/examples/src/chart/chart-stream-example/chart-stream-example.ts
@@ -16,10 +16,10 @@
 
 // tslint:disable:no-magic-numbers
 import { Component } from '@angular/core';
-import { PlotSeriesOptions } from 'highcharts';
 import { Observable } from 'rxjs';
 
 import { DtChartExampleDataService } from '../chart-example-data.service';
+import { DtChartSeries } from '@dynatrace/barista-components/chart';
 
 @Component({
   selector: 'dt-example-chart-stream',
@@ -56,7 +56,7 @@ export class DtExampleChartStream {
     },
   };
 
-  series$: Observable<PlotSeriesOptions[]>;
+  series$: Observable<DtChartSeries[]>;
 
   constructor(private _chartService: DtChartExampleDataService) {
     this.series$ = this._chartService.getStreamedChartdata();


### PR DESCRIPTION
### <strong>Pull Request</strong>

This helps us have proper typing in other apps. Some other types that are derived from SeriesOptions don't have a data property which makes another check mandatory. Since all our consumers only have, column, bar, pie, area and area range this scopes it well enough