### PR TITLE
[table] limit dtIndicator styles inheritance

### DIFF
--- a/libs/barista-components/table/src/expandable/_expandable-row-theme.scss
+++ b/libs/barista-components/table/src/expandable/_expandable-row-theme.scss
@@ -11,7 +11,7 @@
   }
 
   :host {
-    .dt-expandable-row-base-expanded {
+    > .dt-expandable-row-base-expanded {
       border-top-color: $border-color;
 
       $bg-color: get-color($theme-name, 100);
@@ -35,7 +35,7 @@
     $default-color: dt-get-theme-color($palette, 'default');
 
     :host.dt-table-row-indicator.dt-color-#{$name}
-      .dt-expandable-row-base::before {
+      > .dt-expandable-row-base::before {
       background-color: $default-color;
     }
   }

--- a/libs/barista-components/table/src/expandable/expandable-row.scss
+++ b/libs/barista-components/table/src/expandable/expandable-row.scss
@@ -8,6 +8,7 @@
   &:nth-child(even) {
     background-color: #ffffff;
   }
+
   &:nth-child(odd) {
     background-color: $gray-100;
   }
@@ -56,18 +57,20 @@
   }
 }
 
-:host.dt-table-row-indicator .dt-expandable-row-base::before {
-  @include dt-table-row-indicator();
-}
+:host.dt-table-row-indicator > {
+  .dt-expandable-row-base::before {
+    @include dt-table-row-indicator();
+  }
 
-:host.dt-table-row-indicator .dt-expandable-row-base-collapsed:hover::before {
-  height: calc(100% - 6px);
-  left: 3px;
-}
+  .dt-expandable-row-base-collapsed:hover::before {
+    height: calc(100% - 6px);
+    left: 3px;
+  }
 
-:host.dt-table-row-indicator .dt-expandable-row-base-expanded::before {
-  height: calc(100% - 4px);
-  left: 4px;
+  .dt-expandable-row-base-expanded::before {
+    height: calc(100% - 4px);
+    left: 4px;
+  }
 }
 
 // Apply current theme


### PR DESCRIPTION
#### Type of PR
Fixes issue where active indicator on expandable-row is inherited by nested table(s)  expandable-row(s) with indicator

## Situation when nested tables inherited dtIndicator styles from main expandable-row 
rows where indicator is visible but text have standard color shouldn't be marked with indicator
![image](https://user-images.githubusercontent.com/1777108/87148548-de6ced00-c2ae-11ea-8cf4-4be0e4c637e0.png)


## After change
![image](https://user-images.githubusercontent.com/1777108/87148300-73231b00-c2ae-11ea-806a-7e049a6415a7.png)


Bugfix (non-breaking change which fixes an issue)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works
- [-] I have added necessary documentation (if appropriate)
