### PR TITLE
build: Remove stale labels when approvals are dismissed due to update.

### DIFF
--- a/tools/pull-request-labeler/src/utils/get-approval-count.ts
+++ b/tools/pull-request-labeler/src/utils/get-approval-count.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PullsListReviewsResponse } from '@octokit/rest';
+
+/** Get the amount of approvals on a pull request review list. */
+export function getApprovalCount(reviews: PullsListReviewsResponse): number {
+  return reviews.filter((review) => review.state === 'APPROVED').length;
+}

--- a/tools/pull-request-labeler/src/utils/get-pull-request-reviews.ts
+++ b/tools/pull-request-labeler/src/utils/get-pull-request-reviews.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { context, GitHub } from '@actions/github';
+import { PullsGetResponse, PullsListReviewsResponse } from '@octokit/rest';
+/**
+ * Get the Reviews from the pull request.
+ */
+export async function getPullRequestReviews(
+  client: GitHub,
+  prNumber: number,
+): Promise<PullsListReviewsResponse> {
+  const pullRequestTarget = await client.pulls.listReviews({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: prNumber,
+  });
+  return pullRequestTarget.data;
+}


### PR DESCRIPTION
### <strong>Pull Request</strong>

When a pull request is already labeld with merge ready and changes are pushed (effectively discarding the reviews) the labeler should run and remove the merge ready and target labels. 

Fixes #1161

#### Type of PR
Build / Workflow

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
