### PR TITLE
fix(filter-field): Fixes an issue with the infix when deleting a filter while in flight.

### DIFF
--- a/libs/barista-components/filter-field/src/filter-field.spec.ts
+++ b/libs/barista-components/filter-field/src/filter-field.spec.ts
@@ -901,6 +901,45 @@ describe('DtFilterField', () => {
       expect(options[2].textContent).toContain('Luzern');
       expect(options[3].textContent).toContain('St. Gallen');
     }));
+
+    it('should have the correct prefix when a filter is set and gets deleted in flight', () => {
+      filterField.focus();
+      advanceFilterfieldCycle();
+
+      // Set a filter first
+      getAndClickOption(overlayContainerElement, 1);
+      advanceFilterfieldCycle();
+      getAndClickOption(overlayContainerElement, 0);
+      advanceFilterfieldCycle();
+
+      // Get in flight of the next filter
+      getAndClickOption(overlayContainerElement, 0);
+      advanceFilterfieldCycle();
+
+      let category = fixture.debugElement.query(
+        By.css('.dt-filter-field-category'),
+      );
+      expect(category.nativeElement.textContent.trim()).toEqual('AUT');
+
+      // While in flight, delete the first tag
+      const tags = getFilterTags(fixture);
+      const { deleteButton } = getTagButtons(tags[0]);
+      deleteButton.click();
+      advanceFilterfieldCycle();
+
+      // Expect the category to still be there.
+      category = fixture.debugElement.query(
+        By.css('.dt-filter-field-category'),
+      );
+      expect(category).not.toBe(null);
+      expect(category.nativeElement.textContent.trim()).toEqual('AUT');
+
+      // Expect the options to be the same.
+      const options = getOptions(overlayContainerElement);
+      expect(options).toHaveLength(2);
+      expect(options[0].textContent).toContain('Upper Austria');
+      expect(options[1].textContent).toContain('Vienna');
+    });
   });
 
   describe('with range option', () => {

--- a/libs/barista-components/filter-field/src/filter-field.ts
+++ b/libs/barista-components/filter-field/src/filter-field.ts
@@ -981,7 +981,6 @@ export class DtFilterField<T = any>
       } else {
         this._updateTagData();
         this._updateAutocompleteOptionsOrGroups();
-        this._filterByLabel = '';
         this._emitFilterChanges([], removedFilters);
       }
       this._resetEditMode();


### PR DESCRIPTION
### <strong>Pull Request</strong>


When deleting an already set filter with the mouse, while the filter field is in the middle of
adding a new filter, the prefix was deleted.
There was a reset of the prefix, when a filter was deleted that is not the current filter, which is
removed in this commit. I could not find where this would have caused trouble.
I added a test for the current behaviour and have all other tests passing.

Fixes #1264

#### Type of PR
Bugfix
<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
