### PR TITLE
Revert "fix(filter-field): Fixed UX problem where text that wasn't applied to the filter would remain after losing focus."

### DIFF
--- a/libs/barista-components/filter-field/src/filter-field.spec.ts
+++ b/libs/barista-components/filter-field/src/filter-field.spec.ts
@@ -252,20 +252,6 @@ describe('DtFilterField', () => {
     });
   });
 
-  describe('focus loss', () => {
-    it('should clear the current input value', fakeAsync(() => {
-      const input = fixture.debugElement.query(By.css('.dt-filter-field-input'))
-        .nativeElement;
-
-      filterField.focus();
-      typeIntoFilterElement('foo');
-      input.blur();
-      tick();
-
-      expect(input.value).toBe('');
-    }));
-  });
-
   describe('disabled', () => {
     it('should disable the input if filter field is disabled', () => {
       // when

--- a/libs/barista-components/filter-field/src/filter-field.ts
+++ b/libs/barista-components/filter-field/src/filter-field.ts
@@ -538,10 +538,6 @@ export class DtFilterField<T = any>
         // Assign the currently open filter field when it is focused.
         if (this._isFocused) {
           currentlyOpenFilterField = this;
-        } else {
-          // Clear pending input values on focus loss to communicate that the input
-          // wasn't applied as a filter
-          this._writeInputValue('');
         }
       });
 


### PR DESCRIPTION
Reverts dynatrace-oss/barista#1585
Fixes dynatrace-oss/barista#1632

---

### Explaination
The code caused the filter field to not properly select suggestion values when typing in filter text any more.
This seems to be caused by the fact, that the filter field does not only loose focus when the user clicks outside of the filter field but also when the user selects a prefiltered value from the suggestion dropdown.

IMHO clearing the text input when the filter field looses focus is an ux improvement and should not be seen as a bug, thus not being included in any patch version.

I would propose to re-open #1572 and postpone this change to `8.1.x`, keeping this regression in mind when re-implementing.