### PR TITLE
refactor(radio): Move radio group name assignment to ngOnInit, due to…

### DIFF
--- a/libs/barista-components/radio/src/radio.ts
+++ b/libs/barista-components/radio/src/radio.ts
@@ -210,14 +210,12 @@ export class DtRadioButton<T> extends _DtRadioButtonMixinBase
         }
       },
     );
-    if (this._radioGroup) {
-      this.name = this._radioGroup.name;
-    }
   }
 
   ngOnInit(): void {
     if (this._radioGroup) {
       this.checked = this._radioGroup.value === this._value;
+      this.name = this._radioGroup.name;
     }
   }
 


### PR DESCRIPTION
… upcoming lifecycle issues in v10.

This PR was done, because with v10 the test starts failing. The assignment for the name from the group needs to be done in the ngOnInit, the constructor is too early. 