### PR TITLE
build(bazel): Fix npm install on windows.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,6 +25,9 @@ http_archive(
     name = "build_bazel_rules_nodejs",
     sha256 = RULES_NODEJS_SHA256,
     url = "https://github.com/bazelbuild/rules_nodejs/releases/download/%s/rules_nodejs-%s.tar.gz" % (RULES_NODEJS_VERSION, RULES_NODEJS_VERSION),
+    patches = [
+      "//:rules_nodejs-npm-install+2.0.3.patch",
+    ]
 )
 
 http_archive(
@@ -56,6 +59,7 @@ npm_install(
     ],
     package_json = "//:package.json",
     package_lock_json = "//:package-lock.json",
+    quiet = False,
     symlink_node_modules = True,
 )
 

--- a/rules_nodejs-npm-install+2.0.3.patch
+++ b/rules_nodejs-npm-install+2.0.3.patch
@@ -1,0 +1,13 @@
+diff --git internal/npm_install/npm_install.bzl internal/npm_install/npm_install.bzl
+index 7bbe1297..9dfb51c3 100644
+--- internal/npm_install/npm_install.bzl
++++ internal/npm_install/npm_install.bzl
+@@ -225,7 +225,7 @@ set -e
+         repository_ctx.file(
+             "_npm.cmd",
+             content = """@echo off
+-cd /D "{root}" && "{npm}" {npm_args}
++cd /D "{root}" && npm {npm_args}
+ """.format(
+                 root = root,
+                 npm = repository_ctx.path(npm),


### PR DESCRIPTION
### <strong>Pull Request</strong>

Currently `npm_install` cannot access npm binaries in postinstall script on windows. With this small patch the postinstall script is using the global npm executable that is set via nodejs. 

Patch for https://github.com/bazelbuild/rules_nodejs/issues/2144.
