### PR TITLE
fix(table): Reorder input being cut off in Firefox.

### DIFF
--- a/libs/barista-components/table/src/order/order-cell.scss
+++ b/libs/barista-components/table/src/order/order-cell.scss
@@ -86,13 +86,13 @@
 }
 
 .dt-simple-order-cell-data {
-  display: inline-flex;
+  display: grid;
+  grid-template-columns: 1fr minmax(2.5rem, auto);
   align-items: center;
+  gap: 4px;
 }
 
 :host .dt-simple-order-column-icon {
-  margin-right: 4px;
-  width: auto;
   height: 1rem;
 }
 


### PR DESCRIPTION
Closes #1132

When the table column gets too narrow, the input is still being cut off, but at some point there's just no way around it...

### <strong>Pull Request</strong>

#### Type of PR

Bugfix (non-breaking change which fixes an issue)
<!-- Feature (non-breaking change which adds functionality) --!>
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
