### PR TITLE
docs(filter-field): Adds docs explaining nesting nodes

### DIFF
--- a/apps/demos/src/app-routing.module.ts
+++ b/apps/demos/src/app-routing.module.ts
@@ -322,6 +322,7 @@ import {
   DtExampleTreeTableProblemIndicator,
   DtExampleTreeTableSimple,
   DtExampleComboboxCustomOptionHeight,
+  DtExampleFilterFieldInfiniteDataDepth,
 } from '@dynatrace/examples';
 
 // The Routing Module replaces the routing configuration in the root or feature module.
@@ -691,6 +692,10 @@ const ROUTES: Routes = [
     component: DtExampleFilterFieldDistinct,
   },
   {
+    path: 'filter-field-infinite-data-depth-example',
+    component: DtExampleFilterFieldInfiniteDataDepth,
+  },
+  {
     path: 'filter-field-partial-example',
     component: DtExampleFilterFieldPartial,
   },
@@ -992,11 +997,26 @@ const ROUTES: Routes = [
   { path: 'slider-simple-example', component: DtExampleSimpleSlider },
   { path: 'slider-fraction-example', component: DtExampleFractionSlider },
   { path: 'slider-disabled-example', component: DtExampleDisabledSlider },
-  { path: 'stacked-series-chart-single-example', component: DtExampleStackedSeriesChartSingle},
-  { path: 'stacked-series-chart-connected-legend-example', component: DtExampleStackedSeriesChartConnectedLegend},
-  { path: 'stacked-series-chart-generic-example', component: DtExampleStackedSeriesChartGeneric},
-  { path: 'stacked-series-chart-filled-example', component: DtExampleStackedSeriesChartFilled},
-  { path: 'stacked-series-chart-column-example', component: DtExampleStackedSeriesChartColumn},
+  {
+    path: 'stacked-series-chart-single-example',
+    component: DtExampleStackedSeriesChartSingle,
+  },
+  {
+    path: 'stacked-series-chart-connected-legend-example',
+    component: DtExampleStackedSeriesChartConnectedLegend,
+  },
+  {
+    path: 'stacked-series-chart-generic-example',
+    component: DtExampleStackedSeriesChartGeneric,
+  },
+  {
+    path: 'stacked-series-chart-filled-example',
+    component: DtExampleStackedSeriesChartFilled,
+  },
+  {
+    path: 'stacked-series-chart-column-example',
+    component: DtExampleStackedSeriesChartColumn,
+  },
   { path: 'stepper-default-example', component: DtExampleStepperDefault },
   { path: 'stepper-editable-example', component: DtExampleStepperEditable },
   { path: 'stepper-linear-example', component: DtExampleStepperLinear },

--- a/apps/demos/src/barista-examples.a11y.ts
+++ b/apps/demos/src/barista-examples.a11y.ts
@@ -49,6 +49,7 @@ const BLOCKLIST: string[] = [
   'filter-field-readonly-non-editable-tags-example',
   'filter-field-unique-example',
   'filter-field-validator-example',
+  'filter-field-infinite-data-depth-example',
   'quick-filter-default-example',
   'quick-filter-custom-show-more-example',
 ];

--- a/apps/demos/src/nav-items.ts
+++ b/apps/demos/src/nav-items.ts
@@ -613,6 +613,10 @@ export const DT_DEMOS_EXAMPLE_NAV_ITEMS = [
         route: '/filter-field-distinct-example',
       },
       {
+        name: 'filter-field-infinite-data-depth-example',
+        route: '/filter-field-infinite-data-depth-example',
+      },
+      {
         name: 'filter-field-partial-example',
         route: '/filter-field-partial-example',
       },

--- a/libs/barista-components/filter-field/README.md
+++ b/libs/barista-components/filter-field/README.md
@@ -27,6 +27,9 @@ class MyModule {}
 | `disabled`   | `boolean`                 | `false` | Whether the filter-field is disabled.                                                                            |
 | `aria-label` | `string`                  |         | Sets the value for the Aria-Label attribute.                                                                     |
 
+_Note: Check out the [Data source](components/filter-field#data-source) section
+to understand how to provide the correct data structure for the filter-field._
+
 ## Outputs
 
 | Name                   | Type                                                  | Description                                                                                                              |
@@ -43,10 +46,10 @@ class MyModule {}
 
 ## Methods
 
-| Name                             | Return value              | Description                                                                  |
-| -------------------------------- | ------------------------- | ---------------------------------------------------------------------------- |
-| `getTagForFilter(needle: any[])` | `DtFilterFieldTag | null` | Returns a `DtFilterFieldTag` if one can be found for the given filter needle |
-| `focus`                          | `void`                    | Focuses the filter field                                                     |
+| Name                             | Return value               | Description                                                                  |
+| -------------------------------- | -------------------------- | ---------------------------------------------------------------------------- |
+| `getTagForFilter(needle: any[])` | `DtFilterFieldTag \| null` | Returns a `DtFilterFieldTag` if one can be found for the given filter needle |
+| `focus`                          | `void`                     | Focuses the filter field                                                     |
 
 ## Distinct options
 
@@ -151,12 +154,17 @@ interface.
 
 The filter-field provides a default implementation of a `DataSource`, named
 `DtFilterFieldDefaultDataSource`, that takes a specific form of data
-(`DtFilterFieldDefaultDataSourceType`). If your data has a different form you
-can either transform your data so the default data source can understand it, or
-you create your own custom data source.
+(`DtFilterFieldDefaultDataSourceType`). The filter-field supports many layers of
+nesting for autocomplete nodes. You can have as many autocomplete nodes nested
+as you need. E.g. Having "continent > country > region > city" as 3 layers of
+autocomplete works perfectly fine. Nodes that can only be leaf nodes are
+free-text, range and options.
 
-When creating a custom data source, we also provide a lot of utility functions
-for converting and creating data into the form of definition node objects the
+<ba-live-example name="DtExampleFilterFieldInfiniteDataDepth"></ba-live-example>
+
+If your data has a different structure create your own custom data source. When
+creating a custom data source, we also provide a lot of utility functions for
+converting and creating data into the form of definition node objects the
 filter-field can understand. You can also take a look at the implementation of
 the `DtFilterFieldDefaultDataSource` to get a better understanding on how to
 create a custom data source.

--- a/libs/examples/src/filter-field/filter-field-examples.module.ts
+++ b/libs/examples/src/filter-field/filter-field-examples.module.ts
@@ -23,6 +23,7 @@ import { DtExampleFilterFieldCustomParser } from './filter-field-custom-parser-e
 import { DtExampleFilterFieldDefault } from './filter-field-default-example/filter-field-default-example';
 import { DtExampleFilterFieldDisabled } from './filter-field-disabled-example/filter-field-disabled-example';
 import { DtExampleFilterFieldDistinct } from './filter-field-distinct-example/filter-field-distinct-example';
+import { DtExampleFilterFieldInfiniteDataDepth } from './filter-field-infinite-data-depth-example/filter-field-infinite-data-depth-example';
 import { DtExampleFilterFieldPartial } from './filter-field-partial-example/filter-field-partial-example';
 import { DtExampleFilterFieldProgrammaticFilters } from './filter-field-programmatic-filters-example/filter-field-programmatic-filters-example';
 import { DtExampleFilterFieldReadOnlyTags } from './filter-field-readonly-non-editable-tags-example/filter-field-readonly-non-editable-tags-example';
@@ -37,6 +38,7 @@ import { DtExampleFilterFieldValidator } from './filter-field-validator-example/
     DtExampleFilterFieldCustomParser,
     DtExampleFilterFieldDefault,
     DtExampleFilterFieldDistinct,
+    DtExampleFilterFieldInfiniteDataDepth,
     DtExampleFilterFieldPartial,
     DtExampleFilterFieldProgrammaticFilters,
     DtExampleFilterFieldDisabled,

--- a/libs/examples/src/filter-field/filter-field-infinite-data-depth-example/filter-field-infinite-data-depth-example.html
+++ b/libs/examples/src/filter-field/filter-field-infinite-data-depth-example/filter-field-infinite-data-depth-example.html
@@ -1,0 +1,6 @@
+<dt-filter-field
+  [dataSource]="_dataSource"
+  label="Filter by"
+  aria-label="Filter By Input Value"
+  clearAllLabel="Clear All"
+></dt-filter-field>

--- a/libs/examples/src/filter-field/filter-field-infinite-data-depth-example/filter-field-infinite-data-depth-example.ts
+++ b/libs/examples/src/filter-field/filter-field-infinite-data-depth-example/filter-field-infinite-data-depth-example.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component } from '@angular/core';
+import { DtFilterFieldDefaultDataSource } from '@dynatrace/barista-components/filter-field';
+
+@Component({
+  selector: 'dt-example-filter-field-infinite-data-depth-filter-field',
+  templateUrl: './filter-field-infinite-data-depth-example.html',
+})
+export class DtExampleFilterFieldInfiniteDataDepth {
+  private DATA = {
+    autocomplete: [
+      {
+        name: 'Europe',
+        distinct: true,
+        autocomplete: [
+          {
+            name: 'Austria',
+            autocomplete: [
+              {
+                name: 'Upper Austria',
+                autocomplete: [
+                  {
+                    name: 'Linz',
+                  },
+                ],
+              },
+              {
+                name: 'Vienna',
+                autocomplete: [
+                  {
+                    name: 'Districts',
+                    range: {
+                      operators: {
+                        range: true,
+                      },
+                      unit: ' district',
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: 'North America',
+        autocomplete: [
+          {
+            name: 'USA',
+            autocomplete: [
+              {
+                name: 'California',
+                autocomplete: [
+                  {
+                    name: 'San Francisco',
+                  },
+                  {
+                    name: 'Los Angeles',
+                  },
+                ],
+              },
+              {
+                name: 'New York',
+                autocomplete: [
+                  {
+                    name: 'New York',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  _dataSource = new DtFilterFieldDefaultDataSource(this.DATA);
+}

--- a/libs/examples/src/filter-field/index.ts
+++ b/libs/examples/src/filter-field/index.ts
@@ -21,6 +21,7 @@ export * from './filter-field-default-example/filter-field-default-example';
 export * from './filter-field-disabled-example/filter-field-disabled-example';
 export * from './filter-field-distinct-example/filter-field-distinct-example';
 export * from './filter-field-examples.module';
+export * from './filter-field-infinite-data-depth-example/filter-field-infinite-data-depth-example';
 export * from './filter-field-partial-example/filter-field-partial-example';
 export * from './filter-field-programmatic-filters-example/filter-field-programmatic-filters-example';
 export * from './filter-field-readonly-non-editable-tags-example/filter-field-readonly-non-editable-tags-example';

--- a/libs/examples/src/index.ts
+++ b/libs/examples/src/index.ts
@@ -331,7 +331,7 @@ import { DtExampleTreeTableDefault } from './tree-table/tree-table-default-examp
 import { DtExampleTreeTableProblemIndicator } from './tree-table/tree-table-problem-indicator-example/tree-table-problem-indicator-example';
 import { DtExampleTreeTableSimple } from './tree-table/tree-table-simple-example/tree-table-simple-example';
 import { DtExampleComboboxCustomOptionHeight } from './combobox/combobox-custom-option-height-example/combobox-custom-option-height-example';
-
+import { DtExampleFilterFieldInfiniteDataDepth } from './filter-field/filter-field-infinite-data-depth-example/filter-field-infinite-data-depth-example';
 export { DtExamplesModule } from './examples.module';
 export { DtAlertExamplesModule } from './alert/alert-examples.module';
 export { DtAutocompleteExamplesModule } from './autocomplete/autocomplete-examples.module';
@@ -703,6 +703,7 @@ export {
   DtExampleTreeTableDefault,
   DtExampleTreeTableProblemIndicator,
   DtExampleTreeTableSimple,
+  DtExampleFilterFieldInfiniteDataDepth,
 };
 
 export const EXAMPLES_MAP = new Map<string, Type<unknown>>([
@@ -1076,4 +1077,8 @@ export const EXAMPLES_MAP = new Map<string, Type<unknown>>([
   ['DtExampleTreeTableDefault', DtExampleTreeTableDefault],
   ['DtExampleTreeTableProblemIndicator', DtExampleTreeTableProblemIndicator],
   ['DtExampleTreeTableSimple', DtExampleTreeTableSimple],
+  [
+    'DtExampleFilterFieldInfiniteDataDepth',
+    DtExampleFilterFieldInfiniteDataDepth,
+  ],
 ]);


### PR DESCRIPTION
### <strong>Pull Request</strong>

Some users didn't know that data sources in the filter field could be nested.
This PR provides an example that outlines this use case

#### Type of PR

Documentation update (changes to documentation)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
