### PR TITLE
ci: Shutdown bazel server after build on windows 

### DIFF
--- a/.buildkite/baristaPipeline.yml
+++ b/.buildkite/baristaPipeline.yml
@@ -27,6 +27,8 @@ tasks:
         - bash -c ".buildkite/build_cache/setup_ci_build_cache.sh"
       bazel_cmd:
         - "//..."
+      post_cmd:
+        - bazel shutdown
     test:
       disable: true
       bazel_flags:


### PR DESCRIPTION
(this prevents 'Permission denied' errors in next build)

### <strong>Pull Request</strong>

<hr>
#### Type of PR

Bugfix (non-breaking change which fixes an issue) 

