### PR TITLE
barista: Allow subpages to be created in strapi without breaking the navigation.

### DIFF
--- a/libs/tools/barista/src/generators/category-navigation.ts
+++ b/libs/tools/barista/src/generators/category-navigation.ts
@@ -205,8 +205,9 @@ export const overviewBuilder = async (distDir: string) => {
   const pages = allDirectories.map(async (directory) => {
     const path = join(distDir, directory);
     let overviewPage: BaCategoryNavigation;
-    const files = readdirSync(path);
-
+    const files = readdirSync(path)
+      // Only use files from the list directory and no subfolders
+      .filter((p) => lstatSync(join(path, p)).isFile());
     const capitalizedTitle =
       directory.charAt(0).toUpperCase() + directory.slice(1);
 


### PR DESCRIPTION
### <strong>Pull Request</strong>

Creating sub pages for components in the cms broke the generation of the navigation. The added filter checks to only iterate files in the respective section folders, to not break the generation of the navigation. 

This is a prerequisite for APM-266090

#### Type of PR
Documentation

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
