### PR TITLE
chore: Fix module boundaries rules for library dependencies and restrict shared imports

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -90,6 +90,14 @@
               "type:shared",
               "type:types"
             ]
+          },
+          {
+            "sourceTag": "type:shared",
+            "onlyDependsOnLibsWithTags": ["type:shared"]
+          },
+          {
+            "sourceTag": "type:library",
+            "onlyDependsOnLibsWithTags": ["type:library", "type:shared"]
           }
         ]
       }


### PR DESCRIPTION
### <strong>Pull Request</strong>

Fixes an issue where it was not possible to import from `type:library |  type:shared` in `type:library`.

#### Type of PR
Other

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
