### PR TITLE
build(design-tokens): Consume output with Bazel

### DIFF
--- a/libs/shared/design-tokens/BUILD.bazel
+++ b/libs/shared/design-tokens/BUILD.bazel
@@ -1,13 +1,16 @@
 load("@npm//@bazel/typescript:index.bzl", "ts_library")
 load("//tools/design-tokens:index.bzl", "build_design_tokens", "generate_color_palette")
 
+# TODO: remove this
+load("//tools/bazel_rules:index.bzl", "rollup")
+
 package(default_visibility = ["//:__subpackages__"])
 
 ts_library(
     name = "design-tokens",
-    srcs = glob(["generated/**/*.ts"]),
+    srcs = [":build"],
     module_name = "@dynatrace/fluid-design-tokens",
-    module_root = "generated",
+    module_root = "build",
     tsconfig = "//:tsconfig.base.json",
     deps = [
         "@npm//tslib",
@@ -20,7 +23,23 @@ generate_color_palette(
 )
 
 build_design_tokens(
-  name = "build",
-  entrypoints = glob(["src/lib/global/*.yml", "src/lib/patterns/*.yml"]),
-  aliases_entrypoints = glob(["src/lib/aliases/*.yml"]) + [":color_palette"]
+    name = "build",
+    entrypoints = glob(["src/lib/global/*.yml", "src/lib/patterns/*.yml"]),
+    aliases_entrypoints = glob(["src/lib/aliases/*.yml"]) + [":color_palette"]
+)
+
+ts_library(
+    name = "testlib",
+    srcs = ["dummy.ts"],
+    tsconfig = "//:tsconfig.base.json",
+    deps = [
+        ":design-tokens",
+        "@npm//tslib",
+    ],
+)
+
+rollup(
+    name = "testbuild",
+    entry_point = {"dummy.ts": "dummy.build.js"},
+    deps = [":testlib"],
 )

--- a/libs/shared/design-tokens/dummy.ts
+++ b/libs/shared/design-tokens/dummy.ts
@@ -1,0 +1,7 @@
+import {
+  FLUID_BUTTON_PADDING_SMALL,
+  FLUID_BUTTON_PADDING_MEDIUM,
+} from './build/ts';
+
+console.log(FLUID_BUTTON_PADDING_SMALL);
+console.log(FLUID_BUTTON_PADDING_MEDIUM);

--- a/tools/bazel_rules/rollup/rollup.bzl
+++ b/tools/bazel_rules/rollup/rollup.bzl
@@ -16,8 +16,9 @@ def _npm_deps_aspect(target, ctx):
 
     # If the target is not from the external npm repository it is a target
     # like the ts_library with dependencies
-    for dep in ctx.rule.attr.deps:
-        deps.append(dep.label.package)
+    if hasattr(ctx.rule.attr, 'deps'):
+        for dep in ctx.rule.attr.deps:
+            deps.append(dep.label.package)
 
     return [NpmDepsInfo(
         transitive_dependencies = deps,

--- a/tools/design-tokens/build/build_design_tokens.bzl
+++ b/tools/design-tokens/build/build_design_tokens.bzl
@@ -1,3 +1,6 @@
+load("@build_bazel_rules_nodejs//:providers.bzl", "declaration_info", "js_module_info")
+load("@io_bazel_rules_sass//:defs.bzl", "SassInfo")
+
 """
 Build rule for generating design token outputs
 """
@@ -19,18 +22,25 @@ def _build_design_tokens_impl(ctx):
     inputs.extend(entrypoint_files)
     inputs.extend(aliases_entrypoint_files)
 
-    output_directory_name = ctx.attr.output_directory_name
-    output_dir = ctx.actions.declare_directory(output_directory_name)
-    
-    outputs = [output_dir]
+    typescript_output_dir = ctx.actions.declare_directory(ctx.attr.typescript_output_directory_name)
+    javascript_output_dir = ctx.actions.declare_directory(ctx.attr.javascript_output_directory_name)
+    scss_output_dir = ctx.actions.declare_directory(ctx.attr.scss_output_directory_name)
+    css_output_dir = ctx.actions.declare_directory(ctx.attr.css_output_directory_name)
+    json_output_dir = ctx.actions.declare_directory(ctx.attr.json_output_directory_name)
+
+    outputs = [typescript_output_dir, javascript_output_dir, scss_output_dir, css_output_dir, json_output_dir]
 
     args = []
     args.append("--entrypoints")
     args.extend([file.path for file in entrypoint_files])
     args.append("--aliases-entrypoints")
     args.extend([file.path for file in aliases_entrypoint_files])
-    args.append("--output-path")
-    args.append(output_dir.path)
+
+    args.extend(["--typescript-output-path", typescript_output_dir.path])
+    args.extend(["--javascript-output-path", javascript_output_dir.path])
+    args.extend(["--scss-output-path", scss_output_dir.path])
+    args.extend(["--css-output-path", css_output_dir.path])
+    args.extend(["--json-output-path", json_output_dir.path])
 
     ctx.actions.run(
         mnemonic = "DesignTokensBuild",
@@ -42,7 +52,13 @@ def _build_design_tokens_impl(ctx):
         tools = [executable]
     )
 
-    return [DefaultInfo(files = depset(outputs))]
+    return [
+        # Factory functions should be used for TS and JS providers
+        declaration_info(declarations = depset([typescript_output_dir])),
+        js_module_info(sources = depset([javascript_output_dir])),
+        SassInfo(transitive_sources = depset([scss_output_dir])),
+        DefaultInfo(files = depset([css_output_dir, json_output_dir])),
+    ]
 
 build_design_tokens = rule(
     implementation = _build_design_tokens_impl,
@@ -63,15 +79,31 @@ build_design_tokens = rule(
             default = [],
             doc = "Alias entry point tokens .yml files",
         ),
-        "output_directory_name": attr.string(
-            doc = "Target output directory",
-        )
+        "typescript_output_directory_name": attr.string(
+            doc = "Target output directory for Typescript files",
+        ),
+        "javascript_output_directory_name": attr.string(
+            doc = "Target output directory for Javascript files",
+        ),
+        "scss_output_directory_name": attr.string(
+            doc = "Target output directory for SCSS files",
+        ),
+        "css_output_directory_name": attr.string(
+            doc = "Target output directory for CSS files",
+        ),
+        "json_output_directory_name": attr.string(
+            doc = "Target output directory for JSON files",
+        ),
     },
 )
 
 def build_design_tokens_macro(name, **kwargs):
     build_design_tokens(
         name = name,
-        output_directory_name = name,
+        typescript_output_directory_name = name + "/ts",
+        javascript_output_directory_name = name + "/js",
+        scss_output_directory_name = name + "/scss",
+        css_output_directory_name = name + "/css",
+        json_output_directory_name = name + "/json",
         **kwargs
     )

--- a/tools/design-tokens/build/src/options.ts
+++ b/tools/design-tokens/build/src/options.ts
@@ -20,6 +20,14 @@ export interface DesignTokensBuildOptions {
   entrypoints: string[];
   /** List of glob patterns for alias files to build JSON metadata for as required by some applications. */
   aliasesEntrypoints: string[];
-  /** Output path that defines the destination directory. */
-  outputPath: string;
+  /** Output path that defines the destination directory for Typescript files. */
+  typescriptOutputPath: string;
+  /** Output path that defines the destination directory for Javascript files. */
+  javascriptOutputPath: string;
+  /** Output path that defines the destination directory for SCSS files. */
+  scssOutputPath: string;
+  /** Output path that defines the destination directory for CSS files. */
+  cssOutputPath: string;
+  /** Output path that defines the destination directory for JSON files. */
+  jsonOutputPath: string;
 }


### PR DESCRIPTION
### <strong>Pull Request</strong>

Allows directly consuming the design tokens built with Bazel instead of copying the generated tokens back into the repository.

#### Type of PR

Other