### PR TITLE
fix(option): Fixes multiple selected bug when using keyboard and mouse

### DIFF
--- a/apps/components-e2e/src/components/autocomplete/autocomplete.e2e.ts
+++ b/apps/components-e2e/src/components/autocomplete/autocomplete.e2e.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { autocompleteInput, overlayPane } from './autocomplete.po';
+import {
+  autocompleteInput,
+  overlayPane,
+  option1,
+  option3,
+  option2,
+} from './autocomplete.po';
 import { resetWindowSizeToDefault, waitForAngular } from '../../utils';
 
 fixture('Autocomplete')
@@ -29,4 +35,22 @@ test('should propagate attribute to overlay', async (testController: TestControl
     .click(autocompleteInput, { speed: 0.5 })
     .expect(overlayPane.getAttribute('dt-ui-test-id'))
     .contains('autocomplete-overlay');
+});
+
+test('should highlight the correct option after navigating using mouse and keyboard', async (testController: TestController) => {
+  await testController
+    .click(autocompleteInput, { speed: 0.5 })
+    .pressKey('down')
+    .expect(option1.classNames)
+    .contains('dt-option-active')
+    .hover(overlayPane)
+    .expect(option1.classNames)
+    .notContains('dt-option-active')
+    .expect(option2.classNames)
+    .contains('dt-option-active')
+    .pressKey('down')
+    .expect(option2.classNames)
+    .notContains('dt-option-active')
+    .expect(option3.classNames)
+    .contains('dt-option-active');
 });

--- a/apps/components-e2e/src/components/autocomplete/autocomplete.po.ts
+++ b/apps/components-e2e/src/components/autocomplete/autocomplete.po.ts
@@ -18,3 +18,7 @@ import { Selector } from 'testcafe';
 
 export const autocompleteInput = Selector('input');
 export const overlayPane = Selector('.cdk-overlay-pane');
+
+export const option1 = Selector('#dt-option-0');
+export const option2 = Selector('#dt-option-1');
+export const option3 = Selector('#dt-option-2');

--- a/apps/components-e2e/src/components/select/select.e2e.ts
+++ b/apps/components-e2e/src/components/select/select.e2e.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { select, overlayPane } from './select.po';
+import { select, overlayPane, option2, option3, option4 } from './select.po';
 import { resetWindowSizeToDefault, waitForAngular } from '../../utils';
 
 fixture('Select')
@@ -29,4 +29,22 @@ test('should propagate attribute to overlay', async (testController: TestControl
     .click(select, { speed: 0.3 })
     .expect(overlayPane.getAttribute('dt-ui-test-id'))
     .contains('select-overlay');
+});
+
+test('should highlight the correct option after navigating using mouse and keyboard', async (testController: TestController) => {
+  await testController
+    .click(select, { speed: 0.5 })
+    .pressKey('down')
+    .expect(option2.classNames)
+    .contains('dt-option-active')
+    .hover(option3)
+    .expect(option2.classNames)
+    .notContains('dt-option-active')
+    .expect(option3.classNames)
+    .contains('dt-option-active')
+    .pressKey('down')
+    .expect(option3.classNames)
+    .notContains('dt-option-active')
+    .expect(option4.classNames)
+    .contains('dt-option-active');
 });

--- a/apps/components-e2e/src/components/select/select.po.ts
+++ b/apps/components-e2e/src/components/select/select.po.ts
@@ -18,3 +18,7 @@ import { Selector } from 'testcafe';
 
 export const select = Selector('#select');
 export const overlayPane = Selector('.cdk-overlay-pane');
+
+export const option2 = Selector('#dt-option-1');
+export const option3 = Selector('#dt-option-2');
+export const option4 = Selector('#dt-option-3');

--- a/apps/dev/src/select/select-demo.component.html
+++ b/apps/dev/src/select/select-demo.component.html
@@ -39,8 +39,10 @@
   <dt-select
     placeholder="Enabled select with placeholder"
     dt-ui-test-id="select"
-    ><dt-option value="Yuanyang">Yuanyang</dt-option></dt-select
   >
+    <dt-option value="Yuanyang">Yuanyang</dt-option>
+    <dt-option value="Haoyang">Haoyang</dt-option>
+  </dt-select>
 </p>
 <p>
   <dt-select

--- a/libs/barista-components/core/src/option/option.scss
+++ b/libs/barista-components/core/src/option/option.scss
@@ -14,7 +14,6 @@
   outline: none;
   font-variant: tabular-nums;
 
-  &:not(.dt-option-disabled):hover,
   &:not(.dt-option-disabled).dt-option-active {
     background-color: $turquoise-100;
     cursor: pointer;

--- a/libs/barista-components/select/src/select.ts
+++ b/libs/barista-components/select/src/select.ts
@@ -526,8 +526,23 @@ export class DtSelect<T> extends _DtSelectMixinBase
     this.options.changes
       .pipe(startWith(null), takeUntil(this._destroy))
       .subscribe(() => {
-        this._resetOptions();
         this._initializeSelection();
+        this._resetOptions();
+      });
+
+    // We need to check for changes in the options when the user is hovering
+    this.options.changes
+      .pipe(
+        startWith(null),
+        switchMap(() =>
+          merge(...this.options.map((option) => option._optionHovered)),
+        ),
+        takeUntil(this._destroy),
+      )
+      .subscribe((option) => {
+        this._ngZone.run(() => {
+          this._keyManager.setActiveItem(option);
+        });
       });
   }
 


### PR DESCRIPTION
@ffriedl89 @thomaspink 

Tom and I have come up with this sollution for the filter field selection "bug" we have.
The DtOption has a subject containing the item that is hovered on mousemove which the autocomplete subscribes to setting the active item.

Any thoughts?

Fixes #1070