### PR TITLE
style(input): Fixes extra outlines when places inside form-field

### DIFF
--- a/apps/dev/src/form-field/form-field-demo.component.html
+++ b/apps/dev/src/form-field/form-field-demo.component.html
@@ -27,3 +27,18 @@
     </dt-select>
   </dt-form-field>
 </div>
+
+<dt-form-field>
+  <dt-label>No nested focus outlines</dt-label>
+  <input
+    type="text"
+    dtInput
+    placeholder="Please insert amount"
+    aria-label="Please insert amount"
+  />
+  <dt-icon dtPrefix name="filter">$</dt-icon>
+  <dt-loading-spinner dtPrefix></dt-loading-spinner>
+  <button dt-icon-button dtSuffix variant="nested" aria-label="Submit changes">
+    <dt-icon name="checkmark"></dt-icon>
+  </button>
+</dt-form-field>

--- a/apps/dev/src/form-field/form-field-demo.component.scss
+++ b/apps/dev/src/form-field/form-field-demo.component.scss
@@ -1,3 +1,7 @@
 :host {
   display: block;
 }
+
+.dt-form-field {
+  margin-bottom: 8px;
+}

--- a/libs/barista-components/input/src/input.scss
+++ b/libs/barista-components/input/src/input.scss
@@ -33,9 +33,11 @@
     min-height: 30px;
   }
 
-  :not(.dt-form-field-infix) > &:focus:not([disabled]),
-  :not(.dt-inline-editor-infix) > &:focus:not([disabled]) {
-    @include dt-focus-style();
+  :host-context(:not(.dt-focused)) {
+    :not(.dt-form-field-infix) > &:focus:not([disabled]),
+    :not(.dt-inline-editor-infix) > &:focus:not([disabled]) {
+      @include dt-focus-style();
+    }
   }
 
   &[disabled] {


### PR DESCRIPTION
Bugfix (non-breaking change which fixes an issue)

Fixes #999

Before fix:
https://barista.dynatrace.com/components/form-field#prefix-and-suffix

After fix:
![barista-form-field-no-nested-outlines](https://user-images.githubusercontent.com/1777108/87538365-62064f80-c69c-11ea-87a7-fe6076e85ebd.gif)

#### Checklist
- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
