### PR TITLE
chore: Update dependency to barista icons to ^7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5837,9 +5837,9 @@
       "integrity": "sha512-Bt8wSfDvn97UDvTJFVv3t/LU2KS7rLejaAQkjwKHkTT/UFSrapXf9vIklLXtNlvGPcOrxVCLTCemOkw9oQLocA=="
     },
     "@dynatrace/barista-icons": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@dynatrace/barista-icons/-/barista-icons-6.0.0.tgz",
-      "integrity": "sha512-a9WxXRNIGMz/bRuuShNzRjVgKTVEZzmIR0lPX2hoQ88+ECk+lsQrhar7VEczGYA+c6hHf4k/10taY9V6gX50Vw=="
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@dynatrace/barista-icons/-/barista-icons-7.3.0.tgz",
+      "integrity": "sha512-LCjhHl3AqffZ6sHF6O3paoZzMaVjBBICUiAqF8/ghgyXKqTp43X2Sl6BYFAeQKh0UVXfoIUnsUI7VbDG++6J+g=="
     },
     "@fullhuman/postcss-purgecss": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@angular/localize": "^9.1.11",
     "@angular/platform-browser": "^9.1.11",
     "@dynatrace/barista-fonts": "^1.0.0",
-    "@dynatrace/barista-icons": "^6.0.0",
+    "@dynatrace/barista-icons": "^7.3.0",
     "ansi-colors": "^4.1.1",
     "core-js": "^3.6.5",
     "d3-scale": "^3.0.0",


### PR DESCRIPTION
### <strong>Pull Request</strong>

Update the barista icons dependency to ^7 to have all currently supported icons show up on the overview pages. 

#### Type of PR
Other

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
