### PR TITLE
chore: Remove the customizable tooltip references from the micro-chart doc

### DIFF
--- a/libs/barista-components/micro-chart/README.md
+++ b/libs/barista-components/micro-chart/README.md
@@ -45,12 +45,6 @@ To use a micro chart, add the `<dt-micro-chart>` element to the view and set
 | `seriesId`          | `string | undefined` | Gets the series ID of the series currently used in the chart. |
 | `highchartsOptions` | `Options`            | Returns highchart options which are used in the chart.        |
 
-## Content children
-
-As the microchart component is a wrapper for charts, the same content children –
-e.g. a `dt-chart-tooltip` – can be used. Find details on the
-[chart page](/components/charts/).
-
 ## Variants
 
 <ba-ux-snippet name="micro-chart-variants"></ba-ux-snippet>

--- a/libs/examples/src/micro-chart/micro-chart-columns-example/micro-chart-columns-example.html
+++ b/libs/examples/src/micro-chart/micro-chart-columns-example/micro-chart-columns-example.html
@@ -1,7 +1,1 @@
-<dt-micro-chart [options]="options" [series]="series">
-  <dt-chart-tooltip>
-    <ng-template let-tooltip>
-      {{ tooltip.y | dtCount }}
-    </ng-template>
-  </dt-chart-tooltip>
-</dt-micro-chart>
+<dt-micro-chart [options]="options" [series]="series"> </dt-micro-chart>

--- a/libs/examples/src/micro-chart/micro-chart-columns-interpolated-example/micro-chart-columns-interpolated-example.html
+++ b/libs/examples/src/micro-chart/micro-chart-columns-interpolated-example/micro-chart-columns-interpolated-example.html
@@ -1,7 +1,1 @@
-<dt-micro-chart [options]="options" [series]="series">
-  <dt-chart-tooltip>
-    <ng-template let-tooltip>
-      {{ tooltip.y | dtCount }}
-    </ng-template>
-  </dt-chart-tooltip>
-</dt-micro-chart>
+<dt-micro-chart [options]="options" [series]="series"> </dt-micro-chart>

--- a/libs/examples/src/micro-chart/micro-chart-default-example/micro-chart-default-example.html
+++ b/libs/examples/src/micro-chart/micro-chart-default-example/micro-chart-default-example.html
@@ -1,7 +1,2 @@
 <dt-micro-chart [series]="series" [labelFormatter]="_formatterFn">
-  <dt-chart-tooltip>
-    <ng-template let-tooltip>
-      {{ tooltip.y | dtCount }}
-    </ng-template>
-  </dt-chart-tooltip>
 </dt-micro-chart>

--- a/libs/examples/src/micro-chart/micro-chart-interpolated-example/micro-chart-interpolated-example.html
+++ b/libs/examples/src/micro-chart/micro-chart-interpolated-example/micro-chart-interpolated-example.html
@@ -1,7 +1,1 @@
-<dt-micro-chart [options]="options" [series]="series">
-  <dt-chart-tooltip>
-    <ng-template let-tooltip>
-      {{ tooltip.y | dtCount }}
-    </ng-template>
-  </dt-chart-tooltip>
-</dt-micro-chart>
+<dt-micro-chart [options]="options" [series]="series"> </dt-micro-chart>

--- a/libs/examples/src/micro-chart/micro-chart-stream-example/micro-chart-stream-example.html
+++ b/libs/examples/src/micro-chart/micro-chart-stream-example/micro-chart-stream-example.html
@@ -1,7 +1,1 @@
-<dt-micro-chart [options]="options" [series]="series$">
-  <dt-chart-tooltip>
-    <ng-template let-tooltip>
-      {{ tooltip.y | dtCount }}
-    </ng-template>
-  </dt-chart-tooltip>
-</dt-micro-chart>
+<dt-micro-chart [options]="options" [series]="series$"> </dt-micro-chart>


### PR DESCRIPTION
### <strong>Pull Request</strong>

Remove the customizable tooltip references from the micro-chart documentation. It will not be possible in the future to have customizable tooltip for the micro chart, only the default one. The references to hat approach has to be removed from the documentation.

#### Type of PR

Documentation update (changes to documentation)