### PR TITLE
feat(select): Remove deprecated function in select component

### DIFF
--- a/libs/barista-components/experimental/combobox/src/combobox.ts
+++ b/libs/barista-components/experimental/combobox/src/combobox.ts
@@ -201,8 +201,10 @@ export class DtCombobox<T> extends _DtComboboxMixinBase
     // tslint:disable-next-line:strict-type-predicates
     if (typeof fn !== 'function') {
       LOG.error(DT_COMPARE_WITH_NON_FUNCTION_VALUE_ERROR_MSG);
+    } else {
+      this._compareWith = fn;
     }
-    this._compareWith = fn;
+
     if (this._selectionModel) {
       // A different comparator means the selection could change.
       this._initializeSelection();

--- a/libs/barista-components/select/src/select.spec.ts
+++ b/libs/barista-components/select/src/select.spec.ts
@@ -67,18 +67,13 @@ import {
 } from '@dynatrace/barista-components/core';
 import { DtFormFieldModule } from '@dynatrace/barista-components/form-field';
 import { DtIconModule } from '@dynatrace/barista-components/icon';
-import {
-  DtSelect,
-  DtSelectModule,
-  getDtSelectNonFunctionValueError,
-} from '@dynatrace/barista-components/select';
+import { DtSelect, DtSelectModule } from '@dynatrace/barista-components/select';
 import {
   dispatchEvent,
   dispatchFakeEvent,
   dispatchKeyboardEvent,
   createComponent,
   createKeyboardEvent,
-  wrappedErrorMessage,
 } from '@dynatrace/testing/browser';
 
 describe('DtSelect', () => {
@@ -1734,16 +1729,6 @@ describe('DtSelect', () => {
 
         expect(instance.selectedFood.value).toEqual('steak-0');
         expect(instance.select.selected).toBeUndefined();
-      }));
-
-      it('should throw an error when using a non-function comparator', fakeAsync(() => {
-        instance.useNullComparator();
-
-        expect(() => {
-          fixture.detectChanges();
-        }).toThrowError(
-          wrappedErrorMessage(getDtSelectNonFunctionValueError()),
-        );
       }));
     });
   });

--- a/libs/barista-components/select/src/select.ts
+++ b/libs/barista-components/select/src/select.ts
@@ -138,13 +138,6 @@ export const _DtSelectMixinBase = mixinTabIndex(
   mixinDisabled(mixinErrorState(DtSelectBase)),
 );
 
-/**
- * @deprecated Will be removed with v8.0.0 - will not throw an Error after 8.0.0 but instead use the Logger
- * see combobox compareWith
- */
-export const getDtSelectNonFunctionValueError = () =>
-  new Error(DT_COMPARE_WITH_NON_FUNCTION_VALUE_ERROR_MSG);
-
 @Component({
   selector: 'dt-select',
   exportAs: 'dtSelect',
@@ -360,9 +353,11 @@ export class DtSelect<T> extends _DtSelectMixinBase
   set compareWith(fn: (v1: T, v2: T) => boolean) {
     // tslint:disable-next-line:strict-type-predicates
     if (typeof fn !== 'function') {
-      throw getDtSelectNonFunctionValueError();
+      LOG.error(DT_COMPARE_WITH_NON_FUNCTION_VALUE_ERROR_MSG);
+    } else {
+      this._compareWith = fn;
     }
-    this._compareWith = fn;
+
     if (this._selectionModel) {
       // A different comparator means the selection could change.
       this._initializeSelection();


### PR DESCRIPTION
### <strong>Remove deprecated function in select component</strong>

<hr>

Removed deprecated function `getDtSelectNonFunctionValueError()` in select component and replaced it with an error log.

> I also do not understand why this was deprecated in the first place. Because these changes can lead to a broken component, if the user provides something other than a function. (In my opinion it should rather be changed in the combobox to the solution we have here in the select).

@lukasholzer Any input on this? I haven't touched the select component before, so I cannot answer this question.