### PR TITLE
style(select): Fixes border issue when select is used inside form-field

### DIFF
--- a/libs/barista-components/select/src/select.scss
+++ b/libs/barista-components/select/src/select.scss
@@ -34,7 +34,6 @@ $dt-select-panel-min-width: 112px !default;
 
   .dt-form-field-infix > & {
     border: none;
-    border-radius: 0;
     min-height: 30px;
   }
 


### PR DESCRIPTION
Bugfix (non-breaking change which fixes an issue)

Can be reproduce here:
https://barista.dynatrace.com/components/select#form-field

Problem is more visible on Firefox
![image](https://user-images.githubusercontent.com/1777108/87536643-b65c0000-c699-11ea-8ba2-c48240e33895.png)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
