### PR TITLE
fix(table): Update table reorder examples due to api change.

### DIFF
--- a/apps/dev/src/table-order/table-order-demo.component.html
+++ b/apps/dev/src/table-order/table-order-demo.component.html
@@ -42,7 +42,11 @@
   cdkDropList
   [cdkDropListData]="dataSource1"
 >
-  <dt-simple-order-column name="order" label="Order"></dt-simple-order-column>
+  <ng-container [dtColumnDef]="'order'" dtColumnAlign="text">
+    <dt-header-cell *dtHeaderCellDef>Order</dt-header-cell>
+    <dt-order-cell *dtCellDef="let data; let index = index" [index]="index">
+    </dt-order-cell>
+  </ng-container>
   <ng-container dtColumnDef="host" dtColumnAlign="text">
     <dt-header-cell *dtHeaderCellDef>Host</dt-header-cell>
     <dt-cell *dtCellDef="let row">{{ row.host }}</dt-cell>

--- a/libs/barista-components/table/README.md
+++ b/libs/barista-components/table/README.md
@@ -268,21 +268,20 @@ direction. The event contains the following properties.
 
 ## Ordering
 
-The `DtOrder` and `dt-simple-order-column` in combination with Angular's
-`DragDropModule` are used to add ordering functionality to the table. To add
-ordering capabilities to a table, import the `DragDropModule` and add the
-`dtOrder` and `cdkDropList` directive and `cdkDropListData` input to the
-`dt-table` component.
+The `DtOrder` and `dt-order-cell` in combination with Angular's `DragDropModule`
+are used to add ordering functionality to the table. To add ordering
+capabilities to a table, import the `DragDropModule` and add the `dtOrder` and
+`cdkDropList` directive and `cdkDropListData` input to the `dt-table` component.
 
 ```html
 <dt-table ... dtOrder cdkDropList [cdkDropListData]="dataSource" ...></dt-table>
 ```
 
 The `cdkDropListData` gets the same data as the table's `dataSource` input. When
-combining the `dt-simple-order-column` with other `dt-simple-column`s, their
-`sortable` input should be set to false. The `DtTableOrderDataSource` does not
-mutate the original data when ordering, if you want to persist the ordered state
-you have to take care of that yourself.
+combining the `dt-order-cell` with `dt-simple-column`s, their `sortable` input
+should be set to false. The `DtTableOrderDataSource` does not mutate the
+original data when ordering, if you want to persist the ordered state you have
+to take care of that yourself.
 
 <ba-live-example name="DtExampleTableOrderColumn" fullWidth></ba-live-example>
 

--- a/libs/barista-components/table/src/simple-columns/simple-order-column.ts
+++ b/libs/barista-components/table/src/simple-columns/simple-order-column.ts
@@ -21,8 +21,6 @@ import {
 } from '@angular/core';
 
 import { DtSimpleColumnBase } from './simple-column-base';
-import { DtTableOrderDataSource } from '../table-order-data-source';
-import { Observable } from 'rxjs';
 
 /**
  * @deprecated Using a simple order column does not work after angular version 9.1.6 anymore -
@@ -46,10 +44,4 @@ import { Observable } from 'rxjs';
     { provide: DtSimpleColumnBase, useExisting: DtSimpleOrderColumn },
   ],
 })
-export class DtSimpleOrderColumn<T> extends DtSimpleColumnBase<T> {
-  _getIndex(data: T): Observable<number> {
-    return (this.table.dataSource as DtTableOrderDataSource<
-      T
-    >)._dataIndexObservableMap.get(data)!;
-  }
-}
+export class DtSimpleOrderColumn<T> extends DtSimpleColumnBase<T> {}

--- a/libs/examples/src/table/table-order-column-example/table-order-column-example.html
+++ b/libs/examples/src/table/table-order-column-example/table-order-column-example.html
@@ -5,11 +5,11 @@
   cdkDropList
   [cdkDropListData]="dataSource"
 >
-  <dt-simple-order-column
-    name="order"
-    label="Order"
-    dtColumnProportion="0.2"
-  ></dt-simple-order-column>
+  <ng-container [dtColumnDef]="'order'" dtColumnAlign="text">
+    <dt-header-cell *dtHeaderCellDef>Order</dt-header-cell>
+    <dt-order-cell *dtCellDef="let data; let index = index" [index]="index">
+    </dt-order-cell>
+  </ng-container>
   <dt-simple-text-column
     name="name"
     label="Rule name"

--- a/libs/examples/src/table/table-order-expandable-example/table-order-expandable-example.html
+++ b/libs/examples/src/table/table-order-expandable-example/table-order-expandable-example.html
@@ -5,7 +5,11 @@
   cdkDropList
   [cdkDropListData]="dataSource"
 >
-  <dt-simple-order-column name="order" label="Order"></dt-simple-order-column>
+  <ng-container [dtColumnDef]="'order'" dtColumnAlign="text">
+    <dt-header-cell *dtHeaderCellDef>Order</dt-header-cell>
+    <dt-order-cell *dtCellDef="let data; let index = index" [index]="index">
+    </dt-order-cell>
+  </ng-container>
   <ng-container dtColumnDef="host" dtColumnAlign="text">
     <dt-header-cell *dtHeaderCellDef>Host</dt-header-cell>
     <dt-cell *dtCellDef="let row">{{ row.host }}</dt-cell>

--- a/libs/examples/src/table/table-order-observable-example/table-order-observable-example.html
+++ b/libs/examples/src/table/table-order-observable-example/table-order-observable-example.html
@@ -20,7 +20,11 @@
   cdkDropList
   [cdkDropListData]="dataSource"
 >
-  <dt-simple-order-column name="order" label="Order"></dt-simple-order-column>
+  <ng-container [dtColumnDef]="'order'" dtColumnAlign="text">
+    <dt-header-cell *dtHeaderCellDef>Order</dt-header-cell>
+    <dt-order-cell *dtCellDef="let data; let index = index" [index]="index">
+    </dt-order-cell>
+  </ng-container>
   <ng-container dtColumnDef="host" dtColumnAlign="text">
     <dt-header-cell *dtHeaderCellDef>Host</dt-header-cell>
     <dt-cell *dtCellDef="let row">{{ row.host }}</dt-cell>


### PR DESCRIPTION
### <strong>Pull Request</strong>

Deleted leftover `_getIndex` method (`simple-order-column.ts`) and updated all the examples of the reorder tables.

#### Type of PR

Bugfix (non-breaking change which fixes an issue)
<!-- Feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
Documentation update (changes to documentation)
<!-- Other (if none of the above apply) -->

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
