### PR TITLE
chore: Shareable examples win compatibility.

### DIFF
--- a/libs/tools/shareable-examples/src/utils/get-boilerplate-files.ts
+++ b/libs/tools/shareable-examples/src/utils/get-boilerplate-files.ts
@@ -149,7 +149,9 @@ export async function getBoilerplateFiles(
     exampleModulePath,
   )
     // remove the .ts extension for imports
-    .replace('.ts', '');
+    .replace('.ts', '')
+    // replace \ with /
+    .replace(/\\/g, '/');
 
   files.push({
     path: resolve(environment.examplesLibDir, 'app/app.module.ts'),


### PR DESCRIPTION
### <strong>Pull Request</strong>

Shareable examples generation on win had some wrong paths.

Fixes #1408 