### PR TITLE
ci: Do not fail immediately (if bazel build fails) to be able to shut…

### DIFF
--- a/.buildkite/baristaPipeline.yml
+++ b/.buildkite/baristaPipeline.yml
@@ -10,12 +10,16 @@ tasks:
         - "--keep_going"
       bazel_cmd:
         - "//..."
+      post_cmd:
+        - bazel shutdown
     test:
       execution_log_binary_file: false
       bazel_flags:
         - "--keep_going"
       bazel_cmd:
         - "//..."
+      post_cmd:
+        - bazel shutdown
   windows10:
     build:
       disable: false
@@ -35,3 +39,5 @@ tasks:
         - "--keep_going"
       bazel_cmd:
         - "//..."
+      post_cmd:
+        - bazel shutdown


### PR DESCRIPTION
…down bazel server.

This should help builds in CI to get a fresh instance without a running bazel server.

### <strong>Pull Request</strong>

<hr>

#### Type of PR

Bugfix (non-breaking change which fixes an issue)

