### PR TITLE
Adds the value property to the checkboxes and a README to the switch webcomponent

### DIFF
--- a/apps/fluid-dev/src/pages/checkbox/checkbox-page.component.html
+++ b/apps/fluid-dev/src/pages/checkbox/checkbox-page.component.html
@@ -3,6 +3,7 @@
   [disabled]="disabled"
   [checked]="_isChecked()"
   [indeterminate]="_isIndeterminate()"
+  value="checkbox"
   (change)="changeAll($event)"
 >
   I am the label

--- a/apps/fluid-dev/src/pages/switch/switch-page.component.html
+++ b/apps/fluid-dev/src/pages/switch/switch-page.component.html
@@ -1,6 +1,7 @@
 <fluid-switch
   [disabled]="disabled"
   [checked]="checked"
+  value="switch"
   (change)="handleChange($event)"
   >Switch</fluid-switch
 >

--- a/libs/fluid-elements/checkbox/README.md
+++ b/libs/fluid-elements/checkbox/README.md
@@ -4,11 +4,12 @@ A basic representation of the checkbox input
 
 ## Properties
 
-| Property        | Attribute       | Type      | Default | Description                                 |
-| --------------- | --------------- | --------- | ------- | ------------------------------------------- |
-| `checked`       | `checked`       | `boolean` |         | Defines if the checkbox is checked or not.  |
-| `disabled`      | `disabled`      | `boolean` | false   | Defines if the checkbox is disabled or not. |
-| `indeterminate` | `indeterminate` | `boolean` |         | Indeterminate state property.               |
+| Property        | Attribute       | Type      | Default | Description                                     |
+| --------------- | --------------- | --------- | ------- | ----------------------------------------------- |
+| `checked`       | `checked`       | `boolean` |         | Defines if the checkbox is checked or not.      |
+| `disabled`      | `disabled`      | `boolean` | false   | Defines if the checkbox is disabled or not.     |
+| `indeterminate` | `indeterminate` | `boolean` |         | Indeterminate state property.                   |
+| `value`         | `value`         | `string`  | "on"    | The value attribute of the native input element |
 
 ## Methods
 

--- a/libs/fluid-elements/checkbox/src/lib/checkbox.spec.ts
+++ b/libs/fluid-elements/checkbox/src/lib/checkbox.spec.ts
@@ -218,6 +218,27 @@ describe('Fluid checkbox', () => {
     });
   });
 
