### PR TITLE
barista: Fixes an issue with the TOC not being generated on strapi-only pages.

### DIFF
--- a/apps/barista-design-system/src/shared/services/scroll-spy.service.ts
+++ b/apps/barista-design-system/src/shared/services/scroll-spy.service.ts
@@ -57,21 +57,24 @@ export class BaScrollSpyService {
 
   /** Start spying on an element array of headlines returning a stream with the active item */
   spyOn(elements: Element[]): Observable<string | null> {
-    const headlines$ = this._zone.onStable.pipe(
-      take(1),
-      map(() => {
-        return this._calculateTopValues(elements);
-      }),
-    );
-    // Resize and Scroll trigger event calculates top values and active item.
-    return merge(
-      fromEvent(window, 'resize').pipe(auditTime(300)),
-      fromEvent(window, 'scroll').pipe(auditTime(50)),
-    ).pipe(
-      startWith(null),
-      withLatestFrom(headlines$),
-      map(([_ev, ele]) => this._findActiveItemId(ele)),
-    );
+    if (this._platform.isBrowser) {
+      const headlines$ = this._zone.onStable.pipe(
+        take(1),
+        map(() => {
+          return this._calculateTopValues(elements);
+        }),
+      );
+      // Resize and Scroll trigger event calculates top values and active item.
+      return merge(
+        fromEvent(window, 'resize').pipe(auditTime(300)),
+        fromEvent(window, 'scroll').pipe(auditTime(50)),
+      ).pipe(
+        startWith(null),
+        withLatestFrom(headlines$),
+        map(([_ev, ele]) => this._findActiveItemId(ele)),
+      );
+    }
+    return of(null);
   }
 
   /** Calculates top bounding properties for an element array */

--- a/libs/tools/barista/src/builder/strapi.ts
+++ b/libs/tools/barista/src/builder/strapi.ts
@@ -40,6 +40,7 @@ import {
   headingIdTransformer,
   copyHeadlineTransformer,
   relativeUrlTransformer,
+  tableOfContentGenerator,
 } from '../transform';
 
 const TRANSFORMERS: BaPageTransformer[] = [
@@ -47,6 +48,7 @@ const TRANSFORMERS: BaPageTransformer[] = [
   headingIdTransformer,
   copyHeadlineTransformer,
   relativeUrlTransformer,
+  tableOfContentGenerator,
 ];
 
 /** Page-builder for Strapi CMS pages. */


### PR DESCRIPTION
### <strong>Pull Request</strong>

The TOC transformer was not called on strapi only pages.
Additionally a platform check in the spyOn scrollspy was added to fix an issue with window access in
server side rendering.

Fixes #1219

#### Type of PR

Other

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
