### PR TITLE
Ci/check cache hits

### DIFF
--- a/.buildkite/baristaPipeline.yml
+++ b/.buildkite/baristaPipeline.yml
@@ -1,6 +1,7 @@
 tasks:
   default:
     build:
+      execution_log_binary_file: false
       trigger:
         - test
       pre_cmd:
@@ -13,6 +14,7 @@ tasks:
       post_cmd:
         - echo "Post command"
     test:
+      execution_log_binary_file: false
       bazel_flags:
         - "--keep_going"
       bazel_cmd:
@@ -29,8 +31,6 @@ tasks:
         - bash -c ".buildkite/build_cache/setup_ci_build_cache.sh"
       bazel_cmd:
         - "//..."
-      post_cmd:
-        - dir
     test:
       disable: true
       bazel_flags:


### PR DESCRIPTION
### <strong>Pull Request</strong>

<hr>

- Remove man page entries in sshpk package.json to get rid of insufficient usage of bazel cache.

e.g.

```
 "man": [
    "/var/lib/buildkite-agent/builds/designops-buildkite-i-0e57b7da3745f484a-1/dynatrace/bazel/node_modules/sshpk/man/man1/sshpk-conv.1",
    "/var/lib/buildkite-agent/builds/designops-buildkite-i-0e57b7da3745f484a-1/dynatrace/bazel/node_modules/sshpk/man/man1/sshpk-sign.1",
    "/var/lib/buildkite-agent/builds/designops-buildkite-i-0e57b7da3745f484a-1/dynatrace/bazel/node_modules/sshpk/man/man1/sshpk-verify.1"
  ],
```
Generated bazel sha key differs from one build/test to the next one because path of workspace isn't the same across each nodes.

- added option to enable and disable `execution_log_binary_file` creation
#### Type of PR

Bugfix (non-breaking change which fixes an issue) 
