### PR TITLE
test(sunburst-chart): Fixes an issue with flaky tests on hover.

### DIFF
--- a/apps/components-e2e/src/components/sunburst-chart/sunburst-chart.e2e.ts
+++ b/apps/components-e2e/src/components/sunburst-chart/sunburst-chart.e2e.ts
@@ -16,7 +16,7 @@
 
 import { resetWindowSizeToDefault, waitForAngular } from '../../utils';
 import {
-  body,
+  root,
   centralLabel,
   centralValue,
   overlay,
@@ -26,12 +26,9 @@ import {
   percentBtn,
 } from './sunburst-chart.po';
 
-// Reduced speed of hovering should get our e2e tests stable.
-// We should think about removing the dtOverlay and using the cdk one,
-// that is not flaky on other e2e tests #86
-const hover: MouseActionOptions = {
-  // Slowest possible speed should help as workaround til the issue is fixed.
-  // The issue #646 is opened for this.
+// Reduced speed of mouse actions should get our e2e tests stable.
+// We should think about removing the dtOverlay and using the cdk one.
+const mouseInteraction: MouseActionOptions = {
   speed: 0.6,
 };
 
@@ -46,7 +43,7 @@ test('should enable selection and select with absolute values', async (testContr
   await testController
     .expect(segments.count)
     .eql(6)
-    .click(sliceShephard, { offsetY: -20 })
+    .click(sliceShephard, { ...mouseInteraction, offsetY: -20 })
     .expect(centralLabel.textContent)
     .match(/Shephard/)
     .expect(centralValue.textContent)
@@ -55,7 +52,7 @@ test('should enable selection and select with absolute values', async (testContr
     .eql(9)
     .expect(valueJack.textContent)
     .match(/Jack/)
-    .click(body)
+    .click(root, mouseInteraction)
     .expect(centralLabel.textContent)
     .match(/All/)
     .expect(centralValue.textContent)
@@ -65,8 +62,8 @@ test('should enable selection and select with relative values', async (testContr
   await testController
     .expect(segments.count)
     .eql(6)
-    .click(percentBtn)
-    .click(sliceShephard, { offsetY: -20 })
+    .click(percentBtn, mouseInteraction)
+    .click(sliceShephard, { ...mouseInteraction, offsetY: -20 })
     .expect(centralLabel.textContent)
     .match(/Shephard/)
     .expect(centralValue.textContent)
@@ -75,7 +72,7 @@ test('should enable selection and select with relative values', async (testContr
     .eql(9)
     .expect(valueJack.textContent)
     .match(/Jack/)
-    .click(body)
+    .click(root, mouseInteraction)
     .expect(centralLabel.textContent)
     .match(/All/)
     .expect(centralValue.textContent)
@@ -84,12 +81,12 @@ test('should enable selection and select with relative values', async (testContr
 
 test('should show overlay on hover', async (testController: TestController) => {
   await testController
-    .hover(sliceShephard, { ...hover, offsetY: -20 })
+    .hover(sliceShephard, { ...mouseInteraction, offsetY: -20 })
     .expect(overlay.exists)
     .ok()
     .expect(overlay.textContent)
     .match(/Shephard: 23/)
-    .hover(body, { ...hover, offsetX: 10, offsetY: 10 })
+    .hover(root, { ...mouseInteraction, offsetX: 10, offsetY: 10 })
     .expect(overlay.exists)
     .notOk();
 });

--- a/apps/components-e2e/src/components/sunburst-chart/sunburst-chart.html
+++ b/apps/components-e2e/src/components/sunburst-chart/sunburst-chart.html
@@ -4,6 +4,7 @@
   [series]="series"
   (selectedChange)="selected = $event"
   [valueDisplayMode]="valueDisplayMode"
+  style="max-width: 600px;"
 >
   <ng-template dtSunburstChartOverlay let-tooltip>
     {{ tooltip.label }}: {{ tooltip.value }}

--- a/apps/components-e2e/src/components/sunburst-chart/sunburst-chart.po.ts
+++ b/apps/components-e2e/src/components/sunburst-chart/sunburst-chart.po.ts
@@ -16,8 +16,7 @@
 
 import { Selector } from 'testcafe';
 
-export const body = Selector('body');
-export const chart = Selector('test-sunburst-chart');
+export const root = Selector('dt-sunburst-chart');
 export const overlay = Selector('.dt-overlay-container');
 
 export const centralLabel = Selector('.dt-sunburst-chart-selected-label');


### PR DESCRIPTION
### <strong>Pull Request</strong>

A fix was added by making the sunburst chart smaller than the window, which does no longer force
testcafe to scroll the page when clicking / hovering certain items.
Click speed has been reduced to 0.6 to match the hover speed.
Since the chart is no longer filling the whole screen, the click on the body has been replaced with
a click on the root of the chart, which yields the same results.

Fixes #1335

#### Type of PR

Test

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
