### PR TITLE
ds: Change to correct githubuser key in json

### DIFF
--- a/libs/barista-components/experimental/combobox/barista.json
+++ b/libs/barista-components/experimental/combobox/barista.json
@@ -9,17 +9,17 @@
     "dev": [
       {
         "name": "Christoph Matscheko",
-        "gitHubUser": "heartdisease"
+        "githubuser": "heartdisease"
       },
       {
         "name": "Fabian Friedl",
-        "gitHubUser": "ffriedl89"
+        "githubuser": "ffriedl89"
       }
     ],
     "ux": [
       {
         "name": "Andreas Mayr",
-        "gitHubUser": "moarliman"
+        "githubuser": "moarliman"
       }
     ]
   },


### PR DESCRIPTION
The page on barista does not show the avatars correctly. This should fix it :) 

![image](https://user-images.githubusercontent.com/2905693/89192423-a81c4800-d5a4-11ea-9a95-13ab86b13fc2.png)
