### PR TITLE
Bugfix/event chart decimals

### DIFF
--- a/libs/barista-components/event-chart/src/event-chart.ts
+++ b/libs/barista-components/event-chart/src/event-chart.ts
@@ -92,7 +92,7 @@ const EVENT_BUBBLE_SPACING = 4;
 
 const EVENT_BUBBLE_OVERLAP_THRESHOLD = EVENT_BUBBLE_SIZE / 2;
 const TICK_HEIGHT = 24;
-const TICK_WIDTH = 100;
+const TICK_WIDTH = 140;
 
 const LANE_HEIGHT = EVENT_BUBBLE_SIZE * 3;
 
@@ -839,7 +839,13 @@ export class DtEventChart<T> implements AfterContentInit, OnInit, OnDestroy {
       outputUnit = DtTimeUnit.SECOND;
     }
 
-    return formatDuration(timestamp, 'PRECISE', outputUnit);
+    return formatDuration(
+      timestamp,
+      'PRECISE',
+      outputUnit,
+      DtTimeUnit.MILLISECOND,
+      2,
+    );
   }
 }
 

--- a/libs/barista-components/formatters/README.md
+++ b/libs/barista-components/formatters/README.md
@@ -170,6 +170,7 @@ You can specify the following properties on your options:
 | `formatMethod` | `'DEFAULT | 'PRECISE' | number` | `'DEFAULT'`    | Formatting/Precision mode configuring the output |
 | `outputUnit`   | `DtTimeUnit`                    | `undefined`    | Which unit to transform the input to             |
 | `inputUnit`    | `DtTimeUnit`                    | `Milliseconds` | Which timeunit is used for the input             |
+| `maxDecimals`  | `number`                        | 5              | Max amount of decimals                           |
 
 #### Examples
 

--- a/libs/barista-components/formatters/src/duration/duration-formatter-utils/transform-result-precise.ts
+++ b/libs/barista-components/formatters/src/duration/duration-formatter-utils/transform-result-precise.ts
@@ -28,6 +28,7 @@ import { dtConvertToMilliseconds } from './convert-to-milliseconds';
  * @param inputUnit dtTimeUnit value describing which unit the duration is in
  * @param outputUnit dtTimeUnit | undefined value describing the unit to which it should format
  * @param formatMethod the formatting method