+  describe('value', () => {
+    it('should have the correct default set', async () => {
+      const shadowedInput = fixture.shadowRoot?.querySelector('input');
+      expect(shadowedInput?.getAttribute('value')).toBe('on');
+    });
+
+    it('should set the value to customvalue when the property is set', async () => {
+      fixture.value = 'customvalue';
+      await tick();
+      const shadowedInput = fixture.shadowRoot?.querySelector('input');
+      expect(shadowedInput?.getAttribute('value')).toBe('customvalue');
+    });
+
+    it('should set the value to customvalue when the attribute is set', async () => {
+      fixture.setAttribute('value', 'customvalue');
+      await tick();
+      const shadowedInput = fixture.shadowRoot?.querySelector('input');
+      expect(shadowedInput?.getAttribute('value')).toBe('customvalue');
+    });
+  });
+
   describe('tabindex', () => {
     it('should have a tabindex on the triggerable element when enabled', () => {
       const checkbox = fixture.shadowRoot?.querySelector('svg');

--- a/libs/fluid-elements/checkbox/src/lib/checkbox.ts
+++ b/libs/fluid-elements/checkbox/src/lib/checkbox.ts
@@ -87,6 +87,11 @@ export class FluidCheckbox extends LitElement {
   })
   disabled = false;
 
+  /** The value attribute of the native input element */
+  @property({ type: String, reflect: true })
+  // Default string for the value is 'on' from MDN (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/checkbox#Additional_attributes)
+  value = 'on';
+
   /**
    * Defines if the checkbox is checked or not.
    * @attr
@@ -193,6 +198,7 @@ export class FluidCheckbox extends LitElement {
           type="checkbox"
           class="fluid-checkbox-input"
           id="${this._unique}"
+          value="${this.value}"
           ?checked="${this.checked}"
           ?disabled="${this.disabled}"
           @change="${this._handleInputChange}"

--- a/libs/fluid-elements/switch/README.md
+++ b/libs/fluid-elements/switch/README.md
@@ -1,0 +1,41 @@
+# fluid-switch
+
+A basic representation of the switch input
+
+## Properties
+
+| Property   | Attribute  | Type      | Default | Description                                     |
+| ---------- | ---------- | --------- | ------- | ----------------------------------------------- |
+| `checked`  | `checked`  | `boolean` |         | Whether the switch is considered `on` or `off`. |
+| `disabled` | `disabled` | `boolean` | false   | Whether the switch is disabled or not           |
+| `value`    | `value`    | `string`  | "on"    | The value attribute of the native input element |
+
+## Methods
+
+| Method   | Type       | Description              |
+| -------- | ---------- | ------------------------ |
+| `toggle` | `(): void` | Toggle the checked state |
+
+## Events
+
+| Event    | Description                                                                           |
+| -------- | ------------------------------------------------------------------------------------- |
+| `change` | Event that is being fired when the switch state changes due<br />to user interaction. |
+
+## Slots
+
+| Name | Description                                                |
+| ---- | ---------------------------------------------------------- |
+|      | Default slot lets the user provide a label for the switch. |
+
+## CSS Custom Properties
+
+| Property                                 | Description                                                            |
+| ---------------------------------------- | ---------------------------------------------------------------------- |
+| `--fluid-switch--container`              | Customize the container color.                                         |
+| `--fluid-switch--container-fill-checked` | Customize the fill color when<br />the switch is in the checked state. |
+| `--fluid-switch--fill`                   | Customize the switch fill color.                                       |
+| `--fluid-switch--focus`                  | Customize the focus color.                                             |
+| `--fluid-switch--knob`                   | Customize the knob color.                                              |
+| `--fluid-switch--knob-checked`           | Customize the knob color when<br />the switch is in the checked state. |
+| `--fluid-switch--label-color`            | Customize the label color.                                             |

--- a/libs/fluid-elements/switch/src/lib/switch.spec.ts
+++ b/libs/fluid-elements/switch/src/lib/switch.spec.ts
@@ -150,6 +150,27 @@ describe('Fluid switch', () => {
     });
   });
 
+  describe('value', () => {
+    it('should have the correct default set', async () => {
+      const shadowedInput = fixture.shadowRoot?.querySelector('input');
+      expect(shadowedInput?.getAttribute('value')).toBe('on');
+    });
+
+    it('should set the value to customvalue when the property is set', async () => {
+      fixture.value = 'customvalue';
+      await tick();
+      const shadowedInput = fixture.shadowRoot?.querySelector('input');
+      expect(shadowedInput?.getAttribute('value')).toBe('customvalue');
+    });
+
+    it('should set the value to customvalue when the attribute is set', async () => {
+      fixture.setAttribute('value', 'customvalue');
+      await tick();
+      const shadowedInput = fixture.shadowRoot?.querySelector('input');
+      expect(shadowedInput?.getAttribute('value')).toBe('customvalue');
+    });
+  });
+
   describe('tabindex', () => {
     it('should have a tabindex on the triggerable element when enabled', () => {
       const checkbox = fixture.shadowRoot?.querySelector('svg');

--- a/libs/fluid-elements/switch/src/lib/switch.ts
+++ b/libs/fluid-elements/switch/src/lib/switch.ts
@@ -28,6 +28,22 @@ import { SPACE } from '@dynatrace/shared/keycodes';
 
 let uniqueCounter = 0;
 
+/**
+ * A basic representation of the switch input
+ * @element fluid-switch
+ * @slot - Default slot lets the user provide a label for the switch.
+ * @fires change - Event that is being fired when the switch state changes due
+ * to user interaction.
+ * @cssprop --fluid-switch--label-color - Customize the label color.
+ * @cssprop --fluid-switch--fill - Customize the switch fill color.
+ * @cssprop --fluid-switch--container - Customize the container color.
+ * @cssprop --fluid-switch--container-fill-checked - Customize the fill color when
+ * the switch is in the checked state.
+ * @cssprop --fluid-switch--knob-checked - Customize the knob color when
+ * the switch is in the checked state.
+ * @cssprop --fluid-switch--knob - Customize the knob color.
+ * @cssprop --fluid-switch--focus - Customize the focus color.
+ */
 export class FluidSwitch extends LitElement {
   /**
    * Unique identifier used for the id and label connection
@@ -47,7 +63,12 @@ export class FluidSwitch extends LitElement {
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
-  /** Whether the switch is active or not */
+  /** The value attribute of the native input element */
+  @property({ type: String, reflect: true })
+  // Default string for the value is 'on' from MDN (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/checkbox#Additional_attributes)
+  value = 'on';
+
+  /** Whether the switch is considered `on` or `off`. */
   @property({ type: Boolean, reflect: true })
   set checked(value: boolean) {
     const oldValue = this.checked;
@@ -81,6 +102,7 @@ export class FluidSwitch extends LitElement {
         tabindex="-1"
         focusable="false"
         type="checkbox"
+        value="${this.value}"
         ?checked="${this.checked}"
         ?disabled="${this.disabled}"
         @change="${this._handleInputChange}"


### PR DESCRIPTION
### <strong>Pull Request</strong>

The native checkbox support a attribute value.
This PR adds that to both the fluid-checkbox and -switch.
Also adds the missing README to the Switch

#### Type of PR

Feature (non-breaking change which adds functionality)
Documentation update (changes to documentation)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
