### PR TITLE
fix(filter-field): Fixes an issue where the range caused an error after its destruction.

### DIFF
--- a/libs/barista-components/filter-field/src/filter-field-range/filter-field-range-trigger.ts
+++ b/libs/barista-components/filter-field/src/filter-field-range/filter-field-range-trigger.ts
@@ -196,12 +196,11 @@ export class DtFilterFieldRangeTrigger implements OnDestroy {
       this.range.closed.emit();
     }
 
-    this.range._isOpen = false;
-    this._detachOverlay();
-
     // Note that in some cases this can end up being called after the component is destroyed.
     // Add a check to ensure that we don't try to run change detection on a destroyed view.
     if (!this._componentDestroyed) {
+      this.range._isOpen = false;
+      this._detachOverlay();
       // We need to trigger change detection manually, because
       // `fromEvent` doesn't seem to do it at the proper time.
       // This ensures that the label is reset when the


### PR DESCRIPTION
### <strong>Pull Request</strong>

The range/filter-field was already destroyed when the filter-field state-advance was calling
closePanel, which led to an error on the client side.
Fixed by moving it into the check that was already there to prevent the same issue.

#### Type of PR
Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
