### PR TITLE
Chore/fixes keyboard tests tab

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -3759,6 +3759,21 @@
           "style": "scss"
         }
       }
+    },
+    "shared-keycodes": {
+      "root": "libs/shared/keycodes",
+      "sourceRoot": "libs/shared/keycodes/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@angular-devkit/build-angular:tslint",
+          "options": {
+            "tsConfig": ["libs/shared/keycodes/tsconfig.lib.json"],
+            "exclude": ["**/node_modules/**", "!libs/shared/keycodes/**/*"]
+          }
+        }
+      }
     }
   },
   "defaultProject": "dev",

--- a/libs/fluid-elements/checkbox/src/lib/checkbox.spec.ts
+++ b/libs/fluid-elements/checkbox/src/lib/checkbox.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { FluidCheckbox } from './checkbox';
-import { SPACE } from '@angular/cdk/keycodes';
+import { SPACE } from '@dynatrace/shared/keycodes';
 import { dispatchKeyboardEvent } from '@dynatrace/testing/browser';
 
 function tick(): Promise<void> {

--- a/libs/fluid-elements/checkbox/src/lib/checkbox.ts
+++ b/libs/fluid-elements/checkbox/src/lib/checkbox.ts
@@ -23,6 +23,7 @@ import {
 } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map';
 import styles from './checkbox.scss';
+import { SPACE } from '@dynatrace/shared/keycodes';
 
 let uniqueCounter = 0;
 
@@ -287,7 +288,7 @@ export class FluidCheckbox extends LitElement {
    * @param event
    */
   private _handleKeydown(event: KeyboardEvent): void {
-    if (event.keyCode === 32) {
+    if (event.code === SPACE) {
       event.preventDefault();
     }
   }

--- a/libs/fluid-elements/checkbox/tsconfig.lib.json
+++ b/libs/fluid-elements/checkbox/tsconfig.lib.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
     "target": "es2015",
     "declaration": true,
     "inlineSources": true,

--- a/libs/fluid-elements/switch/src/lib/switch.spec.ts
+++ b/libs/fluid-elements/switch/src/lib/switch.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { FluidSwitch } from './switch';
-import { SPACE } from '@angular/cdk/keycodes';
+import { SPACE } from '@dynatrace/shared/keycodes';
 import { dispatchKeyboardEvent } from '@dynatrace/testing/browser';
 
 function tick(): Promise<void> {

--- a/libs/fluid-elements/switch/src/lib/switch.ts
+++ b/libs/fluid-elements/switch/src/lib/switch.ts
@@ -24,6 +24,7 @@ import {
 import { classMap } from 'lit-html/directives/class-map';
 import { FluidSwitchChangeEvent } from './switch-events';
 import styles from './switch.scss';
+import { SPACE } from '@dynatrace/shared/keycodes';
 
 let uniqueCounter = 0;
 
@@ -143,7 +144,7 @@ export class FluidSwitch extends LitElement {
    * @param event
    */
   private _handleKeyDown(event: KeyboardEvent): void {
-    if (event.keyCode === 32) {
+    if (event.code === SPACE) {
       event.preventDefault();
     }
   }
@@ -152,7 +153,7 @@ export class FluidSwitch extends LitElement {
    * Handling the key up event on the svg.
    */
   private _handleKeyUp(event: KeyboardEvent): void {
-    if (event.keyCode === 32) {
+    if (event.code === SPACE) {
       this._inputElement.click();
     }
   }

--- a/libs/fluid-elements/switch/tsconfig.lib.json
+++ b/libs/fluid-elements/switch/tsconfig.lib.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
     "target": "es2015",
     "declaration": true,
     "inlineSources": true,

--- a/libs/fluid-elements/tab-group/src/lib/tab-group.spec.ts
+++ b/libs/fluid-elements/tab-group/src/lib/tab-group.spec.ts
@@ -16,6 +16,8 @@
 
 import { FluidTabGroup } from './tab-group';
 import { FluidTab } from './tab/tab';
+import { dispatchKeyboardEvent } from '@dynatrace/testing/browser';
+import { ARROW_RIGHT, SPACE } from '@dynatrace/shared/keycodes';
 
 function tick(): Promise<void> {
   return Promise.resolve();
@@ -84,19 +86,19 @@ describe('Fluid tab group', () => {
       await tick();
       expect(fixture.getAttribute('activetabid')).toBe('section2');
     });
-    // Todo: Find out how to dispatch a keyboard event
-    // it('should set last activetabid attribute when using key events', async () => {
-    //   const tab = fixture.querySelector<FluidTab>('fluid-tab');
-    //   console.log(fixture.shadowRoot?.querySelector('ul'));
-    //   tab?.focus();
-    //   await tick();
-    //   expect(fixture.getAttribute('activetabid')).toBe('section1');
-    //   dispatchKeyboardEvent(tab!, 'keydown', RIGHT_ARROW);
-    //   await tick();
-    //   expect(keyDownSpy).toBeCalledTimes(1);
-    //   expect(activeTabChangedSpy).toHaveBeenCalledTimes(1);
-    //   expect(fixture.getAttribute('activetabid')).toBe('section2');
-    // });
+
+    it('should set last activetabid attribute when using key events', async () => {
+      const tab = fixture.querySelector<FluidTab>('fluid-tab');
+      tab?.focus();
+      await tick();
+      expect(fixture.getAttribute('activetabid')).toBe('section1');
+      dispatchKeyboardEvent(tab!, 'keydown', ARROW_RIGHT);
+      await tick();
+      expect(keyDownSpy).toBeCalledTimes(1);
+      dispatchKeyboardEvent(document.activeElement!, 'keydown', SPACE);
+      expect(activeTabChangedSpy).toHaveBeenCalledTimes(1);
+      expect(fixture.getAttribute('activetabid')).toBe('section2');
+    });
   });
 
   describe('tabindex attribute', () => {
@@ -122,24 +124,23 @@ describe('Fluid tab group', () => {
     // Should have tabindex -1 when element is disabled
   });
 
-  // Todo: Add tests covering the activeTabChanged event when clicking and using keydown
-  // describe('activeTabChanged event', () => {
-  //   it('should fire an event when a tab is clicked', async () => {
-  //     const tab = fixture
-  //       .querySelector('fluid-tab')
-  //       ?.shadowRoot?.querySelector('li') as HTMLLIElement;
-  //     tab?.click();
-  //     await tick();
-  //     expect(activeTabChangedSpy).toBeCalledTimes(1);
-  //   });
+  describe('activeTabChanged event', () => {
+    it('should fire an event when a tab is clicked', async () => {
+      const tab = fixture
+        .querySelector('fluid-tab[tabid="section2"]')
+        ?.shadowRoot?.querySelector('span') as HTMLSpanElement;
+      tab?.click();
+      await tick();
+      expect(activeTabChangedSpy).toBeCalledTimes(1);
+    });
 
-  //   // tslint:disable-next-line: dt-no-focused-tests
-  //   it('should fire an event when using the key events', async () => {
-  //     const tab = fixture.querySelector<FluidTab>('fluid-tab');
-  //     tab?.focus();
-  //     tab?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
-  //     await tick();
-  //     expect(activeTabChangedSpy).toBeCalledTimes(1);
-  //   });
-  // });
+    it('should fire an event when using the key events', async () => {
+      const tab = fixture.querySelector<FluidTab>('fluid-tab');
+      tab?.focus();
+      dispatchKeyboardEvent(tab!, 'keydown', ARROW_RIGHT);
+      await tick();
+      dispatchKeyboardEvent(document.activeElement!, 'keydown', SPACE);
+      expect(activeTabChangedSpy).toBeCalledTimes(1);
+    });
+  });
 });

--- a/libs/fluid-elements/tab-group/src/lib/tab-group.ts
+++ b/libs/fluid-elements/tab-group/src/lib/tab-group.ts
@@ -28,6 +28,12 @@ import {
   FluidTabDisabledEvent,
   FluidTabGroupActiveTabChanged,
 } from '../utils/tab-events';
+import {
+  ENTER,
+  SPACE,
+  ARROW_RIGHT,
+  ARROW_LEFT,
+} from '@dynatrace/shared/keycodes';
 
 /**
  * This is a experimental version of the tab group component
@@ -66,7 +72,7 @@ export class FluidTabGroup extends LitElement {
   /** Sets the active tab on keydown (ArrowLeft and ArrowRight to select / Enter and Space to confirm) */
   private handleKeyDown(event: KeyboardEvent): void {
     // Enter Space controll (validate selection)
-    if (event.key === 'Enter' || event.key === ' ') {
+    if (event.code === ENTER || event.code === SPACE) {
       // Set all tabs to active false
       for (const tab of this.tabChildren) {
         tab.active = false;
@@ -82,17 +88,17 @@ export class FluidTabGroup extends LitElement {
       this.dispatchEvent(new FluidTabGroupActiveTabChanged(this.activetabid));
     }
     // Arrow control (navigate tabs)
-    if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+    if (event.code === ARROW_RIGHT || event.code === ARROW_LEFT) {
       // Loops over to find
       let index = this.tabChildren.findIndex(
         (tab: FluidTab) => this.activetabid === tab.tabid,
       );
 
       const oldIndex = index;
-      if (event.key === 'ArrowRight') {
+      if (event.code === ARROW_RIGHT) {
         index += 1;
       }
-      if (event.key === 'ArrowLeft') {
+      if (event.code === ARROW_LEFT) {
         index -= 1;
       }
       if (index > this.tabChildren.length - 1) {
@@ -105,7 +111,6 @@ export class FluidTabGroup extends LitElement {
       this.tabChildren[index].tabindex = 0;
       this.tabChildren[oldIndex].tabindex = -1;
       this.activetabid = this.tabChildren[index].tabid;
-      console.log(this.tabChildren);
     }
   }
 

--- a/libs/fluid-elements/tab-group/tsconfig.lib.json
+++ b/libs/fluid-elements/tab-group/tsconfig.lib.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
     "target": "es2015",
     "declaration": true,
     "inlineSources": true,

--- a/libs/shared/keycodes/README.md
+++ b/libs/shared/keycodes/README.md
@@ -1,0 +1,3 @@
+# shared-keycodes
+
+This library was generated with [Nx](https://nx.dev).

--- a/libs/shared/keycodes/src/index.ts
+++ b/libs/shared/keycodes/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './lib/keycodes';

--- a/libs/shared/keycodes/src/lib/keycodes.ts
+++ b/libs/shared/keycodes/src/lib/keycodes.ts
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Sourced from https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code/code_values
+
+export const ESCAPE = 'Escape';
+export const DIGIT_0 = 'Digit0';
+export const DIGIT_1 = 'Digit1';
+export const DIGIT_2 = 'Digit2';
+export const DIGIT_3 = 'Digit3';
+export const DIGIT_4 = 'Digit4';
+export const DIGIT_5 = 'Digit5';
+export const DIGIT_6 = 'Digit6';
+export const DIGIT_7 = 'Digit7';
+export const DIGIT_8 = 'Digit8';
+export const DIGIT_9 = 'Digit9';
+export const MINUS = 'Minus';
+export const EQUAL = 'Equal';
+export const BACKSPACE = 'Backspace';
+export const TAB = 'Tab';
+export const KEY_Q = 'KeyQ';
+export const KEY_W = 'KeyW';
+export const KEY_E = 'KeyE';
+export const KEY_R = 'KeyR';
+export const KEY_T = 'KeyT';
+export const KEY_Y = 'KeyY';
+export const KEY_U = 'KeyU';
+export const KEY_I = 'KeyI';
+export const KEY_O = 'KeyO';
+export const KEY_P = 'KeyP';
+export const BRACKET_LEFT = 'BracketLeft';
+export const BRACKET_RIGHT = 'BracketRight';
+export const ENTER = 'Enter';
+export const CONTROL_LEFT = 'ControlLeft';
+export const KEY_A = 'KeyA';
+export const KEY_S = 'KeyS';
+export const KEY_D = 'KeyD';
+export const KEY_F = 'KeyF';
+export const KEY_G = 'KeyG';
+export const KEY_H = 'KeyH';
+export const KEY_J = 'KeyJ';
+export const KEY_K = 'KeyK';
+export const KEY_L = 'KeyL';
+export const SEMICOLON = 'Semicolon';
+export const QUOTE = 'Backquote';
+export const SHIFT_LEFT = 'ShiftLeft';
+export const BACKSLASH = 'Backslash';
+export const KEY_Z = 'KeyZ';
+export const KEY_X = 'KeyX';
+export const KEY_C = 'KeyC';
+export const KEY_V = 'KeyV';
+export const KEY_B = 'KeyB';
+export const KEY_N = 'KeyN';
+export const KEY_M = 'KeyM';
+export const COMMA = 'Comma';
+export const PERIOD = 'Period';
+export const SLASH = 'Slash';
+export const SHIFT_RIGHT = 'ShiftRight';
+export const NUMPAD_MULTIPLY = 'NumpadMultiply';
+export const ALT_LEFT = 'AltLeft';
+export const SPACE = 'Space';
+export const CAPS_LOCK = 'CapsLock';
+export const F1 = 'F1';
+export const F2 = 'F2';
+export const F3 = 'F3';
+export const F4 = 'F4';
+export const F5 = 'F5';
+export const F6 = 'F6';
+export const F7 = 'F7';
+export const F8 = 'F8';
+export const F9 = 'F9';
+export const F10 = 'F10';
+export const PAUSE = 'Pause';
+export const SCROLL_LOCK = 'ScrollLock';
+export const NUMPAD_7 = 'Numpad7';
+export const NUMPAD_8 = 'Numpad8';
+export const NUMPAD_9 = 'Numpad9';
+export const NUMPAD_SUBTRACT = 'NumpadSubtract';
+export const NUMPAD_4 = 'Numpad4';
+export const NUMPAD_5 = 'Numpad5';
+export const NUMPAD_6 = 'Numpad6';
+export const NUMPAD_ADD = 'NumpadAdd';
+export const NUMPAD_1 = 'Numpad1';
+export const NUMPAD_2 = 'Numpad2';
+export const NUMPAD_3 = 'Numpad3';
+export const NUMPAD_0 = 'Numpad0';
+export const NUMPAD_DECIMAL = 'NumpadDecimal';
+export const MEDIA_TRACK_PREVIOUS = 'MediaTrackPrevious';
+export const MEDIA_TRACK_NEXT = 'MediaTrackNext';
+export const NUMPAD_ENTER = 'NumpadEnter';
+export const CONTROL_RIGHT = 'ControlRight';
+export const AUDIO_VOLUME_MUTE = 'AudioVolumeMute';
+export const MEDIA_PLAY_PAUSE = 'MediaPlayPause';
+export const MEDIA_STOP = 'MediaStop';
+export const NUMPAD_DIVIDE = 'NumpadDivide';
+export const ALT_RIGHT = 'AltRight';
+export const NUM_LOCK = 'NumLock';
+export const HOME = 'Home';
+export const ARROW_UP = 'ArrowUp';
+export const PAGE_UP = 'PageUp';
+export const ARROW_LEFT = 'ArrowLeft';
+export const ARROW_RIGHT = 'ArrowRight';
+export const END = 'End';
+export const ARROW_DOWN = 'ArrowDown';
+export const PAGE_DOWN = 'PageDown';
+export const INSERT = 'Insert';
+export const DELETE = 'Delete';

--- a/libs/shared/keycodes/tsconfig.json
+++ b/libs/shared/keycodes/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "types": []
+  },
+  "include": ["**/*.ts"]
+}

--- a/libs/shared/keycodes/tsconfig.lib.json
+++ b/libs/shared/keycodes/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": []
+  },
+  "exclude": ["**/*.spec.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/shared/keycodes/tslint.json
+++ b/libs/shared/keycodes/tslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tslint.json",
+  "linterOptions": { "exclude": ["!**/*"] },
+  "rules": {}
+}

--- a/libs/testing/browser/src/lib/dispatch-events.ts
+++ b/libs/testing/browser/src/lib/dispatch-events.ts
@@ -35,17 +35,37 @@ export function dispatchFakeEvent(
   return dispatchEvent(node, createFakeEvent(type, canBubble));
 }
 
+/** Shorthand to dispatch a keyboard event with a specified code */
+export function dispatchKeyboardEvent(
+  node: Node,
+  type: string,
+  code: string,
+  target?: Element,
+): KeyboardEvent;
 /** Shorthand to dispatch a keyboard event with a specified key code. */
 export function dispatchKeyboardEvent(
   node: Node,
   type: string,
   keyCode: number,
   target?: Element,
+): KeyboardEvent;
+export function dispatchKeyboardEvent(
+  node: Node,
+  type: string,
+  keycodeOrCode: number | string,
+  target?: Element,
 ): KeyboardEvent {
-  return dispatchEvent(
-    node,
-    createKeyboardEvent(type, keyCode, target),
-  ) as KeyboardEvent;
+  if (typeof keycodeOrCode === 'number') {
+    return dispatchEvent(
+      node,
+      createKeyboardEvent(type, keycodeOrCode, target),
+    ) as KeyboardEvent;
+  } else {
+    return dispatchEvent(
+      node,
+      createKeyboardEvent(type, keycodeOrCode, target),
+    ) as KeyboardEvent;
+  }
 }
 
 /** Shorthand to dispatch a mouse event on the specified coordinates. */

--- a/libs/testing/browser/src/lib/event-objects.ts
+++ b/libs/testing/browser/src/lib/event-objects.ts
@@ -71,28 +71,38 @@ export function createTouchEvent(
 /** Dispatches a keydown event from an element. */
 export function createKeyboardEvent(
   type: string,
+  code: string,
+  _target?: Element,
+  key?: string,
+): KeyboardEvent;
+export function createKeyboardEvent(
+  type: string,
   keyCode: number,
-  target?: Element,
+  _target?: Element,
+  key?: string,
+): KeyboardEvent;
+export function createKeyboardEvent(
+  type: string,
+  keycodeOrCode: string | number,
+  _target?: Element,
   key?: string,
 ): KeyboardEvent {
-  // tslint:disable-next-line:no-any
-  const event = document.createEvent('KeyboardEvent') as any;
-  const originalPreventDefault = event.preventDefault;
+  const initializer: KeyboardEventInit = {
+    key,
+    bubbles: true,
+    cancelable: true,
+    view: window,
+  };
 
-  // Firefox does not support `initKeyboardEvent`, but supports `initKeyEvent`.
-  if (event.initKeyEvent) {
-    event.initKeyEvent(type, true, true, window, 0, 0, 0, 0, 0, keyCode);
+  if (typeof keycodeOrCode === 'number') {
+    (initializer as any).keyCode = keycodeOrCode;
   } else {
-    event.initKeyboardEvent(type, true, true, window, 0, key, 0, '', false);
+    initializer.code = keycodeOrCode;
   }
 
-  // Webkit Browsers don't set the keyCode when calling the init function.
-  // See related bug https://bugs.webkit.org/show_bug.cgi?id=16735
-  Object.defineProperties(event, {
-    keyCode: { get: () => keyCode },
-    key: { get: () => key },
-    target: { get: () => target },
-  });
+  // tslint:disable-next-line:no-any
+  const event = new KeyboardEvent(type, initializer);
+  const originalPreventDefault = event.preventDefault;
 
   // IE won't set `defaultPrevented` on synthetic events so we need to do it manually.
   event.preventDefault = function (): void {

--- a/nx.json
+++ b/nx.json
@@ -378,6 +378,9 @@
     },
     "design-tokens-ui-shared": {
       "tags": ["type:library", "type:shared"]
+    },
+    "shared-keycodes": {
+      "tags": ["type:library", "type:shared"]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -261,7 +261,8 @@
       ],
       "@dynatrace/design-tokens-ui/shared": [
         "libs/design-tokens-ui/shared/src/index.ts"
-      ]
+      ],
+      "@dynatrace/shared/keycodes": ["libs/shared/keycodes/src/index.ts"]
     },
     "plugins": [
       {


### PR DESCRIPTION
### <strong>Pull Request</strong>
This was no issue with the test-runner, nor with jsdom. The problem was that the helper function for
dispatchKeyboardEvent only included a keyCode member, which is deprecated. Unifying all key handlers
to use the event.code member and adding overload functions for the dispatchKeyboardEvent testing
helpers, which add the `code` member to the event fixed the issues.

Additionaly a keycodes library was added, which contains a couple of constants that can be used for
comparisons.

Fixes #1258

#### Type of PR

Other

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
