### PR TITLE
Drawer: Fix padding issue in drawer

### DIFF
--- a/libs/barista-components/drawer/src/drawer.html
+++ b/libs/barista-components/drawer/src/drawer.html
@@ -1,7 +1,3 @@
-<div
-  class="dt-drawer-body"
-  [style.min-width.px]="_closedWidth"
-  [style.max-width.px]="_closedWidth"
->
+<div class="dt-drawer-body">
   <ng-content></ng-content>
 </div>

--- a/libs/barista-components/drawer/src/drawer.ts
+++ b/libs/barista-components/drawer/src/drawer.ts
@@ -279,7 +279,14 @@ export class DtDrawer implements OnInit, AfterContentChecked, OnDestroy {
     // it's width to the original size to prevent relayout
     // If the drawer would change size during this process,
     // a drift would appear like in APM-266068
-    if (this._opened === false) {
+    // ---
+    // The this._width !== 0 check is necessary, because if the opened
+    // value on the drawer is set via `opened="false"` (meaning without a binding)
+    // this will be evaluated only once, which means there was no render
+    // cycle that could have determined the correct width of the drawer.
+    // As the drawer would be hidden anyway with a width of 0 we do not need
+    // to set a closed widht.
+    if (this._opened === false && this._width !== 0) {
       this._closedWidth = this._width;
     } else {
       this._closedWidth = null;

--- a/libs/barista-components/drawer/src/drawer.ts
+++ b/libs/barista-components/drawer/src/drawer.ts
@@ -62,6 +62,8 @@ export const DT_DRAWER_CONTAINER = new InjectionToken<DtDrawerContainer>(
     '[class.dt-drawer-over]': '_currentMode === "over"',
     '[class.dt-drawer-side]': '_currentMode === "side"',
     '[attr.aria-hidden]': '!opened ? true : null',
+    '[style.min-width.px]': '_closedWidth',
+    '[style.max-width.px]': '_closedWidth',
   },
 })
 export class DtDrawer implements OnInit, AfterContentChecked, OnDestroy {


### PR DESCRIPTION
### <strong>Pull Request</strong>

Fixes two drawer issues. 
One where there was an initial padding when initializing the drawer as closed. (When fixing the drift issue a couple of weeks back, I applied the min/max width setting to the wrong container #1791 )

Second was a complete breakdown of the render when initilalising the drawer `open="false"` without binding the value. 

Apm 270469 

#### Type of PR

Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
