### PR TITLE
chore: Use later node source to download nodejs.

### DIFF
--- a/.deployment/k8s-barista-builder/Dockerfile
+++ b/.deployment/k8s-barista-builder/Dockerfile
@@ -23,7 +23,7 @@ LABEL maintainer="Dynatrace DesignOps Team <designops@dynatrace.com>" \
 USER root
 ARG NODE_VERSION
 
-RUN  curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - \
+RUN  curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash - \
   && apt-get update \
   && apt-get install -y libgtk-3-0 libasound2 libxss1 nodejs pv \
   && apt-get clean \


### PR DESCRIPTION
Fixes #1170
Failed to fetch the amd64 binary for node 10 so trying to upgrade to the
latest version as we install the specific node version with `n`. It does
not matter which version we use to download `n`.

![image](https://user-images.githubusercontent.com/11156362/85003458-87b03f80-b156-11ea-818c-649c89942218.png)

Building the image locally worked out great. Let's check if it is working on the ci after we merge this to master.

### <strong>Pull Request</strong>

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
