### PR TITLE
Fix a regression that was introduced with the update to the new typescript version.

### DIFF
--- a/libs/barista-components/button-group/src/button-group.ts
+++ b/libs/barista-components/button-group/src/button-group.ts
@@ -41,12 +41,12 @@ import {
   mixinColor,
   mixinTabIndex,
   _readKeyCode,
+  HasElementRef,
 } from '@dynatrace/barista-components/core';
 
-export class DtButtonGroupBase {
-  disabled: boolean;
-}
-export const _DtButtonGroup = mixinTabIndex(DtButtonGroupBase);
+export const _DtButtonGroup = mixinTabIndex(
+  class {} as Constructor<CanDisable>,
+);
 
 @Component({
   selector: 'dt-button-group',
@@ -156,15 +156,14 @@ export interface DtButtonGroupItemSelectionChange<T> {
 
 export type DtButtonGroupThemePalette = 'main' | 'error';
 export class DtButtonGroupItemBase {
-  /** Whether the button group item is disabled. */
-  disabled: boolean;
   constructor(public _elementRef: ElementRef) {}
 }
+
 export const _DtButtonGroupItem = mixinTabIndex(
-  mixinColor<Constructor<DtButtonGroupItemBase>, DtButtonGroupThemePalette>(
-    DtButtonGroupItemBase,
-    'main',
-  ),
+  mixinColor<
+    Constructor<CanDisable & HasElementRef>,
+    DtButtonGroupThemePalette
+  >(DtButtonGroupItemBase as Constructor<CanDisable & HasElementRef>, 'main'),
 );
 
 @Component({
@@ -247,7 +246,8 @@ export class DtButtonGroupItem<T> extends _DtButtonGroupItem
   constructor(
     private _buttonGroup: DtButtonGroup<T>,
     private _changeDetectorRef: ChangeDetectorRef,
-    _elementRef: ElementRef,
+    /** @internal */
+    public _elementRef: ElementRef,
     private _focusMonitor: FocusMonitor,
   ) {
     super(_elementRef);

--- a/libs/barista-components/core/src/common-behaviours/color.ts
+++ b/libs/barista-components/core/src/common-behaviours/color.ts
@@ -70,7 +70,6 @@ export function mixinColor<
     // tslint:disable-next-line:no-any
     constructor(...args: any[]) {
       super(...args);
-
       // Set the default color that can be specified from the mixin.
       this.color = defaultColor as P;
     }


### PR DESCRIPTION
Typescript can now differentiate between properties a get Accessors in the type declarations of the mixins so it broke with the new update

Fixes #1577

### <strong>Pull Request</strong>

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
