### PR TITLE
fix(button): Fixes an issue with secondary theme hover and active state

### DIFF
--- a/libs/barista-components/button/src/_button-theme.scss
+++ b/libs/barista-components/button/src/_button-theme.scss
@@ -87,7 +87,7 @@ a.dt-button-secondary:visited {
   }
 }
 .dt-button-secondary:hover:not([disabled]) {
-  background: $gray-100;
+  background: rgba(255, 255, 255, 0.2);
   border-color: var(--dt-button-hover-color);
   color: var(--dt-button-hover-color);
 
@@ -96,7 +96,7 @@ a.dt-button-secondary:visited {
   }
 }
 .dt-button-secondary:active:not([disabled]) {
-  background: $gray-100;
+  background: rgba(255, 255, 255, 0.2);
   border-color: var(--dt-button-active-color);
   color: var(--dt-button-active-color);
 


### PR DESCRIPTION
According to the UX guidelines hover/active states should not enforce strict background colors, but just some opacity.

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->

#### Checklist

- [*] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [*] Lint and unit tests pass locally with my changes
- [*] I have added tests that prove my fix is effective or that my feature works
- [*] I have added necessary documentation (if appropriate)

@ffriedl89 @lukasholzer FYI