### PR TITLE
fix(highlight): Fixes an issue where the highlight would break layouts.

### DIFF
--- a/libs/examples/src/autocomplete/autocomplete-default-example/autocomplete-default-example.ts
+++ b/libs/examples/src/autocomplete/autocomplete-default-example/autocomplete-default-example.ts
@@ -22,5 +22,20 @@ import { Component } from '@angular/core';
 })
 export class DtExampleAutocompleteDefault {
   value: string;
-  options: string[] = ['One', 'Two', 'Three'];
+  options: string[] = [
+    'first item',
+    'second item',
+    'third item',
+    'fourth item',
+    'fifth item',
+    'sixth item',
+    'seventh item',
+    'eighth item',
+    'ninth item',
+    'tenth item',
+    'eleventh item',
+    'twelfth item',
+    'some very long item',
+    'some even much longer item',
+  ];
 }

--- a/libs/examples/src/filter-field/filter-field-default-example/filter-field-default-example.ts
+++ b/libs/examples/src/filter-field/filter-field-default-example/filter-field-default-example.ts
@@ -25,29 +25,23 @@ export class DtExampleFilterFieldDefault {
   private DATA = {
     autocomplete: [
       {
-        name: 'AUT',
-        autocomplete: [{ name: 'Linz' }, { name: 'Vienna' }, { name: 'Graz' }],
-      },
-      {
-        name: 'USA',
+        name: 'items',
         autocomplete: [
-          { name: 'San Francisco' },
-          { name: 'Los Angeles' },
-          { name: 'New York' },
-          { name: 'Custom', suggestions: [], validators: [] },
+          { name: 'first item' },
+          { name: 'second item' },
+          { name: 'third item' },
+          { name: 'fourth item' },
+          { name: 'fifth item' },
+          { name: 'sixth item' },
+          { name: 'seventh item' },
+          { name: 'eighth item' },
+          { name: 'ninth item' },
+          { name: 'tenth item' },
+          { name: 'eleventh item' },
+          { name: 'twelfth item' },
+          { name: 'some very long item' },
+          { name: 'some even much longer item' },
         ],
-      },
-      {
-        name: 'Requests per minute',
-        range: {
-          operators: {
-            range: true,
-            equal: true,
-            greaterThanEqual: true,
-            lessThanEqual: true,
-          },
-          unit: 's',
-        },
       },
     ],
   };


### PR DESCRIPTION
### <strong>Pull Request</strong>
When the highlight was wrapped in an option in the filter field and out of view, it was not
initially rendered, but broke the layout of the autocomplete overlay by being too small.

When running and forcing highlight after the init a first time, the value will be mirrored into the
visible span, therefor giving it the size it should eventually have.

Fixes #1420

#### Type of PR

Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
