### PR TITLE
fix(filter-field): Fixes an issue with the error validation when trying to submit an empty value.

### DIFF
--- a/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
@@ -72,6 +72,15 @@ test('should hide the error box when the node was deleted', async () => {
     .notOk();
 });
 
+test('should show the error box when the user tries to submit an empty value', async () => {
+  await clickOption(3)
+    .pressKey('enter', { speed: 0.1 })
+    .expect(errorBox.exists)
+    .ok()
+    .expect(errorBox.innerText)
+    .match(/field is required/gm);
+});
+
 test('should remove all filters when clicking the clear-all button', async () => {
   // Create a new filter by clicking the outer- and inner-option
   await clickOption(4);

--- a/libs/barista-components/filter-field/src/filter-field.ts
+++ b/libs/barista-components/filter-field/src/filter-field.ts
@@ -633,6 +633,13 @@ export class DtFilterField<T = any>
       }
       const value = this._inputEl.nativeElement.value;
       this._writeControlValue(value);
+      // Mark the value as dirty and touched to force a validation at this point
+      // If the user without typing anything wants to submit the value,
+      // the validation needs to run.
+      if (this._control) {
+        this._control.markAsDirty();
+        this._control.markAsTouched();
+      }
       this._validateInput();
       if (
         keyCode === ENTER &&


### PR DESCRIPTION
### <strong>Pull Request</strong>

Doe to the check that marked the control as dirty only if the value has changed, the validator never ran, when nothing was typed into the control field and only `Enter` was pressed to submit the filter. 

Fixes #1299

#### Type of PR
Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
