### PR TITLE
fix(a11y): Fixes flaky combobox a11y test and changes aria attribute in button-group-item

### DIFF
--- a/apps/components-e2e/src/components/button-group/button-group.e2e.ts
+++ b/apps/components-e2e/src/components/button-group/button-group.e2e.ts
@@ -17,12 +17,7 @@
 // tslint:disable no-lifecycle-call no-use-before-declare no-magic-numbers
 // tslint:disable no-any max-file-line-count no-unbound-method use-component-selector
 
-import {
-  groupItem,
-  isDisabled,
-  isSelected,
-  labelText,
-} from './button-group.po';
+import { groupItem, isDisabled, isChecked, labelText } from './button-group.po';
 
 fixture('Button Group').page('http://localhost:4200/button-group');
 
@@ -36,12 +31,12 @@ test('should execute click handlers when not disabled', async (testController: T
 
 test('should have styles', async (testController: TestController) => {
   await testController.click(groupItem(0));
-  await testController.expect(await isSelected(groupItem(0))).ok();
-  await testController.expect(await isSelected(groupItem(1))).notOk();
+  await testController.expect(await isChecked(groupItem(0))).ok();
+  await testController.expect(await isChecked(groupItem(1))).notOk();
 
   await testController.click(groupItem(1));
-  await testController.expect(await isSelected(groupItem(0))).notOk();
-  await testController.expect(await isSelected(groupItem(1))).ok();
+  await testController.expect(await isChecked(groupItem(0))).notOk();
+  await testController.expect(await isChecked(groupItem(1))).ok();
 });
 
 test('should not execute click handlers when disabled', async (testController: TestController) => {

--- a/apps/components-e2e/src/components/button-group/button-group.po.ts
+++ b/apps/components-e2e/src/components/button-group/button-group.po.ts
@@ -22,8 +22,8 @@ export const groupItem = (item: number, group = 1) =>
 export const labelText = async (group = 1) =>
   Selector(`#lblGroup-${group}`).textContent;
 
-export const isSelected = async (item: Selector) =>
-  item.hasClass('dt-button-group-item-selected');
+export const isChecked = async (item: Selector) =>
+  item.hasClass('dt-button-group-item-checked');
 
 export const isDisabled = async (item: Selector) =>
   item.hasClass('dt-button-group-item-disabled');

--- a/libs/barista-components/button-group/README.md
+++ b/libs/barista-components/button-group/README.md
@@ -54,14 +54,24 @@ To apply the button group component, use the `<dt-button-group>` and
 
 ## Button group item inputs
 
-| Name           | Type                  | Default     | Description                                                                                            |
-| -------------- | --------------------- | ----------- | ------------------------------------------------------------------------------------------------------ |
-| `<ng-content>` |                       |             | The content which is displayed inside of the item. This should only be text.                           |
-| `value`        | `T | undefined`       | `undefined` | The associated value of this item                                                                      |
-| `disabled`     | `boolean | undefined` | `undefined` | Sets disabled state if property is set and the value is truthy or undefined                            |
-| `tabIndex`     | `number`              | `0`         | Sets and gets the tabIndex property                                                                    |
-| `selected`     | `boolean`             | `false`     | Sets or gets the selected state of this item                                                           |
-| `color`        | `'main' | 'error'`    | `main`      | Sets color. Possible options: <ul><li><code>main</code> (default)</li><li><code>error</code></li></ul> |
+| Name                    | Type                  | Default     | Description                                                                                            |
+| ----------------------- | --------------------- | ----------- | ------------------------------------------------------------------------------------------------------ |
+| `<ng-content>`          |                       |             | The content which is displayed inside of the item. This should only be text.                           |
+| `value`                 | `T | undefined`       | `undefined` | The associated value of this item                                                                      |
+| `disabled`              | `boolean | undefined` | `undefined` | Sets disabled state if property is set and the value is truthy or undefined                            |
+| `tabIndex`              | `number`              | `0`         | Sets and gets the tabIndex property                                                                    |
+| _deprecated_ `selected` | `boolean`             | `false`     | Sets or gets the selected state of this item                                                           |
+| `checked`               | `boolean`             | `false`     | Sets or gets the checked state of this item                                                            |
+| `color`                 | `'main' | 'error'`    | `main`      | Sets color. Possible options: <ul><li><code>main</code> (default)</li><li><code>error</code></li></ul> |
+
+The property `selected` is deprecated and will be renamed to `checked` in
+version 9.0.0
+
+## Button group item outputs
+
+| Name            | Type                                       | Description                                        |
+| --------------- | ------------------------------------------ | -------------------------------------------------- |
+| `checkedChange` | `event<DtButtonGroupItemCheckedChange<T>>` | Emits an event when the checked attribute changed. |
 
 ## Button group item methods
 

--- a/libs/barista-components/button-group/src/_button-group-item-theme.scss
+++ b/libs/barista-components/button-group/src/_button-group-item-theme.scss
@@ -20,7 +20,7 @@
   border-color: var(--dt-button-group-hover-color);
 }
 
-:host.dt-button-group-item.dt-button-group-item-selected,
+:host.dt-button-group-item.dt-button-group-item-checked,
 :host.dt-button-group-item:active {
   &:not(.dt-button-group-item-disabled) {
     z-index: 1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11937,9 +11937,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
-      "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.0.2.tgz",
+      "integrity": "sha512-arU1h31OGFu+LPrOLGZ7nB45v940NMDMEJeNmbutu57P+UFDVnkZg3e+J1I2HJRZ9hT7gO8J91dn/PMrAiKakA==",
       "dev": true
     },
     "axe-testcafe": {

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "@types/theo": "^8.1.3",
     "@types/xml2js": "^0.4.5",
     "@types/yaml": "^1.9.7",
-    "axe-core": "^3.5.5",
+    "axe-core": "^4.0.2",
     "axe-testcafe": "^3.0.0",
     "axios": "^0.19.0",
     "chalk": "^4.1.0",


### PR DESCRIPTION
### <strong>Pull Request</strong>

I've updated axe-core to v4.0.2 and then let the a11y tests run locally and on the CI a few times without errors thrown.
This resulted in the ButtonGroupItem component to fail due to the a11y rule 
`Elements must only use allowed ARIA attributes`, so I changed the attribute from `aria-selected` to `aria-checked`.

Fixes: #1680 

#### Type of PR

Bugfix (non-breaking change which fixes an issue)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
