### PR TITLE
style: Unifying placeholder color for input, select and combobox

### DIFF
--- a/libs/barista-components/core/src/style/_form-control.scss
+++ b/libs/barista-components/core/src/style/_form-control.scss
@@ -66,3 +66,12 @@
   box-sizing: border-box;
   white-space: normal;
 }
+
+@mixin dt-form-control-placeholder() {
+  opacity: 1; // Because it's different in eg.: Firefox
+  color: $placeholdercolor;
+}
+
+@mixin dt-form-control-disabled-placeholder() {
+  color: $disabledcolor;
+}

--- a/libs/barista-components/core/src/style/_variables.scss
+++ b/libs/barista-components/core/src/style/_variables.scss
@@ -16,6 +16,7 @@ $textcolor: $gray-700;
 $focuscolor: $gray-300;
 $linkcolor: $turquoise-600;
 $disabledcolor: $gray-300;
+$placeholdercolor: $gray-500;
 
 $border-radius: 3px;
 $focus-outline-width: 2px;

--- a/libs/barista-components/experimental/combobox/src/combobox.scss
+++ b/libs/barista-components/experimental/combobox/src/combobox.scss
@@ -41,7 +41,7 @@
 
   .dt-combobox-input,
   .dt-combobox-input::placeholder {
-    color: $disabledcolor;
+    @include dt-form-control-disabled-placeholder();
   }
 }
 
@@ -77,6 +77,7 @@
 
 .dt-combobox-input::placeholder {
   @include dt-main-font();
+  @include dt-form-control-placeholder();
 }
 
 .dt-combobox-postfix {

--- a/libs/barista-components/input/src/input.scss
+++ b/libs/barista-components/input/src/input.scss
@@ -23,6 +23,14 @@
   outline: none;
   @include dt-form-control();
 
+  &::placeholder {
+    @include dt-form-control-placeholder();
+  }
+
+  &[disabled]::placeholder {
+    @include dt-form-control-disabled-placeholder();
+  }
+
   &:hover:not([disabled]) {
     border-color: $gray-500;
   }

--- a/libs/barista-components/select/src/select.scss
+++ b/libs/barista-components/select/src/select.scss
@@ -23,8 +23,12 @@ $dt-select-panel-min-width: 112px !default;
   }
 
   &.dt-select-disabled {
-    background-color: $gray-100;
+    background-color: $gray-130;
     color: $disabledcolor;
+
+    .dt-select-value .dt-select-placeholder {
+      @include dt-form-control-disabled-placeholder();
+    }
   }
 
   &.dt-select-open {
@@ -57,6 +61,10 @@ $dt-select-panel-min-width: 112px !default;
   // 29px to give the text a bit more room to breath. Safari breaks line with
   // 30 px (30px is the trigger size)
   width: calc(100% - 29px);
+
+  .dt-select-placeholder {
+    @include dt-form-control-placeholder();
+  }
 }
 
 .dt-select-value-text {


### PR DESCRIPTION
Bugfix (non-breaking change which fixes an issue)

Before:
![image](https://user-images.githubusercontent.com/1777108/87545957-127a5080-c6a9-11ea-9a1d-96f651489454.png)

After:
![image](https://user-images.githubusercontent.com/1777108/87545685-ab5c9c00-c6a8-11ea-86a3-a8b842ada64f.png)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes