### PR TITLE
barista: Breadcrumbs are no longer work in progress.

### DIFF
--- a/libs/barista-components/breadcrumbs/barista.json
+++ b/libs/barista-components/breadcrumbs/barista.json
@@ -5,7 +5,6 @@
   "category": "components",
   "public": true,
   "toc": true,
-  "properties": ["work in progress"],
   "contributors": {
     "dev": [
       {


### PR DESCRIPTION
### <strong>Pull Request</strong>
Breadcrumbs are still marked _work in progress_. Is this still the case?

#### Type of PR
Documentation 

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
