### PR TITLE
feat(formatters): Added maxPrecision parameter to count formatters to…

### DIFF
--- a/libs/barista-components/formatters/README.md
+++ b/libs/barista-components/formatters/README.md
@@ -69,19 +69,21 @@ fields, which are described in a table below:
 The `formatCount` function provides a way to format numbers as abbreviations
 outside the template. The function takes the following parameters:
 
-| Name        | Type                        | Default      | Description                                                                                                                     |
-| ----------- | --------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| `input`     | `DtFormattedValue | number` |              | numeric value to be transformed by the pipe                                                                                     |
-| `inputUnit` | `DtUnit | string`           | `Unit.COUNT` | input unit, if not default - displayed together with the formatted value; does not yet support plurals and internationalization |
+| Name           | Type                        | Default      | Description                                                                                                                     |
+| -------------- | --------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `input`        | `DtFormattedValue | number` |              | numeric value to be transformed by the pipe                                                                                     |
+| `inputUnit`    | `DtUnit | string`           | `Unit.COUNT` | input unit, if not default - displayed together with the formatted value; does not yet support plurals and internationalization |
+| `maxPrecision` | `number`                    | 3            | maximum amount of digits to be used                                                                                             |
 
 ### Percent
 
 The `formatPercent` function provides a way to format percents, adjusting
 precision outside the template. The function takes the following parameters:
 
-| Name    | Type     | Default | Description                                 |
-| ------- | -------- | ------- | ------------------------------------------- |
-| `input` | `number` |         | numeric value to be transformed by the pipe |
+| Name           | Type     | Default | Description                                 |
+| -------------- | -------- | ------- | ------------------------------------------- |
+| `input`        | `number` |         | numeric value to be transformed by the pipe |
+| `maxPrecision` | `number` | 3       | maximum amount of digits to be used         |
 
 ### Bits
 

--- a/libs/barista-components/formatters/src/count/count-formatter.ts
+++ b/libs/barista-components/formatters/src/count/count-formatter.ts
@@ -26,10 +26,12 @@ import { DtUnit } from '../unit';
  * @param input - numeric value to be transformed
  * @param inputUnit - input unit, typically defined unit of type DtUnit (DtUnit.COUNT by default), custom strings are also allowed
  *    value is used only as a reference in case an additional rate pipe is used
