### PR TITLE
chore: Extend demos sidebar filter to example-names and recovery of filtered key.

### DIFF
--- a/apps/demos/src/side-nav.component.html
+++ b/apps/demos/src/side-nav.component.html
@@ -3,6 +3,7 @@
   <form class="dt-demos-side-nav-searchform" novalidate>
     <input
       dtInput
+      #filterInput
       [dtAutocomplete]="auto"
       [(ngModel)]="componentItemsFilterValue"
       type="search"
@@ -12,10 +13,10 @@
     />
     <dt-autocomplete #auto="dtAutocomplete">
       <dt-option
-        *ngFor="let navItem of filteredComponentItems"
-        [value]="navItem.name"
+        *ngFor="let suggestion of exampleSuggestions"
+        [value]="suggestion"
       >
-        {{ navItem.name }}
+        {{ suggestion }}
       </dt-option>
     </dt-autocomplete>
   </form>
@@ -33,11 +34,8 @@
         <span>{{ component.name }}</span>
         <dt-icon name="dropdownopen"></dt-icon>
       </button>
-
       <dt-expandable-panel
-        [expanded]="
-          expandablePanel.expanded || _isSelectedComponent(component.name)
-        "
+        [expanded]="expandablePanel.expanded || component.expanded"
         #expandablePanel
       >
         <ul>

--- a/apps/demos/src/side-nav.component.ts
+++ b/apps/demos/src/side-nav.component.ts
@@ -28,8 +28,12 @@ import { Subscription } from 'rxjs';
 
 interface ComponentItem {
   name: string;
+  expanded?: boolean;
   examples: Array<{ name: string; route: string }>;
 }
+
+/** Key under which the current filter is being persisted into the session storage. */
+const FILTER_SESSION_STORAGE_KEY = 'demos-filter';
 
 @Component({
   selector: 'dt-demos-side-nav',
@@ -48,6 +52,7 @@ export class DtDemosSideNav implements AfterContentInit, OnDestroy {
   }
   set componentItems(values: ComponentItem[]) {
     this._componentItems = values;
+    this._createExampleSuggestionsSource();
     this._updateFilteredComponentItems();
   }
 
@@ -61,12 +66,22 @@ export class DtDemosSideNav implements AfterContentInit, OnDestroy {
     if (this._componentItemsFilterValue !== filterValue) {
       this._componentItemsFilterValue = filterValue;
       this._updateFilteredComponentItems();
+
+      if (window && window.sessionStorage) {
+        window.sessionStorage.setItem(FILTER_SESSION_STORAGE_KEY, filterValue);
+      }
     }
   }
 
   get filteredComponentItems(): ComponentItem[] {
     return this._filteredComponentItems;
   }
+
+  /** Array of examples that are listed in the suggestions */
+  exampleSuggestionsSource: string[] = [];
+
+  /** Array of examples that are listed in the suggestions */
+  exampleSuggestions: string[] = [];
 
   private _selectedComponentName = '';
   private _componentItemsFilterValue = '';
@@ -92,6 +107,12 @@ export class DtDemosSideNav implements AfterContentInit, OnDestroy {
         window.document.body.scrollIntoView(true);
       }
     });
+
+    if (window && window.sessionStorage) {
+      const savedFilter =
+        window.sessionStorage.getItem(FILTER_SESSION_STORAGE_KEY) || '';
+      this.componentItemsFilterValue = savedFilter;
+    }
   }
 
   ngOnDestroy(): void {
@@ -103,26 +124,51 @@ export class DtDemosSideNav implements AfterContentInit, OnDestroy {
     return this._selectedComponentName === componentName;
   }
 
+  /** Update the filtered elements for render in the sidebar. */
   private _updateFilteredComponentItems(): void {
     if (this._componentItemsFilterValue.length === 0) {
       this._filteredComponentItems = [...this._componentItems];
+      this.exampleSuggestions = this.exampleSuggestionsSource;
     } else {
       const filterValue = this._componentItemsFilterValue.toLocaleLowerCase();
 
-      this._filteredComponentItems = this._componentItems.filter(
-        (componentItem) => {
-          const componentItemName = componentItem.name.toLocaleLowerCase();
-
-          return (
-            componentItemName.includes(filterValue) ||
-            componentItem.examples.find((example) =>
-              example.name.toLocaleLowerCase().includes(filterValue),
-            ) !== undefined
-          );
-        },
+      this.exampleSuggestions = this.exampleSuggestionsSource.filter(
+        (suggestion) => suggestion.toLocaleLowerCase().includes(filterValue),
       );
+
+      this._filteredComponentItems = this._componentItems
+        .map((componentItem) => {
+          const filteredExamples = componentItem.examples.filter((example) =>
+            example.name.includes(filterValue),
+          );
+          if (filteredExamples.length > 0) {
+            return {
+              ...componentItem,
+              examples: filteredExamples,
+              expanded: true,
+            };
+          }
+        })
+        .filter(Boolean) as ComponentItem[];
     }
 
     this._changeDetectorRef.markForCheck();
+  }
+
+  /**
+   * Create a flat representation of all examples in their component groups
+   * to provide them as suggestions in the autocomplete.
+   */
+  private _createExampleSuggestionsSource(): void {
+    if (this.componentItems) {
+      this.exampleSuggestionsSource = Object.values(this.componentItems).reduce<
+        string[]
+      >((aggregator, componentGroup) => {
+        aggregator.push(
+          ...componentGroup.examples.map((example) => example.name),
+        );
+        return aggregator;
+      }, []);
+    }
   }
 }


### PR DESCRIPTION
### <strong>Pull Request</strong>

- filtered value is saved in session storage, to keep it alive during reloading
- filter now checks example names instead of component group names
- expandable sections are automatically expanded when filtered.

#### Type of PR

Other

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
