### PR TITLE
ci(bazel): Fix build cache regex on ci.

### DIFF
--- a/tools/bazel_build_cache/setup_ci_build_cache.sh
+++ b/tools/bazel_build_cache/setup_ci_build_cache.sh
@@ -3,8 +3,10 @@
 # The script should immediately exit if any command in the script fails.
 set -e
 
+PULL_BRANCH_REGEX="^pull\/[0-9]+$"
+
 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-if [[ "${CIRCLE_BRANCH}" =~ pull\/[0-9]+ ]]; then
+if [[ "${CIRCLE_BRANCH}" =~ $PULL_BRANCH_REGEX ]]; then
   echo "Forked pull request no setup for upload to remote chache!"
   echo "build --remote_upload_local_results=false" >> ../../.circleci/bazel.rc
   exit 0


### PR DESCRIPTION
### <strong>Pull Request</strong>

Writing bash is hard :D the regex has to be in a variable and the variable has to be referenced without double quotes :D

Tried it directly on circleci via ssh on the failing branch

```bash
thebarista@74a305b5ce06:~/barista/tools/bazel_build_cache$ REGEX="^pull\/[0-9]+$"
thebarista@74a305b5ce06:~/barista/tools/bazel_build_cache$ if [[ "${CIRCLE_BRANCH}" =~ $REGEX ]]; then echo "hello world"; fi
hello world
```

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
