### PR TITLE
fix(option): Fixes truncate issue in firefox

### DIFF
--- a/libs/barista-components/autocomplete/src/autocomplete.scss
+++ b/libs/barista-components/autocomplete/src/autocomplete.scss
@@ -22,6 +22,13 @@ $dt-autocomplete-panel-min-width: 112px !default;
   -webkit-overflow-scrolling: touch; // for momentum scroll on mobile
 }
 
+@supports (-moz-appearance: none) {
+  .dt-autocomplete-panel {
+    width: calc(100% + 20px);
+    flex-shrink: 0; // to not shrink on FF if there is a scroll bar
+  }
+}
+
 .dt-autocomplete-hidden {
   display: none;
 }

--- a/libs/barista-components/core/src/option/option.html
+++ b/libs/barista-components/core/src/option/option.html
@@ -1,0 +1,3 @@
+<span class="dt-option-label">
+  <ng-content></ng-content>
+</span>

--- a/libs/barista-components/core/src/option/option.scss
+++ b/libs/barista-components/core/src/option/option.scss
@@ -3,16 +3,17 @@
 
 :host {
   @include dt-main-font();
-  display: block;
+  position: relative;
+  cursor: pointer;
+  outline: none;
+  display: flex;
+  flex-direction: row;
+  max-width: 100%;
+  box-sizing: border-box;
+  align-items: center;
   padding: 0 12px;
   font-size: 14px;
   line-height: 28px;
-  cursor: default;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  outline: none;
-  font-variant: tabular-nums;
 
   &:not(.dt-option-disabled).dt-option-active {
     background-color: $turquoise-100;
@@ -26,4 +27,12 @@
   &.dt-option-disabled {
     color: $disabledcolor;
   }
+}
+
+.dt-option-label {
+  display: inline-block;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/libs/barista-components/core/src/option/option.ts
+++ b/libs/barista-components/core/src/option/option.ts
@@ -67,7 +67,7 @@ export class DtOptionSelectionChange<T> {
     class: 'dt-option',
   },
   styleUrls: ['option.scss'],
-  template: '<ng-content></ng-content>',
+  templateUrl: 'option.html',
   encapsulation: ViewEncapsulation.Emulated,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
### <strong>Pull Request</strong>

The autocomplete was behaving weirdly in firefox (fixes #1651)
The text in the option was cut off because the scrollbar is rendered identical to the scrollbar on mac maschines. It overlaps the content beneath it so it shrinks the option element. To accomadate, we added a firefox only selector adding 20px to the width of the autocomplete.
This will result in a wider autocomplete than before when there is no scrolling but solves the truncation of the options.

Thank you @bardosmisi for the support on this issue.

#### Type of PR

Bugfix (non-breaking change which fixes an issue)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
