### PR TITLE
fix(filter-field): Fixes an issue where the filterChanges event was not triggered.

### DIFF
--- a/libs/barista-components/filter-field/src/filter-field-edit-mode.spec.ts
+++ b/libs/barista-components/filter-field/src/filter-field-edit-mode.spec.ts
@@ -437,5 +437,34 @@ describe('DtFilterField', () => {
 
       sub.unsubscribe();
     });
+
+    it('should emit a filterchange event when the edited filter is deleted by keyboard input [delete,backspace]', () => {
+      let filterChangeEvent: DtFilterFieldChangeEvent<any> | undefined;
+
+      fixture.componentInstance.dataSource.data = FILTER_FIELD_TEST_DATA_SINGLE_OPTION;
+      const sub = filterField.filterChanges.subscribe(
+        (ev) => (filterChangeEvent = ev),
+      );
+
+      const tags = fixture.debugElement.queryAll(
+        By.css('.dt-filter-field-tag-label'),
+      );
+      tags[1].nativeElement.click();
+      advanceFilterfieldCycle();
+
+      // Send a backspace key
+      const inputfield = getInput(fixture);
+      dispatchKeyboardEvent(inputfield, 'keydown', BACKSPACE);
+
+      advanceFilterfieldCycle();
+      fixture.detectChanges();
+
+      expect(filterChangeEvent).toBeDefined();
+      expect(filterChangeEvent!.added.length).toBe(0);
+      expect(filterChangeEvent!.removed.length).toBe(1);
+      expect(filterChangeEvent!.filters.length).toBe(2);
+
+      sub.unsubscribe();
+    });
   });
 });


### PR DESCRIPTION
### <strong>Pull Request</strong>

When starting to edit a single tag within the filter-field and then deleting the filter with the
keyboard [backspace,delete], the filterChanges event was not dispatched. At this stage, the filter
did not count as actually applied, because it was elevated into the currently edited filter.

Fixes APM-268757

#### Type of PR

Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
