### PR TITLE
chore: Extend accepted barista-icons range up to version 7

### DIFF
--- a/libs/barista-components/package.json
+++ b/libs/barista-components/package.json
@@ -22,7 +22,7 @@
     "@angular/common": "{{NG_VERSION}}",
     "@angular/animations": "{{NG_VERSION}}",
     "@angular/forms": "{{NG_VERSION}}",
-    "@dynatrace/barista-icons": ">= 5.1.0 < 6",
+    "@dynatrace/barista-icons": ">= 5.1.0 < 7",
     "@dynatrace/barista-fonts": ">= 1.0.0 < 2",
     "d3-scale": "^3.0.0",
     "d3-shape": "^1.3.5",


### PR DESCRIPTION
### <strong>Pull Request</strong>

Extend the accepted range to version 7 as it is compatible with the icons usage within the library