### PR TITLE
feat(empty-state): Remove deprecated CustomEmptyStateBase class.

### DIFF
--- a/libs/barista-components/empty-state/src/empty-state.ts
+++ b/libs/barista-components/empty-state/src/empty-state.ts
@@ -34,15 +34,10 @@ import {
   OnDestroy,
   QueryList,
   ViewEncapsulation,
-  ViewChild,
 } from '@angular/core';
+import { _toggleCssClass } from '@dynatrace/barista-components/core';
 import { Subject } from 'rxjs';
-import { takeUntil, startWith } from 'rxjs/operators';
-
-import {
-  DtViewportResizer,
-  _toggleCssClass,
-} from '@dynatrace/barista-components/core';
+import { takeUntil } from 'rxjs/operators';
 
 /** The min-width from which empty state items are displayed horizontally. */
 const ITEMS_HORIZONTAL_BREAKPOINT = 540;
@@ -190,11 +185,6 @@ export class DtEmptyState
   constructor(
     private _changeDetectorRef: ChangeDetectorRef,
     private _elementRef: ElementRef<HTMLElement>,
-    /**
-     * @deprecated Remove the viewportResizer from the constructor as it is no longer needed.
-     * @breaking-change Remove the viewportResizer in version 8.0.0
-     */
-    private _viewportResizer: DtViewportResizer,
     private _platform: Platform,
   ) {}
 
@@ -225,13 +215,6 @@ export class DtEmptyState
           }
         });
         this._containerSizeObserver.observe(this._elementRef.nativeElement);
-      } else {
-        this._viewportResizer
-          .change()
-          .pipe(startWith(null), takeUntil(this._destroy$))
-          .subscribe(() => {
-            this._updateLayout();
-          });
       }
     }
   }
@@ -260,45 +243,6 @@ export class DtEmptyState
       this._elementRef.nativeElement,
       'dt-empty-state-items-horizontal',
     );
-  }
-
-  /**
-   * @internal
-   * Updates the layout according to the width of the container (horizontal or vertical)
-   * @deprecated will be removed once the viewportResizer is removed from the constructor.
-   * @breaking-change Remove with version 8.0.0
-   */
-  _updateLayout(): void {
-    if (this._platform.isBrowser) {
-      const componentWidth = this._elementRef.nativeElement.getBoundingClientRect()
-        .width;
-      this._updateLayoutForSize(componentWidth);
-    }
-  }
-}
-
-/**
- * Empty state base class that needs to be implemented by every custom
- * empty state that is used inside the table. It provides a proxy to the updateLayout
- * function of the empty state that will be called by the table.
- *
- * @deprecated Remove this class, as it is no longer needed to proxy the update
- * layout call, when the layout updates are triggered by the resize observer.
- * @breaking-change Remove the viewportResizer in version 8.0.0
- */
-@Directive()
-export class DtCustomEmptyStateBase {
-  /** @internal Finds the empty state inside the component */
-  @ViewChild(DtEmptyState) _emptyState: DtEmptyState;
-
-  /**
-   * @internal
-   * Proxies the update layout function of the empty state
-   * to react to layout changes.
-   */
-  _updateLayout(): void {
-    // If we have an empty state proxy the updateLayout function
-    this._emptyState?._updateLayout();
   }
 }
 

--- a/libs/barista-components/table/src/table.spec.ts
+++ b/libs/barista-components/table/src/table.spec.ts
@@ -17,6 +17,8 @@
 // tslint:disable no-lifecycle-call no-use-before-declare no-magic-numbers
 // tslint:disable no-any max-file-line-count no-unbound-method use-component-selector
 
+import { CommonModule } from '@angular/common';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import {
   Component,
   DebugElement,
@@ -26,6 +28,20 @@ import {
   ViewChild,
   ViewChildren,
 } from '@angular/core';
+import { async, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import {
+  DtCustomEmptyState,
+  DtEmptyState,
+  DtEmptyStateModule,
+} from '@dynatrace/barista-components/empty-state';
+import { DtIconModule } from '@dynatrace/barista-components/icon';
+import { DtIndicatorModule } from '@dynatrace/barista-components/indicator';
+import {
+  DtLoadingDistractor,
+  DtLoadingDistractorModule,
+} from '@dynatrace/barista-components/loading-distractor';
 import {
   DtCell,
   DtExpandableCell,
@@ -37,24 +53,6 @@ import {
   DtTableLoadingState,
   DtTableModule,
 } from '@dynatrace/barista-components/table';
-import {
-  DtEmptyState,
-  DtEmptyStateModule,
-  DtCustomEmptyState,
-  DtCustomEmptyStateBase,
-} from '@dynatrace/barista-components/empty-state';
-import {
-  DtLoadingDistractor,
-  DtLoadingDistractorModule,
-} from '@dynatrace/barista-components/loading-distractor';
-import { TestBed, async, fakeAsync, tick } from '@angular/core/testing';
-
-import { By } from '@angular/platform-browser';
-import { CommonModule } from '@angular/common';
-import { DtIconModule } from '@dynatrace/barista-components/icon';
-import { DtIndicatorModule } from '@dynatrace/barista-components/indicator';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { createComponent } from '@dynatrace/testing/browser';
 
 describe('DtTable', () => {
@@ -893,4 +891,4 @@ export class TestCustomEmptyStateApp {
     </dt-empty-state>
   `,
 })
-export class CustomEmptyState extends DtCustomEmptyStateBase {}
+export class CustomEmptyState {}

--- a/libs/examples/src/empty-state/empty-state-custom-empty-state-table-example/empty-state-custom-empty-state-table-example.ts
+++ b/libs/examples/src/empty-state/empty-state-custom-empty-state-table-example/empty-state-custom-empty-state-table-example.ts
@@ -15,10 +15,7 @@
  */
 
 import { Component } from '@angular/core';
-import {
-  DtCustomEmptyStateBase,
-  DtEmptyState,
-} from '@dynatrace/barista-components/empty-state';
+import { DtEmptyState } from '@dynatrace/barista-components/empty-state';
 
 @Component({
   templateUrl: 'empty-state-custom-empty-state-table-example.html',
@@ -45,12 +42,12 @@ export class DtExampleCustomEmptyStateTable {}
             alt="My Asset"
           />
         </dt-empty-state-item-img>
-        <dt-empty-state-item-title aria-level="2"
-          >Reusable empty state</dt-empty-state-item-title
-        >
+        <dt-empty-state-item-title aria-level="2">
+          Reusable empty state
+        </dt-empty-state-item-title>
         Custom empty state message
       </dt-empty-state-item>
     </dt-empty-state>
   `,
 })
-export class DtExampleCustomEmptyState extends DtCustomEmptyStateBase {}
+export class DtExampleCustomEmptyState {}


### PR DESCRIPTION
BREAKING CHANGE: Remove ViewportResize and let the resize observer handle the layout changes. Therfore the custom empty state base class is not used anymore and is deleted now.

### <strong>Pull Request</strong>

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
