### PR TITLE
fix(drawer): Fixes an issue where changeDetection was not triggered.

### DIFF
--- a/libs/barista-components/drawer/src/drawer.ts
+++ b/libs/barista-components/drawer/src/drawer.ts
@@ -29,6 +29,8 @@ import {
   OnInit,
   Output,
   ViewEncapsulation,
+  Optional,
+  ChangeDetectorRef,
 } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { distinctUntilChanged, filter, map, takeUntil } from 'rxjs/operators';
@@ -196,6 +198,8 @@ export class DtDrawer implements OnInit, AfterContentChecked, OnDestroy {
   constructor(
     private _elementRef: ElementRef,
     private _breakpointObserver: BreakpointObserver,
+    /** @breaking-change 9.0.0 - Make mandatory with version 9.0.0 */
+    @Optional() private _changeDetectorRef?: ChangeDetectorRef,
   ) {
     // distinctUntilChanged is needed because the done event fires twice on some browsers
     // and fire if animation is done
@@ -297,5 +301,10 @@ export class DtDrawer implements OnInit, AfterContentChecked, OnDestroy {
         ? 'open'
         : 'open-instant'
       : (this._animationState = 'closed');
+
+    /** @breaking-change 9.0.0 - remove if check when changeDetectorRef is no longer optional */
+    if (this._changeDetectorRef) {
+      this._changeDetectorRef.markForCheck();
+    }
   }
 }


### PR DESCRIPTION
### <strong>Pull Request</strong>

When toggling the drawer programmatically, it could happen that changeDetection was not run on the drawer (setTimeout / defer). The mark for check is necessary in these cases.

#### Type of PR

Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
