### PR TITLE
fix(table): Fixes an issue where the table tried to render after it was destroyed

### DIFF
--- a/libs/barista-components/table/src/cell.ts
+++ b/libs/barista-components/table/src/cell.ts
@@ -168,7 +168,7 @@ export class DtCell implements AfterContentInit, OnDestroy {
         .subscribe((sort: DtSortEvent) => {
           // If event is void, it is being unregisterd.
           this._isSorted = sort.active === this._columnDef.name;
-          this._changeDetectorRef.detectChanges();
+          this._changeDetectorRef.markForCheck();
         });
     }
 

--- a/libs/barista-components/table/src/table-data-source.ts
+++ b/libs/barista-components/table/src/table-data-source.ts
@@ -104,7 +104,7 @@ export class DtTableDataSource<T> extends DataSource<T> {
   private readonly _internalPageChanges = new Subject<void>();
 
   /** Used for unsubscribing */
-  private readonly _destroy = new Subject<void>();
+  private readonly _destroy$ = new Subject<void>();
 
   /**
    * Subscription to the changes that should trigger an update to the table's rendered rows, such
@@ -447,7 +447,7 @@ export class DtTableDataSource<T> extends DataSource<T> {
    */
   connect(_table: DtTable<T>): Observable<T[]> {
     _table._dataAccessors
-      .pipe(takeUntil(this._destroy))
+      .pipe(takeUntil(this._destroy$))
       .subscribe(({ comparatorMap, displayAccessorMap, sortAccessorMap }) => {
         this._displayAccessorMap = displayAccessorMap;
         this._simpleColumnSortAccessorMap = sortAccessorMap;
@@ -464,8 +464,8 @@ export class DtTableDataSource<T> extends DataSource<T> {
     this._renderChangesSubscription.unsubscribe();
     this._searchChangeSubscription.unsubscribe();
 
-    this._destroy.next();
-    this._destroy.complete();
+    this._destroy$.next();
+    this._destroy$.complete();
   }
 
   /**

--- a/libs/barista-components/table/src/table.ts
+++ b/libs/barista-components/table/src/table.ts
@@ -158,6 +158,7 @@ export class DtTable<T> extends _DtTableBase<T> implements OnDestroy {
   }
 
   ngOnDestroy(): void {
+    super.ngOnDestroy();
     this._destroy$.next();
     this._destroy$.complete();
     this._portalOutletSubscription.unsubscribe();


### PR DESCRIPTION
### <strong>Pull Request</strong>

After adding the simple columns and adding the ngOnDestroy to the table,
we missed to add the super call the the cdkTable that handled the disconnecting from
the dataSource.
This has now been added again and the datasource is correctly disconnected.

Fixes #1046

#### Type of PR
Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
