### PR TITLE
Next(top-nav): Section generator

### DIFF
--- a/apps/next/src/app/components/nav/nav.html
+++ b/apps/next/src/app/components/nav/nav.html
@@ -5,12 +5,12 @@
     </a>
     <nav class="next-nav-bar">
       <ul class="next-nav-list">
-        <li class="next-nav-item" *ngFor="let item of (_navData$)?.navItems">
+        <li class="next-nav-item" *ngFor="let item of (_navData$ | async)">
           <a
             class="next-nav-link"
-            [routerLink]="item.url"
+            [routerLink]="item.link"
             routerLinkActive="next-nav-link-active"
-            >{{ item.label }}</a
+            >{{ item.section }}</a
           >
         </li>
       </ul>

--- a/apps/next/src/app/components/nav/nav.ts
+++ b/apps/next/src/app/components/nav/nav.ts
@@ -16,6 +16,8 @@
 
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { ThemeService } from '../../theme.service';
+import { BaPageService } from '@dynatrace/shared/data-access-strapi';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'next-nav',
@@ -28,30 +30,16 @@ import { ThemeService } from '../../theme.service';
 })
 export class Nav {
   /** @internal Data needed to render the navigation. */
-  _navData$ = {
-    navItems: [
-      {
-        url: 'overview',
-        label: 'Overview',
-      },
-      {
-        url: 'design',
-        label: 'Design',
-      },
-      {
-        url: 'develop',
-        label: 'Develop',
-      },
-      {
-        url: 'components',
-        label: 'Components',
-      },
-      {
-        url: 'design-tokens',
-        label: 'Design Tokens',
-      },
-    ],
-  };
-
-  constructor(public _themeService: ThemeService) {}
+  _navData$ = this._pageService.getCategories().pipe(
+    map((data) =>
+      data.map((category) => ({
+        section: category,
+        link: category.toLowerCase(),
+      })),
+    ),
+  );
+  constructor(
+    public _themeService: ThemeService,
+    private _pageService: BaPageService,
+  ) {}
 }

--- a/libs/shared/data-access-strapi/src/lib/page.service.ts
+++ b/libs/shared/data-access-strapi/src/lib/page.service.ts
@@ -84,6 +84,17 @@ export class BaPageService<T = any> {
   }
 
   /**
+   * Provides an array of categories for the Design System as an observable.
+   */
+  getCategories(): Observable<string[]> {
+    const requestPath = `${this._baseHref}/data/categories.json`;
+
+    return this._http.get<string[]>(requestPath, {
+      responseType: 'json',
+    });
+  }
+
+  /**
    * Fetches page from data source.
    * @param id - page id (path).
    */

