### PR TITLE
fix(tree-table): Reverts changes causing unwanted behaviour expanding text on hover

### DIFF
--- a/libs/barista-components/tree-table/README.md
+++ b/libs/barista-components/tree-table/README.md
@@ -166,9 +166,7 @@ You want to add the table header by adding a `<dt-header-row>` inside the
 The next step is to add the row where the columns get rendered. You can do this
 by adding the `<dt-tree-table-row>` inside the `<dt-tree-table>` tag. You can
 specify the columns that should be rendered and don't forget to bind the row's
-data to the `<dt-tree-table-row>`s data input `[data]="row"`. The text contained
-will be cut to preserve the width correctly. Hovering over the cell/text will
-reveal the whole text.
+data to the `<dt-tree-table-row>`s data input `[data]="row"`.
 
 ```html
 <dt-tree-table-row

--- a/libs/barista-components/tree-table/src/tree-table-row.scss
+++ b/libs/barista-components/tree-table/src/tree-table-row.scss
@@ -35,18 +35,6 @@
   &:nth-child(odd) ::ng-deep .dt-tree-toggle-cell {
     border-left: solid 1px $dt-table-row-color-odd;
   }
-
-  &::ng-deep .dt-tree-toggle-cell {
-    max-width: 24vw;
-  }
-
-  &::ng-deep .dt-tree-toggle-cell:hover {
-    max-width: none;
-  }
-
-  &::ng-deep .dt-info-group-title {
-    text-overflow: ellipsis;
-  }
 }
 
 :host.dt-table-row-indicator ::ng-deep .dt-tree-table-toggle-cell-wrap::before {

--- a/libs/barista-components/tree-table/src/tree-table-toggle-cell.html
+++ b/libs/barista-components/tree-table/src/tree-table-toggle-cell.html
@@ -13,7 +13,5 @@
       [name]="_isExpanded ? 'dropdownopen' : 'dropdownclosed'"
     ></dt-icon>
   </button>
-  <div class="dt-tree-table-content">
-    <ng-content></ng-content>
-  </div>
+  <ng-content></ng-content>
 </div>

--- a/libs/barista-components/tree-table/src/tree-table-toggle-cell.scss
+++ b/libs/barista-components/tree-table/src/tree-table-toggle-cell.scss
@@ -14,10 +14,3 @@
   align-items: center;
   position: relative;
 }
-
-.dt-tree-table-content {
-  width: auto;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}


### PR DESCRIPTION
### <strong>Pull Request</strong>

Reverts the changes made in the PR's #1564 and #1626 from issue #1502  back to the original behavior of hiding the overflow and setting `text-overflow: ellipsis`

fixes: #1681

#### Type of PR

Bugfix (non-breaking change which fixes an issue)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
