### PR TITLE
chore: Correct e2e test command to be runnable without CIRCLECI token

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "ng serve dev",
     "test": "npm run affected:test -- --parallel",
     "lint": "nx workspace-lint && npm run affected:lint -- --parallel && npm run affected:stylelint -- --parallel",
-    "e2e": "ng e2e components-e2e",
+    "e2e": "ng run components-e2e:e2e-all",
     "universal": "ng build universal",
     "postinstall": "node postinstall.js",
     "build:components": "npm run build components",


### PR DESCRIPTION
### <strong>Pull Request</strong>

After changing the default e2e target to the affected one, the one in the package.json should work without a CIRCLE_CI token.

#### Type of PR
Other
<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
