### PR TITLE
build(e2e): Create a custom builder that only passes affected sources into the e2e test environment.

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -148,7 +148,7 @@
             }
           }
         },
-        "e2e": {
+        "e2e-all": {
           "builder": "@politie/angular-testcafe-builder:testcafe",
           "options": {
             "devServerTarget": "components-e2e:serve",
@@ -194,6 +194,21 @@
               "stopOnFirstFail": false,
               "live": true,
               "concurrency": 1
+            }
+          }
+        },
+        "e2e": {
+          "builder": "./dist/libs/workspace:affected-e2e",
+          "options": {
+            "e2eTarget": "components-e2e:e2e-all",
+            "testAppSourceFolder": "./apps/components-e2e/src/"
+          },
+          "configurations": {
+            "remote-pr": {
+              "e2eTarget": "components-e2e:e2e-all:remote-pr"
+            },
+            "ci": {
+              "e2eTarget": "components-e2e:e2e-all:ci"
             }
           }
         },

--- a/libs/workspace/builders.json
+++ b/libs/workspace/builders.json
@@ -45,6 +45,11 @@
       "implementation": "./src/builders/elements/index",
       "schema": "./src/builders/elements/schema.json",
       "description": "Run individual element builds and package them into one publishable library"
+    },
+    "affected-e2e": {
+      "implementation": "./src/builders/affected-e2e/index",
+      "schema": "./src/builders/affected-e2e/schema.json",
+      "description": "Run affected e2e tests for components"
     }
   }
 }

--- a/libs/workspace/src/builders/affected-e2e/build.ts
+++ b/libs/workspace/src/builders/affected-e2e/build.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  BuilderContext,
+  BuilderOutput,
+  targetFromTargetString,
+} from '@angular-devkit/architect';
+import { AffectedE2EOptions } from './schema';
+import { Observable, from, forkJoin, of } from 'rxjs';
+import { map, switchMap, catchError } from 'rxjs/operators';
+import { green } from 'chalk';
+import { readNxJson } from '@nrwl/workspace';
+import { affectedArgs } from '../../scripts/affected-args';
+import { getAffectedProjects } from '../../scripts/util';
+import { findE2eModulesUsingAffectedComponents } from './utils/find-modules-using-affected-components';
+import { join } from 'path';
+import { transformModulePathToGlob } from './utils/transform-module-path-to-glob';
+
+/**
+ * Custom builder for run only affected e2e tests
+ * This builder will run all e2e tests that use components that are
+ * affected by the changeset
+ */
+export function affectedE2EBuilder(
+  options: AffectedE2EOptions,
+  context: BuilderContext,
+): Observable<BuilderOutput> {
+  context.logger.info(
+    green(
+      `Running only affected E2E tests for components, to run all use ng run components-e2e:e2e-all`,
+    ),
+  );
+  return from(affectedArgs()).pipe(
+    map((baseSha) => {
+      // Figure out which projects are affected in this one.
+      const projects = getAffectedProjects(baseSha);
+      const nxJson = readNxJson();
+      // Figure out which of the affected projects are actually components.
+      const affectedComponents = projects.filter((component) => {
+        return (nxJson.projects[component].tags || []).includes(
+          'scope:components',
+        );
+      });
+      return affectedComponents;
+    }),
+    switchMap((affectedComponents) => {
+      return findE2eModulesUsingAffectedComponents(
+        affectedComponents,
+        join(context.workspaceRoot, options.testAppSourceFolder),
+      );
+    }),
+    switchMap((affectedTestModules) => {
+      const globSource = affectedTestModules.map((affectedModule) =>
+        join(
+          options.testAppSourceFolder,
+          transformModulePathToGlob(affectedModule),
+        ),
+      );
+      context.logger.info(`
+Running e2e tests matching the following globs
+${globSource.map((comp) => `- ${comp}`).join('\n')}
+`);
+      const e2eTarget = targetFromTargetString(options.e2eTarget);
+      return context.scheduleTarget(e2eTarget, { src: globSource });
+    }),
+    // Wait for the output and result Observable to resolve
+    switchMap((build) => forkJoin(build.output, build.result)),
+    // Switch over to the result of the e2e target
+    map((results) => results[1]),
+    catchError((error: Error) => {
+      context.logger.error(error.stack!);
+      return of({
+        success: false,
+      });
+    }),
+  );
+}

--- a/libs/workspace/src/builders/affected-e2e/index.ts
+++ b/libs/workspace/src/builders/affected-e2e/index.ts
@@ -14,24 +14,11 @@
  * limitations under the License.
  */
 
-import { execSync } from 'child_process';
+import { createBuilder } from '@angular-devkit/architect';
+import { JsonObject } from '@angular-devkit/core';
+import { affectedE2EBuilder } from './build';
+import { AffectedE2EOptions } from './schema';
 
-/** Get a list of affected libraries with the target */
-export function getAffectedProjects(
-  baseSha: string,
-  target?: string,
-): string[] {
-  const command = [`npx nx print-affected`, `--base=${baseSha}`];
-
-  if (target) {
-    command.push(`--target=${target}`);
-  }
-
-  const affected = execSync(command.join(' ')).toString().trim();
-
-  const parsed = JSON.parse(affected);
-
-  return target
-    ? parsed.tasks.map((task) => task.target.project).sort()
-    : parsed.projects.sort();
-}
+export default createBuilder<AffectedE2EOptions & JsonObject>(
+  affectedE2EBuilder,
+);

