### PR TITLE
fix(context-dialog): Focuses the first tabbable element inside the overlay con…

### DIFF
--- a/libs/barista-components/context-dialog/src/context-dialog.html
+++ b/libs/barista-components/context-dialog/src/context-dialog.html
@@ -14,6 +14,11 @@
 </button>
 <ng-template>
   <div class="dt-context-dialog-panel" #panel role="dialog" dtTheme=":dark">
+    <ng-content select="dt-context-dialog-header"></ng-content>
+    <div class="dt-context-dialog-content" [ngClass]="overlayPanelClass">
+      <ng-content></ng-content>
+    </div>
+    <ng-content select="dt-context-dialog-footer"></ng-content>
     <button
       dt-icon-button
       variant="secondary"
@@ -24,10 +29,5 @@
     >
       <dt-icon name="abort"></dt-icon>
     </button>
-    <ng-content select="dt-context-dialog-header"></ng-content>
-    <div class="dt-context-dialog-content" [ngClass]="overlayPanelClass">
-      <ng-content></ng-content>
-    </div>
-    <ng-content select="dt-context-dialog-footer"></ng-content>
   </div>
 </ng-template>

--- a/libs/barista-components/context-dialog/src/context-dialog.ts
+++ b/libs/barista-components/context-dialog/src/context-dialog.ts
@@ -268,7 +268,7 @@ export class DtContextDialog extends _DtContextDialogMixinBase
         this._overlayRef.overlayElement,
       );
       this._focusTrap
-        .focusLastTabbableElementWhenReady()
+        .focusFirstTabbableElementWhenReady()
         .catch((error: Error) => {
           if (isDevMode()) {
             LOG.debug('Error when trying to set initial focus', error);


### PR DESCRIPTION
### <strong>Pull Request</strong>

Fixes a bug that caused the last tabbable item in an overlay context to be focused. The list of elements in the overlay was scrolled to the bottom as the focus is set to the last element.

_**Fixed**_ by focusing the first tabbable item

fixes #1649 

#### Type of PR

Bugfix (non-breaking change which fixes an issue)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
