### PR TITLE
chore: Bump version to 7.0.0-rc.5 w/ changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [7.0.0-rc.4](https://github.com/dynatrace-oss/barista/compare/6.0.0...7.0.0-rc.4) (2020-05-20)
+## [7.0.0-rc.5](https://github.com/dynatrace-oss/barista/compare/6.0.0...7.0.0-rc.5) (2020-05-20)
 
 Most of the breaking changes will be fixed automatically by running
 `ng update @dynatrace/barista-components`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynatrace-oss/barista",
-  "version": "7.0.0-rc.4",
+  "version": "7.0.0-rc.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynatrace-oss/barista",
-  "version": "7.0.0-rc.4",
+  "version": "7.0.0-rc.5",
   "description": "",
   "scripts": {
     "build": "ng build",


### PR DESCRIPTION
This rc includes the change to initialize a DtFilterFieldDefaultDatasource without data.