### PR TITLE
fix: Missing styles definition for h3 #1081.

### DIFF
--- a/libs/barista-components/style/font-styles.scss
+++ b/libs/barista-components/style/font-styles.scss
@@ -17,6 +17,7 @@ h2 {
 }
 
 h3 {
+  @include dt-h3-font();
 }
 
 pre,


### PR DESCRIPTION
Bugfix: Missing style definition for  h3 (see #1081) has been restored.


#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