--- a/libs/tools/barista/src/builder/strapi.ts
+++ b/libs/tools/barista/src/builder/strapi.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { join } from 'path';
+import { join, dirname } from 'path';
 
 import {
   BaSinglePageMeta,
@@ -31,6 +31,7 @@ import {
   BaStrapiContentType,
   NextStrapiPage,
   NextContentType,
+  BaStrapiCategory,
 } from '../types';
 
 import { fetchContentList } from '@dynatrace/shared/data-access-strapi';
@@ -44,6 +45,7 @@ import {
   relativeUrlTransformer,
   tableOfContentGenerator,
 } from '../transform';
+import { mkdirSync, writeFileSync } from 'fs';
 
 const TRANSFORMERS: BaPageTransformer[] = [
   markdownToHtmlTransformer,
@@ -57,10 +59,10 @@ const TRANSFORMERS: BaPageTransformer[] = [
 export const strapiBuilder: BaPageBuilder = async (
   globalTransformers: BaPageTransformer[],
   next: boolean = false,
+  dsEnvironment: { distDir: string },
 ) => {
   // Return here if no endpoint is given.
   if (!environment.strapiEndpoint) {
-    console.log('No Strapi endpoint given.');
     return [];
   }
 
@@ -76,12 +78,34 @@ export const strapiBuilder: BaPageBuilder = async (
         environment.strapiEndpoint,
       );
 
+  let categoriesData: BaStrapiCategory[] = [];
+
+  categoriesData = await fetchContentList<BaStrapiCategory>(
+    BaStrapiContentType.Categories,
+    { publicContent: isPublicBuild() },
+    environment.strapiEndpoint,
+  );
+
+  categoriesData = next
+    ? categoriesData.filter((data) => data.nextpages.length > 0)
+    : categoriesData.filter((data) => data.pages.length > 0);
+
   // Filter pages with draft set to null or false
   pagesData = pagesData.filter((page) => !page.draft);
 
+  // Results from transforming the pagecontent
   const transformed: BaPageBuildResult[] = [];
 
+  // Array of categories for corresponding design systems
+  const categories: string[] = [];
+
   for (const page of pagesData) {
+    // Check if any pages have no a category assigned. These pages would be considered main pages.
+    // E.g. A page like the overview page describing the Design System itself does not relate to any category (angular-components or design-tokens for example).
+    // It is considered a main (or landing page) that the user should be able to navigate to.
+    if (next && page.category === null) {
+      categories.push(page.title);
+    }
     const pageDir = page.category ? page.category.title.toLowerCase() : '/';
     const relativeOutFile = page.slug
       ? join(pageDir, `${page.slug}.json`)
@@ -96,8 +120,30 @@ export const strapiBuilder: BaPageBuilder = async (
     transformed.push({ pageContent, relativeOutFile });
   }
 
+  categories.push(...categoriesData.map((category) => category.title));
+
+  writeCategoriesJson(dsEnvironment, categories);
+
   return transformed;
 };
+
+/**
+ * Creates a file containing an array of the categories from strapi
+ */
+function writeCategoriesJson(
+  dsEnvironment: { distDir: string },
+  categories: string[],
+): void {
+  const outFile = join(dsEnvironment.distDir, 'categories.json');
+
+  // Creating folder path if it does not exist
+  mkdirSync(dirname(outFile), { recursive: true });
+
+  // Write file with page content to disc.
+  writeFileSync(outFile, JSON.stringify(categories), {
+    encoding: 'utf8',
+  });
+}
 
 /**
  * Transform page metadata fetched from strapi

--- a/libs/tools/barista/src/main.ts
+++ b/libs/tools/barista/src/main.ts
@@ -91,6 +91,7 @@ async function createExampleInlineSourcesTransformer(): Promise<
 
   return exampleInlineSourcesTransformerFactory(JSON.parse(examplesMetadata));
 }
+/** Defines the paths for our DS's */
 const nextEnvironment = { distDir: 'dist/next-data' };
 const baristaEnvironment = { distDir: 'dist/barista-data' };
 
@@ -116,7 +117,7 @@ async function buildPages(): Promise<void[]> {
   const results = await builders.reduce<Promise<BaPageBuildResult[]>>(
     async (aggregatedResults, currentBuilder) => [
       ...(await aggregatedResults),
-      ...(await currentBuilder(globalTransformers, next)),
+      ...(await currentBuilder(globalTransformers, next, environment)),
     ],
     Promise.resolve([]),
   );

--- a/libs/tools/barista/src/types.ts
+++ b/libs/tools/barista/src/types.ts
@@ -63,6 +63,7 @@ export enum BaStrapiContentType {
   Pageteasers = 'pageteasers',
   CTAs = 'ctas',
   UXDNodes = 'decisiongraphs',
+  Categories = 'categories',
 }
 
 /** Base interface for Strapi content types */
@@ -80,6 +81,8 @@ export interface BaStrapiContributor extends BaStrapiBase, BaContributor {
 /** Strapi category */
 export interface BaStrapiCategory extends BaStrapiBase {
   title: string;
+  pages: string[];
+  nextpages: string[];
 }
 
 /** Strapi tag */


### PR DESCRIPTION
This PR removes the hardcoded top nav sections and adds a generator to the barista-tools, which creates a file containing the corresponding categories and saves them as a string array.
The top nav then displays that array.

Fixes: #1250 