### PR TITLE
fix(formatters): Fix setting maxPrecision to negative number and input >= 1

### DIFF
--- a/libs/barista-components/formatters/src/number-formatter.spec.ts
+++ b/libs/barista-components/formatters/src/number-formatter.spec.ts
@@ -189,6 +189,11 @@ describe('FormatterUtil', () => {
         output: '< 1',
       },
       {
+        input: 1.123456789,
+        maxPrecision: -1,
+        output: '1',
+      },
+      {
         input: 0.123456789,
         output: '0.123',
       },
@@ -262,7 +267,7 @@ describe('FormatterUtil', () => {
         output: '-0.001',
       },
     ].forEach((testCase: TestCase) => {
-      it(`should return ${testCase.input} with max precision`, () => {
+      it(`should return ${testCase.output} with input ${testCase.output} and max precision set to ${testCase.maxPrecision}`, () => {
         expect(
           adjustNumber(
             testCase.input,

--- a/libs/barista-components/formatters/src/number-formatter.ts
+++ b/libs/barista-components/formatters/src/number-formatter.ts
@@ -80,7 +80,7 @@ function adjustPrecision(value: number, maxPrecision?: number): string {
   } else if (calcValue < 100) {
     digits = 1;
   }
-  return formatNumber(value, 'en-US', `0.0-${digits}`);
+  return formatNumber(value, 'en-US', `0.0-${digits < 0 ? 0 : digits}`);
 }
 
 function abbreviateNumber(sourceValue: number): string {


### PR DESCRIPTION
### <strong>Pull Request</strong>

Fixes a bug in the adjustNumber function causing an error when maxprecision is set to a negative number and the input is >= 1

#### Type of PR

Bugfix (non-breaking change which fixes an issue)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
