### PR TITLE
chore(transformer): Adds transformation step adding classes to headlines

### DIFF
--- a/libs/tools/barista/src/builder/strapi.ts
+++ b/libs/tools/barista/src/builder/strapi.ts
@@ -43,6 +43,7 @@ import {
   copyHeadlineTransformer,
   relativeUrlTransformer,
   tableOfContentGenerator,
+  headlineClassTransformer,
 } from '../transform';
 
 const TRANSFORMERS: BaPageTransformer[] = [
@@ -51,6 +52,7 @@ const TRANSFORMERS: BaPageTransformer[] = [
   copyHeadlineTransformer,
   relativeUrlTransformer,
   tableOfContentGenerator,
+  headlineClassTransformer,
 ];
 
 /** Page-builder for Strapi CMS pages. */

--- a/libs/tools/barista/src/transform.spec.ts
+++ b/libs/tools/barista/src/transform.spec.ts
@@ -27,6 +27,7 @@ import {
   internalContentTransformerFactory,
   relativeUrlTransformer,
   tableOfContentGenerator,
+  headlineClassTransformer,
 } from './transform';
 
 describe('Barista transformers', () => {
@@ -145,6 +146,20 @@ describe('Barista transformers', () => {
       });
       expect(transformed.content).toBe(
         '<h2 id="h1-definitions">1. Definitions.</h2>',
+      );
+    });
+  });
+
+  describe('headingClassTransformer', () => {
+    it('Should add classes to headlines corresponding to level of the element', async () => {
+      const content = `<h1>h1</h1><h2>h2</h2><h3>h3</h3><h4>h4</h4><h5>h5</h5>`;
+      const transformed = await headlineClassTransformer({
+        title: '',
+        layout: BaPageLayoutType.Default,
+        content,
+      });
+      expect(transformed.content).toBe(
+        '<h1 class="h1">h1</h1><h2 class="h2">h2</h2><h3 class="h3">h3</h3><h4 class="h4">h4</h4><h5 class="h5">h5</h5>',
       );
     });
   });

--- a/libs/tools/barista/src/transform.ts
+++ b/libs/tools/barista/src/transform.ts
@@ -184,6 +184,20 @@ export const headingIdTransformer: BaPageTransformer = async (source) => {
   return transformed;
 };
 
+/** Adds a class to a headline element named after the tagname of the element (e.g <h1>...</h1> -> <h1 class="h1">...</h1>) */
+export const headlineClassTransformer: BaPageTransformer = async (source) => {
+  const transformed = { ...source };
+  if (source.content && source.content.length) {
+    transformed.content = runWithCheerio(source.content, ($) => {
+      const headlines = $('h1, h2, h3, h4, h5, h6');
+      headlines.each((_, headline) => {
+        $(headline).addClass(headline.tagName);
+      });
+    });
+  }
+  return transformed;
+};
+
 /** Adds ids to each headline on the page. */
 export const copyHeadlineTransformer: BaPageTransformer = async (source) => {
   const transformed = { ...source };


### PR DESCRIPTION
### <strong>Pull Request</strong>

Adds a transformer that adds headline classes to headline elements
E.g.: `<h1>headline 1</h1>  =>  <h1 class="h1">headline 1</h1>`

P.S: The transformer is only transforming next pages!

Fixes: #1314 

#### Type of PR
Feature (non-breaking change which adds functionality

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
