### PR TITLE
fix(filter-field): Fixes an issue with async data and programmatically set filters.

### DIFF
--- a/apps/components-e2e/src/components/filter-field/filter-field.po.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.po.ts
@@ -18,6 +18,7 @@ import { Selector, t, ClientFunction } from 'testcafe';
 
 export const errorBox = Selector('.dt-filter-field-error');
 export const filterField = Selector('.dt-filter-field');
+export const options = Selector('.dt-option');
 export const option = (nth: number) => Selector(`.dt-option:nth-child(${nth})`);
 export const clearAll = Selector('.dt-filter-field-clear-all-button');
 export const filterTags = Selector('dt-filter-field-tag');

--- a/apps/components-e2e/src/components/quick-filter/quick-filter.e2e.ts
+++ b/apps/components-e2e/src/components/quick-filter/quick-filter.e2e.ts
@@ -21,6 +21,7 @@ import {
   tagDeleteButton,
   clickOption,
   filterFieldRangePanel,
+  options,
 } from '../filter-field/filter-field.po';
 import {
   getGroupItem,
@@ -301,4 +302,50 @@ test('should check the show more with distinct values', async (testController: T
     .click(quickFilterBackButton)
     .expect(getFilterfieldTags())
     .eql(['ValueValue 23']);
+});
+
+fixture('Quick Filter async')
+  .page('http://localhost:4200/quick-filter/async')
+  .beforeEach(async () => {
+    await resetWindowSizeToDefault();
+    await waitForAngular();
+  });
+
+test('should work with async data and handle distincts correctly', async (testController: TestController) => {
+  // Click option Aut (async)
+  await clickOption(1);
+  // wait for the async process to finish
+  await testController.wait(1500);
+  // Click option Linz
+  await clickOption(1);
+
+  // Expect the filter to be set
+  await testController.expect(getFilterfieldTags()).eql(['AUT (async)Linz']);
+
+  // Choose another option in the filter field, which will trigger the
+  // quickfilter to set the filters on the filter-field, previously
+  // breaking the id-mapping.
+  // Click option USA
+  await clickOption(2);
+  // Click option Los Angeles
+  await clickOption(2);
+
+  // Expect the filter to be set
+  await testController
+    .expect(getFilterfieldTags())
+    .eql(['AUT (async)Linz', 'USALos Angeles']);
+
+  // Click option Aut (async)
+  await clickOption(1);
+  await testController
+    // Expect Linz no longer in the options
+    .expect(options.count)
+    .eql(2)
+    // Expect Vienna and Graz to still be in the list.
+    .expect(options.nth(0).textContent)
+    // textContent is duplicated because of the highlight within the option
+    .eql('ViennaVienna')
+    .expect(options.nth(1).textContent)
+    // textContent is duplicated because of the highlight within the option
+    .eql('GrazGraz');
 });

--- a/libs/barista-components/filter-field/src/filter-field-util.ts
+++ b/libs/barista-components/filter-field/src/filter-field-util.ts
@@ -365,7 +365,7 @@ export function findFilterValuesForSources<T>(
           const asyncDef = asyncDefs.get(def);
           if (asyncDef) {
             parentDef = asyncDef;
-            foundValues.push(def, asyncDef as DtAutocompleteValue<T>);
+            foundValues.push(def);
           } else {
             parentDef = def;
             foundValues.push(def);


### PR DESCRIPTION
### <strong>Pull Request</strong>
When setting the filters programmatically, as the quickfilter does when a filter is set, the
retreival of set filters breaks.
The programmatic setting of the filters runs a function called `tryApplyFilters`, which looks in the
datasource and async dataset for the correct filters.
For some reason, the root of the async def was pushed twice, resulting in a wrong path and a wrong
id.

@thomaspink do you remember the reasoning on why the `def` and `asyncDef` where pushed to the array in the partial async case.
Event with the change in this PR, the partial async example behaves the same and all tests are passing.

Fixes APM-267380

#### Type of PR

Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
