### PR TITLE
fix(drawer): Fixes an issue of width-drift when closing the drawer.

### DIFF
--- a/apps/components-e2e/src/components/quick-filter/quick-filter/quick-filter.html
+++ b/apps/components-e2e/src/components/quick-filter/quick-filter/quick-filter.html
@@ -9,7 +9,12 @@
     All options in the filter field above
   </dt-quick-filter-sub-title>
 
-  my content
+  <div>
+    my contentmy contentmy contentmy contentmy contentmy contentmy contentmy
+    contentmy contentmy contentmy contentmy contentmy contentmy contentmy
+    contentmy contentmy contentmy contentmy contentmy contentmy contentmy
+    contentmy contentmy contentmy contentmy contentmy contentmy content
+  </div>
 </dt-quick-filter>
 
 <button id="switchToFirstDatasource" (click)="switchToDataSource(0)">

--- a/libs/barista-components/drawer/src/drawer.html
+++ b/libs/barista-components/drawer/src/drawer.html
@@ -1,3 +1,7 @@
-<div class="dt-drawer-body">
+<div
+  class="dt-drawer-body"
+  [style.min-width.px]="_closedWidth"
+  [style.max-width.px]="_closedWidth"
+>
   <ng-content></ng-content>
 </div>

--- a/libs/barista-components/drawer/src/drawer.ts
+++ b/libs/barista-components/drawer/src/drawer.ts
@@ -177,6 +177,14 @@ export class DtDrawer implements OnInit, AfterContentChecked, OnDestroy {
    */
   _animationEnd = new Subject<AnimationEvent>();
 
+  /**
+   * @internal
+   * Width that will be set when the Drawer is closing to keep
+   * the drawer from relayouting and adjusting it's size
+   * due to the flex container.
+   */
+  _closedWidth: number | null;
+
   /** Used to skip the initial animation */
   private _enableAnimations = false;
 
@@ -264,6 +272,16 @@ export class DtDrawer implements OnInit, AfterContentChecked, OnDestroy {
    */
   toggle(opened: boolean = !this.opened): void {
     this._opened = opened;
+
+    // When the drawer is closed, we need to fix
+    // it's width to the original size to prevent relayout
+    // If the drawer would change size during this process,
+    // a drift would appear like in APM-266068
+    if (this._opened === false) {
+      this._closedWidth = this._width;
+    } else {
+      this._closedWidth = null;
+    }
 
     this._animationState = opened
       ? this._enableAnimations


### PR DESCRIPTION
### <strong>Pull Request</strong>

With a lot of content in the drawer-content, the drawer-body was changing size due to the flex container around it.

Keeping track of the width when closing and setting it as a min and max width boundary, keeps the drawer-body from relayouting and prevents the drift.

Fixes APM-266068

#### Type of PR

Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