+ * @param maxDecimals max amount of decimals
  */
 
 export function dtTransformResultPrecise(
@@ -35,20 +36,22 @@ export function dtTransformResultPrecise(
   inputUnit: DtTimeUnit,
   outputUnit: DtTimeUnit | undefined,
   formatMethod: DurationMode,
+  maxDecimals?: number,
 ): Map<DtTimeUnit, string> | undefined {
   const amount =
     inputUnit === DtTimeUnit.MILLISECOND
       ? duration
       : dtConvertToMilliseconds(duration, inputUnit);
   return outputUnit !== undefined
-    ? calcResult(amount!, formatMethod, outputUnit)
-    : calcResult(amount!, formatMethod, inputUnit);
+    ? calcResult(amount!, formatMethod, outputUnit, maxDecimals)
+    : calcResult(amount!, formatMethod, inputUnit, maxDecimals);
 }
 
 function calcResult(
   amount: number,
   formatMethod: DurationMode,
   unit: DtTimeUnit,
+  maxDecimals: number | undefined,
 ): Map<DtTimeUnit, string> {
   let result = new Map<DtTimeUnit, string>();
   if (formatMethod === 'PRECISE') {
@@ -56,6 +59,9 @@ function calcResult(
     // Need to move the comma since IEEE can't handle floating point numbers very well.
     if (unit === DtTimeUnit.MICROSECOND || unit === DtTimeUnit.NANOSECOND) {
       amount *= MOVE_COMMA;
+    }
+    if (maxDecimals) {
+      amount = Math.round(amount * 10 ** maxDecimals) / 10 ** maxDecimals;
     }
     result.set(unit, amount.toString());
   } else {

--- a/libs/barista-components/formatters/src/duration/duration-formatter.ts
+++ b/libs/barista-components/formatters/src/duration/duration-formatter.ts
@@ -31,12 +31,14 @@ import {
  * @param formatMethod the formatting method
  * @param outputUnit dtTimeUnit | undefined value describing the unit to which it should format e.g to seconds
  * @param inputUnit dtTimeUnit value describing which unit the duration is in (default: milliseconds)
+ * @param maxDecimals max amount of decimals
  */
 export function formatDuration(
   duration: number,
   formatMethod: DurationMode = 'DEFAULT',
   outputUnit?: DtTimeUnit,
   inputUnit: DtTimeUnit = DtTimeUnit.MILLISECOND,
+  maxDecimals?: number,
 ): DtFormattedValue | string {
   const inputData: SourceData = {
     input: duration,
@@ -52,7 +54,13 @@ export function formatDuration(
   }
   const result =
     outputUnit || formatMethod === 'PRECISE'
-      ? dtTransformResultPrecise(duration, inputUnit, outputUnit, formatMethod)
+      ? dtTransformResultPrecise(
+          duration,
+          inputUnit,
+          outputUnit,
+          formatMethod,
+          maxDecimals,
+        )
       : dtTransformResult(duration, inputUnit, formatMethod);
 
   // Return NO_DATA when inputUnit is invalid

--- a/libs/barista-components/formatters/src/duration/duration-functions-tests/transform-result-precise.spec.ts
+++ b/libs/barista-components/formatters/src/duration/duration-functions-tests/transform-result-precise.spec.ts
@@ -31,6 +31,7 @@ describe('DtDurationFormatter', () => {
     formatMethod: string;
     outPut: Output[];
     displayedOutPut: string;
+    maxDecimals?: number;
   }
 
   describe('dtTransformResultPrecise() with OutputUnit', () => {
@@ -225,6 +226,20 @@ describe('DtDurationFormatter', () => {
           displayedOutPut: '29629.656 h',
         },
         {
+          duration: 1234.569,
+          inputUnit: DtTimeUnit.DAY,
+          outputUnit: DtTimeUnit.HOUR,
+          formatMethod: 'PRECISE',
+          maxDecimals: 2,
+          outPut: [
+            {
+              timeUnit: DtTimeUnit.HOUR,
+              duration: '29629.66',
+            },
+          ],
+          displayedOutPut: '29629.66 h',
+        },
+        {
           duration: 12345.5,
           inputUnit: DtTimeUnit.MILLISECOND,
           outputUnit: DtTimeUnit.MICROSECOND,
@@ -285,6 +300,7 @@ describe('DtDurationFormatter', () => {
               testCase.inputUnit,
               testCase.outputUnit,
               formatMethod,
+              testCase.maxDecimals,
             )!,
           );
           testCase.outPut.forEach((output: Output, index) => {

--- a/libs/barista-components/formatters/src/duration/duration.spec.ts
+++ b/libs/barista-components/formatters/src/duration/duration.spec.ts
@@ -39,6 +39,7 @@ describe('DtDurationPipe', () => {
     inputUnit: DtTimeUnit;
     outputUnit: DtTimeUnit | undefined;
     output: string;
+    maxDecimals?: number;
   }
 
   let pipe: DtDuration;
@@ -187,11 +188,19 @@ describe('DtDurationPipe', () => {
           output: '0.5 s',
         },
         {
-          input: 1.5,
+          input: 1234.5678,
           outputUnit: DtTimeUnit.SECOND,
           inputUnit: DtTimeUnit.MILLISECOND,
           precision: 'PRECISE',
-          output: '0.0015 s',
+          output: '1.2345678 s',
+        },
+        {
+          input: 1.6,
+          outputUnit: DtTimeUnit.SECOND,
+          inputUnit: DtTimeUnit.MILLISECOND,
+          precision: 'PRECISE',
+          output: '0.002 s',
+          maxDecimals: 3,
         },
         {
           input: 30000,
@@ -244,6 +253,7 @@ describe('DtDurationPipe', () => {
                 'PRECISE',
                 testCasePrecision.outputUnit,
                 testCasePrecision.inputUnit,
+                testCasePrecision.maxDecimals,
               )
               .toString()
               .trim(),

--- a/libs/barista-components/formatters/src/duration/duration.ts
+++ b/libs/barista-components/formatters/src/duration/duration.ts
@@ -34,12 +34,14 @@ export class DtDuration implements PipeTransform {
    * @param formatMethod DtDurationMode Configuration for formatting the output
    * @param outputUnit dtTimeUnit | undefined value describing the unit to which it should format
    * @param inputUnit dtTimeUnit value describing which unit the duration is in
+   * @param maxDecimals max amount of decimals
    */
   transform(
     duration: any,
     formatMethod: DurationMode,
     outputUnit: DtTimeUnit | undefined,
     inputUnit: DtTimeUnit = DtTimeUnit.MILLISECOND,
+    maxDecimals?: number,
   ): DtFormattedValue | string {
     if (isEmpty(duration)) {
       return NO_DATA;
@@ -50,6 +52,7 @@ export class DtDuration implements PipeTransform {
           formatMethod,
           outputUnit,
           inputUnit,
+          maxDecimals,
         )
       : NO_DATA;
   }

--- a/libs/examples/src/event-chart/event-chart-complex-selection-example/event-chart-complex-selection-example.html
+++ b/libs/examples/src/event-chart/event-chart-complex-selection-example/event-chart-complex-selection-example.html
@@ -6,28 +6,28 @@
   ></dt-event-chart-event>
   <dt-event-chart-event
     (selected)="triggerSelection($event)"
-    value="15"
+    value="15000"
     lane="xhr"
   ></dt-event-chart-event>
   <dt-event-chart-event
     (selected)="triggerSelection($event)"
-    value="25"
+    value="25000"
     lane="xhr"
   ></dt-event-chart-event>
   <dt-event-chart-event
     (selected)="triggerSelection($event)"
-    value="10"
+    value="10000"
     lane="user-event"
   ></dt-event-chart-event>
   <dt-event-chart-event
     (selected)="triggerSelection($event)"
-    value="35"
+    value="35000"
     lane="xhr"
     duration="15"
   ></dt-event-chart-event>
   <dt-event-chart-event
     (selected)="triggerSelection($event)"
-    value="75"
+    value="75000"
     lane="user-event"
   ></dt-event-chart-event>
 


### PR DESCRIPTION
Bugfix (non-breaking change which fixes an issue)
- Added a maxDecimals param in the DurationFormatter
- Use this param in event chart

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