+ * @param maxPrecision - The maximum amount of digits to be used, if provided
  */
 export function formatCount(
   input: DtFormattedValue | number,
   inputUnit: DtUnit | string = DtUnit.COUNT,
+  maxPrecision?: number,
 ): DtFormattedValue {
   const sourceData: SourceData =
     input instanceof DtFormattedValue
@@ -43,7 +45,7 @@ export function formatCount(
   const formattedData = !isNaN(value)
     ? {
         transformedValue: value,
-        displayValue: adjustNumber(value, true),
+        displayValue: adjustNumber(value, true, maxPrecision),
         displayUnit: inputUnit !== DtUnit.COUNT ? inputUnit : undefined,
         displayRateUnit:
           input instanceof DtFormattedValue

--- a/libs/barista-components/formatters/src/count/count.spec.ts
+++ b/libs/barista-components/formatters/src/count/count.spec.ts
@@ -22,6 +22,7 @@ describe('DtCount', () => {
   interface TestCase {
     input: number;
     inputUnit: DtUnit | string;
+    maxPrecision?: number;
     output: string;
   }
 
@@ -113,6 +114,47 @@ describe('DtCount', () => {
     it('should handle 0', () => {
       expect(pipe.transform('0').toString()).toEqual('0');
       expect(pipe.transform(0).toString()).toEqual('0');
+    });
+  });
+
+  describe('Transforming input with max precision', () => {
+    [
+      {
+        input: 0.50234,
+        inputUnit: DtUnit.COUNT,
+        maxPrecision: 0,
+        output: '< 1',
+      },
+      {
+        input: 1.50234,
+        inputUnit: DtUnit.COUNT,
+        maxPrecision: 0,
+        output: '2',
+      },
+      {
+        input: 20000001,
+        inputUnit: DtUnit.COUNT,
+        maxPrecision: 0,
+        output: '20mil',
+      },
+      {
+        input: 0.50234,
+        inputUnit: DtUnit.COUNT,
+        maxPrecision: 5,
+        output: '0.50234',
+      },
+    ].forEach((testCase: TestCase) => {
+      it(`should display ${testCase.input} without unit`, () => {
+        expect(
+          pipe
+            .transform(
+              testCase.input,
+              testCase.inputUnit,
+              testCase.maxPrecision,
+            )
+            .toString(),
+        ).toEqual(testCase.output);
+      });
     });
   });
 });

--- a/libs/barista-components/formatters/src/count/count.ts
+++ b/libs/barista-components/formatters/src/count/count.ts
@@ -30,20 +30,22 @@ export class DtCount implements PipeTransform {
   /**
    * @param input - The value to be formatted as an abbreviation
    * @param inputUnit - The unit for the input number. Default is DtUnit.COUNT
+   * @param maxPrecision - The maximum amount of digits to be used, if provided
    */
   transform(
     // tslint:disable-next-line:no-any
     input: any,
     inputUnit: DtUnit | string = DtUnit.COUNT,
+    maxPrecision?: number,
   ): DtFormattedValue | string {
     if (isEmpty(input)) {
       return NO_DATA;
     }
     if (input instanceof DtFormattedValue) {
-      return formatCount(input, inputUnit);
+      return formatCount(input, inputUnit, maxPrecision);
     }
     if (isNumberLike(input)) {
-      return formatCount(coerceNumberProperty(input), inputUnit);
+      return formatCount(coerceNumberProperty(input), inputUnit, maxPrecision);
     }
 
     return NO_DATA;

--- a/libs/barista-components/formatters/src/number-formatter.spec.ts
+++ b/libs/barista-components/formatters/src/number-formatter.spec.ts
@@ -194,6 +194,11 @@ describe('FormatterUtil', () => {
       },
       {
         input: 0.123456789,
+        maxPrecision: 0,
+        output: '< 1',
+      },
+      {
+        input: 0.123456789,
         maxPrecision: 1,
         output: '0.1',
       },
@@ -225,6 +230,11 @@ describe('FormatterUtil', () => {
       {
         input: 0.0001,
         output: '< 0.001',
+      },
+      {
+        input: 0.0001,
+        maxPrecision: 0,
+        output: '< 1',
       },
       {
         input: 0.0001,

--- a/libs/barista-components/formatters/src/number-formatter.ts
+++ b/libs/barista-components/formatters/src/number-formatter.ts
@@ -60,7 +60,7 @@ function adjustPrecision(value: number, maxPrecision?: number): string {
   const calcValue = Math.abs(value);
   const minValue =
     1 /
-    Math.pow(10, Math.max(maxPrecision || DEFAULT_PRECISION_FOR_MIN_VALUE, 0));
+    Math.pow(10, Math.max(maxPrecision ?? DEFAULT_PRECISION_FOR_MIN_VALUE, 0));
 
   let digits = 0;
   if (calcValue === 0) {
@@ -71,7 +71,7 @@ function adjustPrecision(value: number, maxPrecision?: number): string {
     } else {
       return `< ${minValue}`;
     }
-  } else if (maxPrecision) {
+  } else if (maxPrecision !== undefined) {
     digits = maxPrecision;
   } else if (calcValue < 1) {
     digits = 3;


### PR DESCRIPTION
… control the amount of decimals places

### <strong>Pull Request</strong>

<hr>

I need to configure the maximum amount of digits for the count formatter

The percent formatter can already be configured like that using the maxPrecision argument: https://github.com/dynatrace-oss/barista/blob/b2f11f8db6569c20c81f55ba72d9ae78a058c817/libs/barista-components/formatters/src/percent/percent.ts#L31

I would like to add the same argument to the count formatter.

#### Type of PR

Feature (non-breaking change which adds functionality)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
