### PR TITLE
ci(bazel): Changes shell command invocation to fix fork skip check fo…

### DIFF
--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -19,4 +19,4 @@ build --local_ram_resources=14336
 build --local_cpu_resources=8
 
 # Set credentials for build cache enabling will be handled in the setup file
-build --google_credentials=./tools/bazel_build_cache/cache-write-key.json
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ commands:
           command: echo "import %workspace%/.circleci/bazel.rc" >> ./.bazelrc
       - run:
           name: Setup Bazel Build Cache
-          command: cd ./tools/bazel_build_cache && sh setup_ci_build_cache.sh
+          command: cd ./tools/bazel_build_cache && ./setup_ci_build_cache.sh
 
   run_bazel_stylelint:
     description: >-

--- a/tools/bazel_build_cache/setup_ci_build_cache.sh
+++ b/tools/bazel_build_cache/setup_ci_build_cache.sh
@@ -26,4 +26,5 @@ openssl aes-256-cbc -salt -a -d\
   -in "${DIR}/cache-write-key.json.enc" \
   -pass "pass:${BAZEL_REMOTE_CACHE_PASSWORD}"
 
+echo "build --google_credentials=./tools/bazel_build_cache/cache-write-key.json" >> ../../.circleci/bazel.rc
 echo "build --remote_upload_local_results=true" >> ../../.circleci/bazel.rc


### PR DESCRIPTION
…r bazel setup

This PR should fix the failing shell fork check to skip the bazel setup.

Edit:
~~This is not ideal since the steps are still reported as successful although they should be marked as skipped. Could not find anything in the circleci doc though. @lukasholzer I guess still better than having them fail during setup.~~

Moved the credentials now to the pr branch in the shell script. This works out nicely. Additionally fixed the shell that executes the script to have the brackets working for the fork check.