### PR TITLE
build: Skip labeler on fork pull requests.

### DIFF
--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -4,6 +4,7 @@ on:
     types: [labeled]
 jobs:
   pull_request_labeler:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### <strong>Pull Request</strong>
Skipping the pull request labeler on fork prs, as it will not work there due to access restrictions

#### Type of PR

Build

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
