### PR TITLE
fix(filter-field): Fixes an issue where the range stayed open when datasource updated.

### DIFF
--- a/libs/barista-components/filter-field/src/filter-field.ts
+++ b/libs/barista-components/filter-field/src/filter-field.ts
@@ -1100,6 +1100,16 @@ export class DtFilterField<T = any>
             this._removeFilter(this._currentFilterValues);
             this._currentFilterValues = [];
             this._filterByLabel = '';
+
+            // If the current def is a range during the reset,
+            // we need to handle a couple of extra things about the range, i.e.
+            // closing it and restoring the focus.
+            if (isDtRangeDef(this._currentDef)) {
+              if (this._filterfieldRange.isOpen) {
+                this._filterfieldRangeTrigger.closePanel();
+                this.focus();
+              }
+            }
           }
           this._currentDef = def;
           this._updateControl();


### PR DESCRIPTION
### <strong>Pull Request</strong>
When the data is newly set, the currentDef of the filter field is reset. But because the range
overlay was open, it held the focus which meant that the stateChanges iteration was not executed,
as this only executes its logic when the filterfield has focus.

Relates to #1256

#### Type of PR
Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
