### PR TITLE
chore(ci): Change ownership of repocache folder to enable write acces…

### DIFF
--- a/.deployment/workspace-bazel.Dockerfile
+++ b/.deployment/workspace-bazel.Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /root/barista
 
 COPY --from=fetcher /root/repocache /root/repocache
 
-RUN useradd -ms /bin/bash thebarista && chown thebarista /root
+RUN useradd -ms /bin/bash thebarista && chown -R thebarista /root
 USER thebarista
 
 RUN echo alias bazel=bazel-${bazel_version} > ~/.bashrc


### PR DESCRIPTION
Fix bazel executor image to let Barista user write into Bazel repocache. This is needed when doing dependency updates

#### Type of PR

Bugfix (non-breaking change which fixes an issue) 


#### Checklist

- [x ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