--- a/libs/workspace/src/builders/affected-e2e/schema.json
+++ b/libs/workspace/src/builders/affected-e2e/schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "affected-e2e",
+  "type": "object",
+  "properties": {
+    "e2eTarget": {
+      "type": "string",
+      "description": "The target configuration that should be used."
+    },
+    "testAppSourceFolder": {
+      "type": "string",
+      "description": "The app root of the end to end test that should be scanned for modules using the affected components"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["e2eTarget", "testAppSourceFolder"],
+  "definitions": {}
+}

--- a/libs/workspace/src/builders/affected-e2e/schema.ts
+++ b/libs/workspace/src/builders/affected-e2e/schema.ts
@@ -14,24 +14,13 @@
  * limitations under the License.
  */
 
-import { execSync } from 'child_process';
-
-/** Get a list of affected libraries with the target */
-export function getAffectedProjects(
-  baseSha: string,
-  target?: string,
-): string[] {
-  const command = [`npx nx print-affected`, `--base=${baseSha}`];
-
-  if (target) {
-    command.push(`--target=${target}`);
-  }
-
-  const affected = execSync(command.join(' ')).toString().trim();
-
-  const parsed = JSON.parse(affected);
-
-  return target
-    ? parsed.tasks.map((task) => task.target.project).sort()
-    : parsed.projects.sort();
+/** The options that can be used with the elements builder */
+export interface AffectedE2EOptions {
+  /** Target of the configuration that should be scheduled */
+  e2eTarget: string;
+  /**
+   * The app root of the end to end test that should be scanned for
+   * modules using the affected components.
+   */
+  testAppSourceFolder: string;
 }

--- a/libs/workspace/src/builders/affected-e2e/utils/find-modules-using-affected-components.ts
+++ b/libs/workspace/src/builders/affected-e2e/utils/find-modules-using-affected-components.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { sync } from 'glob';
+import { join } from 'path';
+import { tsCreateSourceFile } from '@dynatrace/shared/node';
+import {
+  isImportDeclaration,
+  ImportDeclaration,
+  isStringLiteral,
+} from 'typescript';
+
+/**
+ * Checks if a module file imports a module that has been affected by
+ * the changeset.
+ */
+async function usesAffectedComponent(
+  filePath: string,
+  affectedComponents: string[],
+): Promise<boolean> {
+  const sourceFile = await tsCreateSourceFile(filePath);
+  const importsFromAffectedModules = sourceFile.statements
+    // Filter all statements that are import statements
+    .filter((statement) => isImportDeclaration(statement))
+    // Filter all import statements that import from @dynatrace/barista-components/
+    .filter((importStatement: ImportDeclaration) => {
+      const moduleSpecifier = importStatement.moduleSpecifier;
+      if (isStringLiteral(moduleSpecifier)) {
+        return (
+          moduleSpecifier.text.includes('@dynatrace/barista-components') &&
+          affectedComponents.some((component) =>
+            moduleSpecifier.text.includes(component),
+          )
+        );
+      }
+      return false;
+    });
+
+  return importsFromAffectedModules.length > 0;
+}
+
+/**
+ * Finds the modules within the e2e test app that are using one
+ * or more of the affected components passed.
+ */
+export async function findE2eModulesUsingAffectedComponents(
+  affectedComponents: string[],
+  appSourceFolder: string,
+): Promise<string[]> {
+  // Find all module.ts files within the target app
+  const moduleFilePaths = sync('**/*.module.ts', { cwd: appSourceFolder });
+
+  // Initilize an array of affected e2e modules.
+  const affectedE2EModules: string[] = [];
+
+  // Iterate over the modules and process them to find out if
+  // a module uses an effected component
+  for (const moduleFilePath of moduleFilePaths) {
+    const hasAffectedComponent = await usesAffectedComponent(
+      join(appSourceFolder, moduleFilePath),
+      affectedComponents,
+    );
+    if (hasAffectedComponent) {
+      affectedE2EModules.push(moduleFilePath);
+    }
+  }
+  return affectedE2EModules;
+}

--- a/libs/workspace/src/builders/affected-e2e/utils/transform-module-path-to-glob.ts
+++ b/libs/workspace/src/builders/affected-e2e/utils/transform-module-path-to-glob.ts
@@ -14,24 +14,12 @@
  * limitations under the License.
  */
 
-import { execSync } from 'child_process';
+import { dirname } from 'path';
 
-/** Get a list of affected libraries with the target */
-export function getAffectedProjects(
-  baseSha: string,
-  target?: string,
-): string[] {
-  const command = [`npx nx print-affected`, `--base=${baseSha}`];
-
-  if (target) {
-    command.push(`--target=${target}`);
-  }
-
-  const affected = execSync(command.join(' ')).toString().trim();
-
-  const parsed = JSON.parse(affected);
-
-  return target
-    ? parsed.tasks.map((task) => task.target.project).sort()
-    : parsed.projects.sort();
+/**
+ * Transform the module path to a test-cafe accessible
+ */
+export function transformModulePathToGlob(modulePath: string): string {
+  const containingDirectory = dirname(modulePath);
+  return `${containingDirectory}/**/*.{e2e,po}.ts`;
 }

--- a/libs/workspace/webpack.config.js
+++ b/libs/workspace/webpack.config.js
@@ -15,6 +15,7 @@ const entries = [
   'src/builders/design-tokens/dependency-tree/index.ts',
   'src/builders/design-tokens/tailwindcss/index.ts',
   'src/builders/elements/index.ts',
+  'src/builders/affected-e2e/index.ts',
   'src/schematics/dt-component-e2e/index.ts',
   'src/schematics/dt-component-dev/index.ts',
   'src/index.ts',


### PR DESCRIPTION
### <strong>Pull Request</strong>

Using the nx affected projects methods to figure out, which componenten modules are affected
and looking for these component modules within the imports of the e2e-testapp-modules
to determine which e2e tests need to be run.

Relates to #601 

#### Type of PR

Other

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
