### PR TITLE
fix(table): Fixes an issue with the empty state not showing up without change detection.

### DIFF
--- a/libs/barista-components/table/src/table.ts
+++ b/libs/barista-components/table/src/table.ts
@@ -209,6 +209,7 @@ export class DtTable<T> extends _DtTableBase<T> implements OnDestroy {
         this._portalOutlet.attachTemplatePortal(template);
       }
       this._emptyState.first._visible = true;
+      this._changeDetectorRef.markForCheck();
     } else {
       // ned to unset the visibility to have every time the component will be attached a fading animation.
       this._emptyState.first._visible = false;


### PR DESCRIPTION
### <strong>Pull Request</strong>

When setting the data to an empty array within a setTimeout, the table did not show the empty state without a changeDetection being triggered (click somewhere). 

#### Type of PR

Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
