### PR TITLE
feat(filter-field): Interaction-state

### DIFF
--- a/apps/dev/src/filter-field/filter-field-demo.component.ts
+++ b/apps/dev/src/filter-field/filter-field-demo.component.ts
@@ -152,6 +152,10 @@ export class FilterFieldDemo implements AfterViewInit, OnDestroy {
         this._firstTag = tags[0];
       }
     });
+
+    this.filterField.interactionStateChange.subscribe((isInteracted) => {
+      console.log('interactionState: ', isInteracted);
+    });
   }
 
   ngOnDestroy(): void {

--- a/libs/barista-components/filter-field/README.md
+++ b/libs/barista-components/filter-field/README.md
@@ -32,17 +32,19 @@ to understand how to provide the correct data structure for the filter-field._
 
 ## Outputs
 
-| Name                   | Type                                                  | Description                                                                                                              |
-| ---------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `filterChanges`        | `EventEmitter<DtFilterFieldChangeEvent>`              | Event emitted when filters have been added or removed.                                                                   |
-| `currentFilterChanges` | `EventEmitter<DtFilterFieldCurrentFilterChangeEvent>` | Event emitted when a part has been added to the currently selected filter (the filter the user is currently working on). |
-| `inputChange`          | `EventEmitter<string>`                                | Event emitted when the input value changes (e.g. when the user is typing).                                               |
+| Name                     | Type                                                  | Description                                                                                                              |
+| ------------------------ | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `filterChanges`          | `EventEmitter<DtFilterFieldChangeEvent>`              | Event emitted when filters have been added or removed.                                                                   |
+| `currentFilterChanges`   | `EventEmitter<DtFilterFieldCurrentFilterChangeEvent>` | Event emitted when a part has been added to the currently selected filter (the filter the user is currently working on). |
+| `inputChange`            | `EventEmitter<string>`                                | Event emitted when the input value changes (e.g. when the user is typing).                                               |
+| `interactionStateChange` | `EventEmitter<boolean>`                               | Event emitted when the interaction state changes (e.g. when the user interactes with the filter-field).                  |
 
 ## Properties
 
-| Name          | Type                             | Description                                                       |
-| ------------- | -------------------------------- | ----------------------------------------------------------------- |
-| `currentTags` | `Observable<DtFilterFieldTag[]>` | A stream that emits the current tags that the filter field holds. |
+| Name               | Type                             | Description                                                       |
+| ------------------ | -------------------------------- | ----------------------------------------------------------------- |
+| `currentTags`      | `Observable<DtFilterFieldTag[]>` | A stream that emits the current tags that the filter field holds. |
+| `interactionState` | `boolean`                        | Whether the filter-field is being interacted with or not          |
 
 ## Methods
 

--- a/libs/barista-components/filter-field/src/filter-field.spec.ts
+++ b/libs/barista-components/filter-field/src/filter-field.spec.ts
@@ -39,6 +39,7 @@ import {
   MockNgZone,
 } from '@dynatrace/testing/browser';
 import {
+  FILTER_FIELD_TEST_DATA,
   FILTER_FIELD_TEST_DATA_ASYNC,
   FILTER_FIELD_TEST_DATA_SINGLE_DISTINCT,
   FILTER_FIELD_TEST_DATA_SINGLE_OPTION,
@@ -47,6 +48,7 @@ import { TEST_DATA_EDITMODE_ASYNC } from './filter-field-edit-mode.spec';
 import {
   TEST_DATA_SUGGESTIONS,
   TEST_DATA_EDITMODE,
+  TEST_DATA_RANGE,
 } from './testing/filter-field-test-data';
 import {
   TestApp,
@@ -260,1293 +262,1320 @@ describe('DtFilterField', () => {
     });
   });
 
-  describe('with autocomplete', () => {
-    it('should open the autocomplete if filter field is focused', () => {
-      expect(filterField._autocomplete.isOpen).toBe(false);
-      filterField.focus();
-      zone.simulateMicrotasksEmpty();
-      expect(filterField._autocomplete.isOpen).toBe(true);
-    });
-
-    it('should emit the inputChange event when typing into the input field with autocomplete', fakeAsync(() => {
-      const spy = jest.fn();
-      const subscription = filterField.inputChange.subscribe(spy);
-
-      typeIntoFilterElement('x');
+  describe('interaction state', () => {
+    it('should emit true when focused', fakeAsync(() => {
+      fixture.componentInstance.dataSource.data = FILTER_FIELD_TEST_DATA;
       fixture.detectChanges();
 
-      expect(spy).toHaveBeenCalledWith('x');
+      filterField.focus();
+      advanceFilterfieldCycle();
 
-      typeIntoFilterElement('xy');
+      expect(filterField.interactionState).toBeTruthy();
+    }));
+
+    it('should emit true when the filterField is focused', fakeAsync(() => {
+      fixture.componentInstance.dataSource.data = TEST_DATA_RANGE;
       fixture.detectChanges();
 
-      expect(spy).toHaveBeenCalledWith('xy');
-      subscription.unsubscribe();
-    }));
-
-    it('should create the correct options and option groups', () => {
-      filterField.focus();
-      advanceFilterfieldCycle();
-
-      const options = getOptions(overlayContainerElement);
-      const optionGroups = getOptionGroups(overlayContainerElement);
-      expect(options.length).toBe(4);
-      expect(optionGroups.length).toBe(0);
-      expect(options[0].textContent).toContain('AUT');
-      expect(options[1].textContent).toContain('USA');
-      expect(options[2].textContent).toContain('Free');
-    });
-
-    it('should switch to the next autocomplete if the selected option is also an autocomplete', () => {
-      filterField.focus();
-      advanceFilterfieldCycle();
-
-      let options = getOptions(overlayContainerElement);
-      expect(options[0].textContent).toContain('AUT');
-      expect(options[1].textContent).toContain('USA');
-      expect(options[2].textContent).toContain('Free');
-
-      getAndClickOption(overlayContainerElement, 0);
-      advanceFilterfieldCycle();
-
-      options = getOptions(overlayContainerElement);
-      let optionGroups = getOptionGroups(overlayContainerElement);
-      expect(optionGroups.length).toBe(0);
-      expect(options.length).toBe(2);
-      expect(options[0].textContent).toContain('Upper Austria');
-      expect(options[1].textContent).toContain('Vienna');
-
-      zone.simulateZoneExit();
-
-      const upperAustriaOption = options[0];
-      upperAustriaOption.click();
-      advanceFilterfieldCycle();
-
-      options = getOptions(overlayContainerElement);
-      optionGroups = getOptionGroups(overlayContainerElement);
-
-      expect(optionGroups.length).toBe(1);
-      expect(optionGroups[0].textContent).toContain('Cities');
-      expect(options[0].textContent).toContain('Linz');
-      expect(options[1].textContent).toContain('Wels');
-      expect(options[2].textContent).toContain('Steyr');
-    });
-
-    it('should clear the filtered string from the input when selecting an option', fakeAsync(() => {
-      filterField.focus();
-      advanceFilterfieldCycle();
-
-      typeIntoFilterElement('US');
-      advanceFilterfieldCycle(true, false);
-
-      // We cannot use the common getAndClick option helper here,
-      // because it triggers advanceFilterfieldCycle which will break this test.
-      let options = getOptions(overlayContainerElement);
-      const usOption = options[0];
-      usOption.click();
-      advanceFilterfieldCycle(true, false);
-
-      options = getOptions(overlayContainerElement);
-      expect(options.length).toBe(2);
-      // We use contain in favor of toBe as the text has to be inside twice due to the highlight
-      // The second occurrence is hidden by display:none
-      expect(options[0].textContent).toContain('Los Angeles');
-      expect(options[1].textContent).toContain('San Fran');
-
-      zone.simulateZoneExit();
-    }));
-
-    it('should highlight & filter the correct options with the same character after resetting', fakeAsync(() => {
-      filterField.focus();
-      advanceFilterfieldCycle();
-
-      typeIntoFilterElement('t');
-      advanceFilterfieldCycle(true, false);
-
-      // We cannot use the common getAndClick option helper here,
-      // because it triggers advanceFilterfieldCycle which will break this test.
-      let options = getOptions(overlayContainerElement);
-      const autOption = options[0];
-      autOption.click();
-      advanceFilterfieldCycle(true, false);
-
-      typeIntoFilterElement('t');
-      advanceFilterfieldCycle(true, false);
-
-      options = getOptions(overlayContainerElement);
-      expect(options.length).toBe(1);
-      // We use contain in favor of toBe as the text has to be inside twice due to the highlight
-      // The second occurrence is hidden by display:none
-      expect(options[0].textContent).toContain('Upper Austria');
-      tick();
-    }));
-
-    it('should switch to the next autocomplete if the selected option is also a free text with suggestions', () => {
-      fixture.componentInstance.dataSource.data = TEST_DATA_SUGGESTIONS;
-      filterField.focus();
-      advanceFilterfieldCycle();
-
-      let options = getOptions(overlayContainerElement);
-      expect(options[0].textContent).toContain('Custom Simple Option');
-      expect(options[1].textContent).toContain('Node Label');
-
-      getAndClickOption(overlayContainerElement, 1);
-
-      options = getOptions(overlayContainerElement);
-      const optionGroups = getOptionGroups(overlayContainerElement);
-      expect(optionGroups.length).toBe(0);
-      expect(options.length).toBe(2);
-      expect(options[0].textContent).toContain('some cool');
-      expect(options[1].textContent).toContain('very weird');
-
-      zone.simulateZoneExit();
-    });
-
-    it('should focus the input element after selecting an option in autocomplete (autocomplete -> autocomplete)', () => {
-      filterField.focus();
-      advanceFilterfieldCycle(true, false);
-
-      getAndClickOption(overlayContainerElement, 0);
-      const inputEl = getInput(fixture);
-
-      expect(document.activeElement).toBe(inputEl);
-    });
-
-    it('should fire filterChanges and create a tag after an option that has no children is clicked', fakeAsync(() => {
       const spy = jest.fn();
-      const subscription = filterField.filterChanges.subscribe(spy);
+      const subscription = filterField.interactionStateChange.subscribe(spy);
+
       filterField.focus();
       advanceFilterfieldCycle();
-
-      let options = getOptions(overlayContainerElement);
-      expect(options[0].textContent).toContain('AUT');
-      expect(options[1].textContent).toContain('USA');
-
-      // Click the USA option
-      getAndClickOption(overlayContainerElement, 1);
-
-      // Click the San Francisco option
-      getAndClickOption(overlayContainerElement, 0);
-
-      const tags = getFilterTags(fixture);
-      expect(tags.length).toBe(1);
-      expect(tags[0].key).toBe('USA');
-      expect(tags[0].separator).toBe(':');
-      expect(tags[0].value.trim()).toBe('Los Angeles');
 
       expect(spy).toHaveBeenCalledTimes(1);
+
       subscription.unsubscribe();
     }));
 
-    it('should emit filterChanges when adding an option', fakeAsync(() => {
-      let filterChangeEvent: DtFilterFieldChangeEvent<any> | undefined;
+    describe('with autocomplete', () => {
+      it('should open the autocomplete if filter field is focused', () => {
+        expect(filterField._autocomplete.isOpen).toBe(false);
+        filterField.focus();
+        zone.simulateMicrotasksEmpty();
+        expect(filterField._autocomplete.isOpen).toBe(true);
+      });
 
-      fixture.componentInstance.dataSource.data = FILTER_FIELD_TEST_DATA_SINGLE_OPTION;
-      const sub = filterField.filterChanges.subscribe(
-        (ev) => (filterChangeEvent = ev),
-      );
+      it('should emit the inputChange event when typing into the input field with autocomplete', fakeAsync(() => {
+        const spy = jest.fn();
+        const subscription = filterField.inputChange.subscribe(spy);
 
-      fixture.detectChanges();
-      filterField.focus();
-      advanceFilterfieldCycle();
+        typeIntoFilterElement('x');
+        fixture.detectChanges();
 
-      const options = getOptions(overlayContainerElement);
-      options[0].click();
+        expect(spy).toHaveBeenCalledWith('x');
 
-      tick();
+        typeIntoFilterElement('xy');
+        fixture.detectChanges();
 
-      expect(filterChangeEvent).toBeDefined();
-      expect(filterChangeEvent!.added.length).toBe(1);
-      expect(filterChangeEvent!.removed.length).toBe(0);
-      expect(filterChangeEvent!.filters.length).toBe(1);
+        expect(spy).toHaveBeenCalledWith('xy');
+        subscription.unsubscribe();
+      }));
 
-      sub.unsubscribe();
-    }));
+      it('should create the correct options and option groups', () => {
+        filterField.focus();
+        advanceFilterfieldCycle();
 
-    it('should emit filterChanges when removing an option', fakeAsync(() => {
-      let filterChangeEvent: DtFilterFieldChangeEvent<any> | undefined;
+        const options = getOptions(overlayContainerElement);
+        const optionGroups = getOptionGroups(overlayContainerElement);
+        expect(options.length).toBe(4);
+        expect(optionGroups.length).toBe(0);
+        expect(options[0].textContent).toContain('AUT');
+        expect(options[1].textContent).toContain('USA');
+        expect(options[2].textContent).toContain('Free');
+      });
 
-      fixture.componentInstance.dataSource.data = FILTER_FIELD_TEST_DATA_SINGLE_OPTION;
-      const sub = filterField.filterChanges.subscribe(
-        (ev) => (filterChangeEvent = ev),
-      );
+      it('should switch to the next autocomplete if the selected option is also an autocomplete', () => {
+        filterField.focus();
+        advanceFilterfieldCycle();
 
-      fixture.detectChanges();
-      filterField.focus();
-      advanceFilterfieldCycle();
+        let options = getOptions(overlayContainerElement);
+        expect(options[0].textContent).toContain('AUT');
+        expect(options[1].textContent).toContain('USA');
+        expect(options[2].textContent).toContain('Free');
 
-      const options = getOptions(overlayContainerElement);
-      options[0].click();
+        getAndClickOption(overlayContainerElement, 0);
+        advanceFilterfieldCycle();
 
-      tick();
+        options = getOptions(overlayContainerElement);
+        let optionGroups = getOptionGroups(overlayContainerElement);
+        expect(optionGroups.length).toBe(0);
+        expect(options.length).toBe(2);
+        expect(options[0].textContent).toContain('Upper Austria');
+        expect(options[1].textContent).toContain('Vienna');
 
-      const tags = getFilterTags(fixture);
-      tags[0].removeButton.click();
+        zone.simulateZoneExit();
 
-      tick();
+        const upperAustriaOption = options[0];
+        upperAustriaOption.click();
+        advanceFilterfieldCycle();
 
-      expect(filterChangeEvent).toBeDefined();
-      expect(filterChangeEvent!.added.length).toBe(0);
-      expect(filterChangeEvent!.removed.length).toBe(1);
-      expect(filterChangeEvent!.filters.length).toBe(0);
+        options = getOptions(overlayContainerElement);
+        optionGroups = getOptionGroups(overlayContainerElement);
 
-      sub.unsubscribe();
-    }));
+        expect(optionGroups.length).toBe(1);
+        expect(optionGroups[0].textContent).toContain('Cities');
+        expect(options[0].textContent).toContain('Linz');
+        expect(options[1].textContent).toContain('Wels');
+        expect(options[2].textContent).toContain('Steyr');
+      });
 
-    it('should switch to free text and on enter fire a filterChanges event and create a tag', fakeAsync(() => {
-      const spy = jest.fn();
-      const subscription = filterField.filterChanges.subscribe(spy);
-      filterField.focus();
-      advanceFilterfieldCycle();
+      it('should clear the filtered string from the input when selecting an option', fakeAsync(() => {
+        filterField.focus();
+        advanceFilterfieldCycle();
 
-      getAndClickOption(overlayContainerElement, 2);
+        typeIntoFilterElement('US');
+        advanceFilterfieldCycle(true, false);
 
-      typeIntoFilterElement('abc');
-      fixture.detectChanges();
+        // We cannot use the common getAndClick option helper here,
+        // because it triggers advanceFilterfieldCycle which will break this test.
+        let options = getOptions(overlayContainerElement);
+        const usOption = options[0];
+        usOption.click();
+        advanceFilterfieldCycle(true, false);
 
-      const inputEl = getInput(fixture);
-      dispatchKeyboardEvent(inputEl, 'keydown', ENTER);
+        options = getOptions(overlayContainerElement);
+        expect(options.length).toBe(2);
+        // We use contain in favor of toBe as the text has to be inside twice due to the highlight
+        // The second occurrence is hidden by display:none
+        expect(options[0].textContent).toContain('Los Angeles');
+        expect(options[1].textContent).toContain('San Fran');
 
-      tick(DT_FILTER_FIELD_TYPING_DEBOUNCE);
-      fixture.detectChanges();
+        zone.simulateZoneExit();
+      }));
 
-      const tags = getFilterTags(fixture);
-      expect(tags.length).toBe(1);
-      expect(tags[0].key).toBe('Free');
-      expect(tags[0].separator).toBe('~');
-      expect(tags[0].value).toBe('abc');
-      expect(spy).toHaveBeenCalledTimes(1);
-      subscription.unsubscribe();
-    }));
+      it('should highlight & filter the correct options with the same character after resetting', fakeAsync(() => {
+        filterField.focus();
+        advanceFilterfieldCycle();
 
-    it('should switch to free text with keyboard interaction and on enter fire a filterChanges event and create a tag', fakeAsync(() => {
-      const spy = jest.fn();
-      const subscription = filterField.filterChanges.subscribe(spy);
-      filterField.focus();
-      advanceFilterfieldCycle();
+        typeIntoFilterElement('t');
+        advanceFilterfieldCycle(true, false);
 
-      const inputEl = getInput(fixture);
+        // We cannot use the common getAndClick option helper here,
+        // because it triggers advanceFilterfieldCycle which will break this test.
+        let options = getOptions(overlayContainerElement);
+        const autOption = options[0];
+        autOption.click();
+        advanceFilterfieldCycle(true, false);
 
-      // Select the free text option with the keyboard and hit enter
-      dispatchKeyboardEvent(inputEl, 'keydown', DOWN_ARROW);
-      dispatchKeyboardEvent(inputEl, 'keydown', DOWN_ARROW);
+        typeIntoFilterElement('t');
+        advanceFilterfieldCycle(true, false);
 
-      // Use keydown and keyup arrow, as this is what happens in the real world as well.
-      dispatchKeyboardEvent(inputEl, 'keydown', ENTER);
+        options = getOptions(overlayContainerElement);
+        expect(options.length).toBe(1);
+        // We use contain in favor of toBe as the text has to be inside twice due to the highlight
+        // The second occurrence is hidden by display:none
+        expect(options[0].textContent).toContain('Upper Austria');
+        tick();
+      }));
 
-      advanceFilterfieldCycle();
-      typeIntoFilterElement('abc');
-      fixture.detectChanges();
+      it('should switch to the next autocomplete if the selected option is also a free text with suggestions', () => {
+        fixture.componentInstance.dataSource.data = TEST_DATA_SUGGESTIONS;
+        filterField.focus();
+        advanceFilterfieldCycle();
 
-      dispatchKeyboardEvent(inputEl, 'keydown', ENTER);
+        let options = getOptions(overlayContainerElement);
+        expect(options[0].textContent).toContain('Custom Simple Option');
+        expect(options[1].textContent).toContain('Node Label');
 
-      tick(DT_FILTER_FIELD_TYPING_DEBOUNCE);
-      fixture.detectChanges();
+        getAndClickOption(overlayContainerElement, 1);
 
-      const tags = getFilterTags(fixture);
+        options = getOptions(overlayContainerElement);
+        const optionGroups = getOptionGroups(overlayContainerElement);
+        expect(optionGroups.length).toBe(0);
+        expect(options.length).toBe(2);
+        expect(options[0].textContent).toContain('some cool');
+        expect(options[1].textContent).toContain('very weird');
 
-      expect(tags.length).toBe(1);
-      expect(tags[0].key).toBe('Free');
-      expect(tags[0].separator).toBe('~');
-      expect(tags[0].value).toBe('abc');
-      expect(spy).toHaveBeenCalledTimes(1);
-      subscription.unsubscribe();
-    }));
+        zone.simulateZoneExit();
+      });
 
-    it('should fire currentFilterChanges when an option is selected', fakeAsync(() => {
-      const spy = jest.fn();
-      const subscription = filterField.currentFilterChanges.subscribe(spy);
-      filterField.focus();
-      advanceFilterfieldCycle();
+      it('should focus the input element after selecting an option in autocomplete (autocomplete -> autocomplete)', () => {
+        filterField.focus();
+        advanceFilterfieldCycle(true, false);
 
-      getAndClickOption(overlayContainerElement, 1);
+        getAndClickOption(overlayContainerElement, 0);
+        const inputEl = getInput(fixture);
 
-      expect(spy).toHaveBeenCalledTimes(1);
-      subscription.unsubscribe();
-    }));
+        expect(document.activeElement).toBe(inputEl);
+      });
 
-    it('should fire currentFilterChanges when the current is removed with the BACKSPACE key', fakeAsync(() => {
-      filterField.focus();
-      advanceFilterfieldCycle();
+      it('should fire filterChanges and create a tag after an option that has no children is clicked', fakeAsync(() => {
+        const spy = jest.fn();
+        const subscription = filterField.filterChanges.subscribe(spy);
+        filterField.focus();
+        advanceFilterfieldCycle();
 
-      getAndClickOption(overlayContainerElement, 1);
+        let options = getOptions(overlayContainerElement);
+        expect(options[0].textContent).toContain('AUT');
+        expect(options[1].textContent).toContain('USA');
 
-      const spy = jest.fn();
-      const subscription = filterField.currentFilterChanges.subscribe(spy);
+        // Click the USA option
+        getAndClickOption(overlayContainerElement, 1);
 
-      const inputEl = getInput(fixture);
-      dispatchKeyboardEvent(inputEl, 'keydown', BACKSPACE);
-      fixture.detectChanges();
-      flush();
+        // Click the San Francisco option
+        getAndClickOption(overlayContainerElement, 0);
 
-      expect(spy).toHaveBeenCalledTimes(1);
-      subscription.unsubscribe();
-    }));
+        const tags = getFilterTags(fixture);
+        expect(tags.length).toBe(1);
+        expect(tags[0].key).toBe('USA');
+        expect(tags[0].separator).toBe(':');
+        expect(tags[0].value.trim()).toBe('Los Angeles');
 
-    it('should switch back to root if unfinished filter is deleted with BACKSPACE', () => {
-      filterField.focus();
-      advanceFilterfieldCycle(true, false);
+        expect(spy).toHaveBeenCalledTimes(1);
+        subscription.unsubscribe();
+      }));
 
-      let options = getOptions(overlayContainerElement);
+      it('should emit filterChanges when adding an option', fakeAsync(() => {
+        let filterChangeEvent: DtFilterFieldChangeEvent<any> | undefined;
 
-      // We cannot use the getAndClick option here, because it would trigger
-      // an advancement of the filter field state with zoneExit
-      // and this is not wanted here.
-      const autOption = options[0];
-      autOption.click();
-      fixture.detectChanges();
+        fixture.componentInstance.dataSource.data = FILTER_FIELD_TEST_DATA_SINGLE_OPTION;
+        const sub = filterField.filterChanges.subscribe(
+          (ev) => (filterChangeEvent = ev),
+        );
 
-      const inputEl = getInput(fixture);
-      dispatchKeyboardEvent(inputEl, 'keydown', BACKSPACE);
-      fixture.detectChanges();
+        fixture.detectChanges();
+        filterField.focus();
+        advanceFilterfieldCycle();
 
-      const tags = getFilterTags(fixture);
-      expect(tags.length).toBe(0);
+        const options = getOptions(overlayContainerElement);
+        options[0].click();
 
-      options = getOptions(overlayContainerElement);
-      expect(options[0].textContent).toContain('AUT');
-      expect(options[1].textContent).toContain('USA');
-      expect(options[2].textContent).toContain('Free');
+        tick();
+
+        expect(filterChangeEvent).toBeDefined();
+        expect(filterChangeEvent!.added.length).toBe(1);
+        expect(filterChangeEvent!.removed.length).toBe(0);
+        expect(filterChangeEvent!.filters.length).toBe(1);
+
+        sub.unsubscribe();
+      }));
+
+      it('should emit filterChanges when removing an option', fakeAsync(() => {
+        let filterChangeEvent: DtFilterFieldChangeEvent<any> | undefined;
+
+        fixture.componentInstance.dataSource.data = FILTER_FIELD_TEST_DATA_SINGLE_OPTION;
+        const sub = filterField.filterChanges.subscribe(
+          (ev) => (filterChangeEvent = ev),
+        );
+
+        fixture.detectChanges();
+        filterField.focus();
+        advanceFilterfieldCycle();
+
+        const options = getOptions(overlayContainerElement);
+        options[0].click();
+
+        tick();
+
+        const tags = getFilterTags(fixture);
+        tags[0].removeButton.click();
+
+        tick();
+
+        expect(filterChangeEvent).toBeDefined();
+        expect(filterChangeEvent!.added.length).toBe(0);
+        expect(filterChangeEvent!.removed.length).toBe(1);
+        expect(filterChangeEvent!.filters.length).toBe(0);
+
+        sub.unsubscribe();
+      }));
+
+      it('should switch to free text and on enter fire a filterChanges event and create a tag', fakeAsync(() => {
+        const spy = jest.fn();
+        const subscription = filterField.filterChanges.subscribe(spy);
+        filterField.focus();
+        advanceFilterfieldCycle();
+
+        getAndClickOption(overlayContainerElement, 2);
+
+        typeIntoFilterElement('abc');
+        fixture.detectChanges();
+
+        const inputEl = getInput(fixture);
+        dispatchKeyboardEvent(inputEl, 'keydown', ENTER);
+
+        tick(DT_FILTER_FIELD_TYPING_DEBOUNCE);
+        fixture.detectChanges();
+
+        const tags = getFilterTags(fixture);
+        expect(tags.length).toBe(1);
+        expect(tags[0].key).toBe('Free');
+        expect(tags[0].separator).toBe('~');
+        expect(tags[0].value).toBe('abc');
+        expect(spy).toHaveBeenCalledTimes(1);
+        subscription.unsubscribe();
+      }));
+
+      it('should switch to free text with keyboard interaction and on enter fire a filterChanges event and create a tag', fakeAsync(() => {
+        const spy = jest.fn();
+        const subscription = filterField.filterChanges.subscribe(spy);
+        filterField.focus();
+        advanceFilterfieldCycle();
+
+        const inputEl = getInput(fixture);
+
+        // Select the free text option with the keyboard and hit enter
+        dispatchKeyboardEvent(inputEl, 'keydown', DOWN_ARROW);
+        dispatchKeyboardEvent(inputEl, 'keydown', DOWN_ARROW);
+
+        // Use keydown and keyup arrow, as this is what happens in the real world as well.
+        dispatchKeyboardEvent(inputEl, 'keydown', ENTER);
+
+        advanceFilterfieldCycle();
+        typeIntoFilterElement('abc');
+        fixture.detectChanges();
+
+        dispatchKeyboardEvent(inputEl, 'keydown', ENTER);
+
+        tick(DT_FILTER_FIELD_TYPING_DEBOUNCE);
+        fixture.detectChanges();
+
+        const tags = getFilterTags(fixture);
+
+        expect(tags.length).toBe(1);
+        expect(tags[0].key).toBe('Free');
+        expect(tags[0].separator).toBe('~');
+        expect(tags[0].value).toBe('abc');
+        expect(spy).toHaveBeenCalledTimes(1);
+        subscription.unsubscribe();
+      }));
+
+      it('should fire currentFilterChanges when an option is selected', fakeAsync(() => {
+        const spy = jest.fn();
+        const subscription = filterField.currentFilterChanges.subscribe(spy);
+        filterField.focus();
+        advanceFilterfieldCycle();
+
+        getAndClickOption(overlayContainerElement, 1);
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        subscription.unsubscribe();
+      }));
+
+      it('should fire currentFilterChanges when the current is removed with the BACKSPACE key', fakeAsync(() => {
+        filterField.focus();
+        advanceFilterfieldCycle();
+
+        getAndClickOption(overlayContainerElement, 1);
+
+        const spy = jest.fn();
+        const subscription = filterField.currentFilterChanges.subscribe(spy);
+
+        const inputEl = getInput(fixture);
+        dispatchKeyboardEvent(inputEl, 'keydown', BACKSPACE);
+        fixture.detectChanges();
+        flush();
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        subscription.unsubscribe();
+      }));
+
+      it('should switch back to root if unfinished filter is deleted with BACKSPACE', () => {
+        filterField.focus();
+        advanceFilterfieldCycle(true, false);
+
+        let options = getOptions(overlayContainerElement);
+
+        // We cannot use the getAndClick option here, because it would trigger
+        // an advancement of the filter field state with zoneExit
+        // and this is not wanted here.
+        const autOption = options[0];
+        autOption.click();
+        fixture.detectChanges();
+
+        const inputEl = getInput(fixture);
+        dispatchKeyboardEvent(inputEl, 'keydown', BACKSPACE);
+        fixture.detectChanges();
+
+        const tags = getFilterTags(fixture);
+        expect(tags.length).toBe(0);
+
+        options = getOptions(overlayContainerElement);
+        expect(options[0].textContent).toContain('AUT');
+        expect(options[1].textContent).toContain('USA');
+        expect(options[2].textContent).toContain('Free');
+      });
+
+      it('should show option again after adding all possible options and removing this option from the filters', () => {
+        fixture.componentInstance.dataSource.data = FILTER_FIELD_TEST_DATA_SINGLE_DISTINCT;
+        fixture.detectChanges();
+
+        filterField.focus();
+        advanceFilterfieldCycle();
+
+        // Click the AUT option
+        getAndClickOption(overlayContainerElement, 0);
+
+        let options = getOptions(overlayContainerElement);
+        const viennaOption = options[0];
+        expect(viennaOption.textContent).toContain('Vienna');
+
+        viennaOption.click();
+        advanceFilterfieldCycle();
+
+        const tags = getFilterTags(fixture);
+        expect(tags.length).toBe(1);
+
+        expect(tags[0].key).toBe('AUT');
+        expect(tags[0].separator).toBe(':');
+        expect(tags[0].value.trim()).toBe('Vienna');
+
+        tags[0].removeButton.click();
+
+        filterField.focus();
+        advanceFilterfieldCycle();
+
+        options = getOptions(overlayContainerElement);
+        // We use contain in favor of toBe as the text has to be inside twice due to the highlight
+        // The second occurrence is hidden by display:none
+        expect(options[0].textContent).toContain('AUT');
+      });
+
+      it('should switch back from root after deleting a unfinished freetext filter with BACKSPACE', () => {
+        filterField.focus();
+        advanceFilterfieldCycle();
+
+        getAndClickOption(overlayContainerElement, 2);
+
+        const inputEl = getInput(fixture);
+        dispatchKeyboardEvent(inputEl, 'keydown', BACKSPACE);
+        advanceFilterfieldCycle();
+
+        const tags = getFilterTags(fixture);
+        expect(tags.length).toBe(0);
+
+        const options = getOptions(overlayContainerElement);
+        // We use contain in favor of toBe as the text has to be inside twice due to the highlight
+        // The second occurrence is hidden by display:none
+        expect(options[0].textContent).toContain('AUT');
+        expect(options[1].textContent).toContain('USA');
+        expect(options[2].textContent).toContain('Free');
+      });
+
+      it('should remove a parent from an autocomplete if it is distinct and an option has been selected', () => {
+        fixture.componentInstance.dataSource.data = FILTER_FIELD_TEST_DATA_SINGLE_DISTINCT;
+        fixture.detectChanges();
+        filterField.focus();
+        advanceFilterfieldCycle();
+
+        // Get AUT option
+        getAndClickOption(overlayContainerElement, 0);
+
+        // Get Vienna option
+        getAndClickOption(overlayContainerElement, 0);
+
+        const options = getOptions(overlayContainerElement);
+        expect(options.length).toBe(0);
+      });
+
+      it('should close the panel when pressing escape', fakeAsync(() => {
+        const trigger = filterField._autocompleteTrigger;
+        const input = getInput(fixture);
+
+        input.focus();
+        flush();
+        advanceFilterfieldCycle();
+
+        expect(document.activeElement).toBe(input);
+        expect(trigger.panelOpen).toBe(true);
+
+        dispatchKeyboardEvent(input, 'keydown', ESCAPE);
+        flush();
+        fixture.detectChanges();
+
+        expect(document.activeElement).toBe(input);
+        expect(trigger.panelOpen).toBe(false);
+      }));
+
+      it('should not show options if the autocomplete is marked as async', fakeAsync(() => {
+        filterField.focus();
+        advanceFilterfieldCycle();
+
+        getAndClickOption(overlayContainerElement, 3);
+
+        const options = getOptions(overlayContainerElement);
+        expect(options.length).toBe(0);
+      }));
+
+      it('should add partial update to the autocomplete', fakeAsync(() => {
+        const DATA = {
+          autocomplete: [
+            {
+              name: 'AUT',
+              autocomplete: [
+                { name: 'Linz' },
+                { name: 'Vienna' },
+                { name: 'Graz' },
+              ],
+            },
+            {
+              name: 'CH (async, partial)',
+              async: true,
+              autocomplete: [],
+            },
+          ],
+        };
+
+        const DATA_PARTIAL = {
+          name: 'CH (async, partial)',
+          autocomplete: [
+            { name: 'Zürich' },
+            { name: 'Genf' },
+            { name: 'Basel' },
+            { name: 'Bern' },
+          ],
+          partial: true,
+        };
+
+        const DATA_PARTIAL_2 = {
+          name: 'CH (async, partial)',
+          autocomplete: [
+            { name: 'Zug' },
+            { name: 'Schaffhausen' },
+            { name: 'Luzern' },
+            { name: 'St. Gallen' },
+          ],
+          partial: true,
+        };
+
+        fixture.componentInstance.dataSource.data = DATA;
+        fixture.detectChanges();
+        filterField.focus();
+        advanceFilterfieldCycle(true, true);
+
+        getAndClickOption(overlayContainerElement, 1);
+
+        let options = getOptions(overlayContainerElement);
+        expect(options).toHaveLength(0);
+
+        fixture.componentInstance.dataSource.data = DATA_PARTIAL;
+        fixture.detectChanges();
+        advanceFilterfieldCycle(true, true);
+        tick();
+
+        options = getOptions(overlayContainerElement);
+        expect(options).toHaveLength(4);
+        expect(options[0].textContent).toContain('Zürich');
+        expect(options[1].textContent).toContain('Genf');
+        expect(options[2].textContent).toContain('Basel');
+        expect(options[3].textContent).toContain('Bern');
+
+        fixture.componentInstance.dataSource.data = DATA_PARTIAL_2;
+        fixture.detectChanges();
+        advanceFilterfieldCycle(true, true);
+        tick();
+
+        options = getOptions(overlayContainerElement);
+        expect(options).toHaveLength(4);
+        expect(options[0].textContent).toContain('Zug');
+        expect(options[1].textContent).toContain('Schaffhausen');
+        expect(options[2].textContent).toContain('Luzern');
+        expect(options[3].textContent).toContain('St. Gallen');
+      }));
+
+      it('should have the correct prefix when a filter is set and gets deleted in flight', () => {
+        filterField.focus();
+        advanceFilterfieldCycle();
+
+        // Set a filter first
+        getAndClickOption(overlayContainerElement, 1);
+        advanceFilterfieldCycle();
+        getAndClickOption(overlayContainerElement, 0);
+        advanceFilterfieldCycle();
+
+        // Get in flight of the next filter
+        getAndClickOption(overlayContainerElement, 0);
+        advanceFilterfieldCycle();
+
+        let category = fixture.debugElement.query(
+          By.css('.dt-filter-field-category'),
+        );
+        expect(category.nativeElement.textContent.trim()).toEqual('AUT');
+
+        // While in flight, delete the first tag
+        const tags = getFilterTags(fixture);
+        const { deleteButton } = getTagButtons(tags[0]);
+        deleteButton.click();
+        advanceFilterfieldCycle();
+
+        // Expect the category to still be there.
+        category = fixture.debugElement.query(
+          By.css('.dt-filter-field-category'),
+        );
+        expect(category).not.toBe(null);
+        expect(category.nativeElement.textContent.trim()).toEqual('AUT');
+
+        // Expect the options to be the same.
+        const options = getOptions(overlayContainerElement);
+        expect(options).toHaveLength(2);
+        expect(options[0].textContent).toContain('Upper Austria');
+        expect(options[1].textContent).toContain('Vienna');
+      });
+
+      it('should mark the input as readonly while loading async data', () => {
+        const DATA = {
+          autocomplete: [
+            {
+              name: 'AUT',
+              async: true,
+              autocomplete: [],
+            },
+          ],
+        };
+        const ASYNC_DATA = {
+          name: 'AUT',
+          autocomplete: [
+            {
+              name: 'Linz',
+            },
+          ],
+        };
+
+        const input = getInput(fixture);
+
+        fixture.componentInstance.dataSource.data = DATA;
+        fixture.detectChanges();
+        filterField.focus();
+        advanceFilterfieldCycle();
+
+        // No readonly attribute should be present at the beginning.
+        expect(input.readOnly).toBeFalsy();
+
+        getAndClickOption(overlayContainerElement, 0);
+
+        // readonly should be added while waiting for the data to be loaded
+        expect(input.readOnly).toBeTruthy();
+
+        fixture.componentInstance.dataSource.data = ASYNC_DATA;
+        fixture.detectChanges();
+        advanceFilterfieldCycle(true, true);
+
+        // readonly should be removed after the async data is loaded
+        expect(input.readOnly).toBeFalsy();
+      });
     });
 
-    it('should show option again after adding all possible options and removing this option from the filters', () => {
-      fixture.componentInstance.dataSource.data = FILTER_FIELD_TEST_DATA_SINGLE_DISTINCT;
-      fixture.detectChanges();
+    describe('programmatic setting', () => {
+      beforeEach(() => {
+        fixture.componentInstance.dataSource.data = TEST_DATA_EDITMODE;
+        advanceFilterfieldCycle();
+      });
 
-      filterField.focus();
-      advanceFilterfieldCycle();
+      it('should set the autocomplete filter programmatically', () => {
+        // Autocomplete filter for AUT -> Upper Austria -> Cities -> Linz
+        const autocompleteFilter = [
+          TEST_DATA_EDITMODE.autocomplete[0],
+          (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
+          (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
+            .autocomplete[0].options[0],
+        ];
+        filterField.filters = [autocompleteFilter];
+        fixture.detectChanges();
 
-      // Click the AUT option
-      getAndClickOption(overlayContainerElement, 0);
+        const tags = getFilterTags(fixture);
+        expect(tags[0].key).toBe('AUT');
+        expect(tags[0].separator).toBe(':');
+        expect(tags[0].value).toBe('Linz');
+      });
 
-      let options = getOptions(overlayContainerElement);
-      const viennaOption = options[0];
-      expect(viennaOption.textContent).toContain('Vienna');
+      it('should set the freetext filter programmatically', () => {
+        // Custom free text for Free -> Custom free text
+        const freeTextFilter = [
+          TEST_DATA_EDITMODE.autocomplete[2],
+          'Custom free text',
+        ];
+        filterField.filters = [freeTextFilter];
+        fixture.detectChanges();
 
-      viennaOption.click();
-      advanceFilterfieldCycle();
+        const tags = getFilterTags(fixture);
+        expect(tags[0].key).toBe('Free');
+        expect(tags[0].separator).toBe('~');
+        expect(tags[0].value).toBe('Custom free text');
+      });
 
-      const tags = getFilterTags(fixture);
-      expect(tags.length).toBe(1);
+      it('should set the range filter programmatically (range operator)', () => {
+        // Range filter preset with range operator, second unit and range from 15 to 80
+        const rangeFilter = [
+          TEST_DATA_EDITMODE.autocomplete[3],
+          { operator: 'range', unit: 's', range: [15, 80] },
+        ];
+        filterField.filters = [rangeFilter];
+        fixture.detectChanges();
 
-      expect(tags[0].key).toBe('AUT');
-      expect(tags[0].separator).toBe(':');
-      expect(tags[0].value.trim()).toBe('Vienna');
+        const tags = getFilterTags(fixture);
+        expect(tags[0].key).toBe('Requests per minute');
+        expect(tags[0].separator).toBe(':');
+        expect(tags[0].value).toBe('15s - 80s');
+      });
 
-      tags[0].removeButton.click();
+      it('should set the range filter programmatically (greater-equal operator)', () => {
+        // Range filter preset with greater-equal operator, second unit and value of 75
+        const rangeFilter = [
+          TEST_DATA_EDITMODE.autocomplete[3],
+          { operator: 'greater-equal', unit: 's', range: 75 },
+        ];
+        filterField.filters = [rangeFilter];
+        fixture.detectChanges();
 
-      filterField.focus();
-      advanceFilterfieldCycle();
+        const tags = getFilterTags(fixture);
+        expect(tags[0].key).toBe('Requests per minute');
+        expect(tags[0].separator).toBe('≥');
+        expect(tags[0].value).toBe('75s');
+      });
 
-      options = getOptions(overlayContainerElement);
-      // We use contain in favor of toBe as the text has to be inside twice due to the highlight
-      // The second occurrence is hidden by display:none
-      expect(options[0].textContent).toContain('AUT');
+      it('should set a filter which has the same shape but a different reference', () => {
+        filterField.filters = [
+          [
+            {
+              name: 'USA',
+              autocomplete: [{ name: 'Los Angeles' }, { name: 'San Fran' }],
+            },
+            { name: 'Los Angeles' },
+          ],
+        ];
+        fixture.detectChanges();
+        const tags = getFilterTags(fixture);
+        expect(tags[0].key).toBe('USA');
+        expect(tags[0].separator).toBe(':');
+        expect(tags[0].value).toBe('Los Angeles');
+      });
+
+      it('should set a filter that is not part of the current data set', () => {
+        filterField.filters = [
+          [
+            {
+              name: 'Spain',
+              autocomplete: [{ name: 'Madrid' }, { name: 'Barcelona' }],
+            },
+            { name: 'Madrid' },
+          ],
+        ];
+        fixture.detectChanges();
+        const tags = getFilterTags(fixture);
+        expect(tags[0].key).toBe('Spain');
+        expect(tags[0].separator).toBe(':');
+        expect(tags[0].value).toBe('Madrid');
+      });
+
+      it('should set a filter that has async parts', () => {
+        filterField.filters = [
+          [
+            TEST_DATA_EDITMODE.autocomplete[4],
+            (TEST_DATA_EDITMODE_ASYNC as any).autocomplete[0],
+          ],
+        ];
+        fixture.detectChanges();
+        const tags = getFilterTags(fixture);
+        expect(tags[0].key).toBe('DE (async)');
+        expect(tags[0].separator).toBe(':');
+        expect(tags[0].value).toBe('Berlin');
+      });
     });
 
-    it('should switch back from root after deleting a unfinished freetext filter with BACKSPACE', () => {
-      filterField.focus();
-      advanceFilterfieldCycle();
+    describe('clear all', () => {
+      beforeEach(() => {
+        fixture.componentInstance.dataSource.data = TEST_DATA_EDITMODE;
+        advanceFilterfieldCycle(false);
+      });
 
-      getAndClickOption(overlayContainerElement, 2);
+      it('should not display the clear all button if no filters are set', () => {
+        // Check if the clear all is initially not visible.
+        expect(isClearAllVisible(fixture)).toBe(false);
 
-      const inputEl = getInput(fixture);
-      dispatchKeyboardEvent(inputEl, 'keydown', BACKSPACE);
-      advanceFilterfieldCycle();
+        const autocompleteFilter = [
+          TEST_DATA_EDITMODE.autocomplete[0],
+          (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
+          (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
+            .autocomplete[0].options[0],
+        ];
+        filterField.filters = [autocompleteFilter];
+        fixture.detectChanges();
 
-      const tags = getFilterTags(fixture);
-      expect(tags.length).toBe(0);
+        // After setting the filters, there should be a clear all button visible.
+        expect(isClearAllVisible(fixture)).toBe(true);
+      });
 
-      const options = getOptions(overlayContainerElement);
-      // We use contain in favor of toBe as the text has to be inside twice due to the highlight
-      // The second occurrence is hidden by display:none
-      expect(options[0].textContent).toContain('AUT');
-      expect(options[1].textContent).toContain('USA');
-      expect(options[2].textContent).toContain('Free');
+      // the user is in the edit mode of a filter
+      it('should not display the clear all button if the filter field is focused', () => {
+        const autocompleteFilter = [
+          TEST_DATA_EDITMODE.autocomplete[0],
+          (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
+          (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
+            .autocomplete[0].options[0],
+        ];
+        filterField.filters = [autocompleteFilter];
+        fixture.detectChanges();
+
+        filterField.focus();
+        advanceFilterfieldCycle();
+
+        expect(isClearAllVisible(fixture)).toBe(false);
+      });
+
+      // the user is in the edit mode of a filter
+      it('should not display the clear all button if the current def is not the root def or a panel is open', () => {
+        const autocompleteFilter = [
+          TEST_DATA_EDITMODE.autocomplete[0],
+          (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
+          (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
+            .autocomplete[0].options[0],
+        ];
+        filterField.filters = [autocompleteFilter];
+        fixture.detectChanges();
+
+        filterField.focus();
+        advanceFilterfieldCycle();
+
+        const options = getOptions(overlayContainerElement);
+        const autOption = options[0];
+        autOption.click();
+
+        expect(isClearAllVisible(fixture)).toBe(false);
+      });
+
+      it('should not display the clear all button if no label is provided', () => {
+        const autocompleteFilter = [
+          TEST_DATA_EDITMODE.autocomplete[0],
+          (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
+          (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
+            .autocomplete[0].options[0],
+        ];
+        filterField.filters = [autocompleteFilter];
+        fixture.componentInstance.clearAllLabel = '';
+        fixture.detectChanges();
+
+        expect(isClearAllVisible(fixture)).toBe(false);
+      });
+
+      it('should reset the entire filter field', () => {
+        // Autocomplete filter for AUT -> Upper Austria -> Cities -> Linz
+        const autocompleteFilter = [
+          TEST_DATA_EDITMODE.autocomplete[0],
+          (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
+          (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
+            .autocomplete[0].options[0],
+        ];
+        filterField.filters = [autocompleteFilter];
+        fixture.detectChanges();
+
+        const tagsBefore = getFilterTags(fixture);
+        expect(tagsBefore.length).toBe(1);
+        expect(tagsBefore[0].key).toBe('AUT');
+        expect(tagsBefore[0].separator).toBe(':');
+        expect(tagsBefore[0].value).toBe('Linz');
+
+        const clearAllButtonEl = getClearAll(fixture);
+        clearAllButtonEl!.click();
+        fixture.detectChanges();
+
+        const tagsAfter = getFilterTags(fixture);
+        expect(tagsAfter.length).toBe(0);
+      });
+
+      it('should emit a filter-changed event with all removed filters in the removed array', () => {
+        const spy = jest.fn();
+        const subscription = filterField.filterChanges.subscribe(spy);
+
+        const autocompleteFilter = [
+          TEST_DATA_EDITMODE.autocomplete[0],
+          (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
+          (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
+            .autocomplete[0].options[0],
+        ];
+        filterField.filters = [autocompleteFilter];
+        fixture.detectChanges();
+
+        const clearAllButtonEl = getClearAll(fixture);
+        clearAllButtonEl!.click();
+        fixture.detectChanges();
+
+        expect(spy).toHaveBeenNthCalledWith(1, {
+          source: expect.any(DtFilterField),
+          added: [],
+          removed: [autocompleteFilter],
+          filters: [],
+        });
+
+        subscription.unsubscribe();
+      });
+
+      it('should not remove filter where the corresponding tag has deletable set to false', () => {
+        const autocompleteFilter = [
+          TEST_DATA_EDITMODE.autocomplete[0],
+          (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
+          (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
+            .autocomplete[0].options[0],
+        ];
+        filterField.filters = [autocompleteFilter];
+        filterField.tagData[0].deletable = false;
+
+        fixture.detectChanges();
+
+        const clearAllButtonEl = getClearAll(fixture);
+        clearAllButtonEl!.click();
+        fixture.detectChanges();
+
+        expect(filterField.filters.length).toBe(1);
+      });
+
+      it('should not emit a filter-changed event if every tag-data is set to non-deletable', () => {
+        const spy = jest.fn();
+        const subscription = filterField.filterChanges.subscribe(spy);
+
+        const autocompleteFilter = [
+          TEST_DATA_EDITMODE.autocomplete[0],
+          (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
+          (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
+            .autocomplete[0].options[0],
+        ];
+        filterField.filters = [autocompleteFilter];
+        filterField.tagData[0].deletable = false;
+
+        fixture.detectChanges();
+
+        const clearAllButtonEl = getClearAll(fixture);
+        clearAllButtonEl!.click();
+        fixture.detectChanges();
+
+        expect(spy).not.toHaveBeenCalled();
+
+        subscription.unsubscribe();
+      });
     });
 
-    it('should remove a parent from an autocomplete if it is distinct and an option has been selected', () => {
-      fixture.componentInstance.dataSource.data = FILTER_FIELD_TEST_DATA_SINGLE_DISTINCT;
-      fixture.detectChanges();
-      filterField.focus();
-      advanceFilterfieldCycle();
-
-      // Get AUT option
-      getAndClickOption(overlayContainerElement, 0);
-
-      // Get Vienna option
-      getAndClickOption(overlayContainerElement, 0);
-
-      const options = getOptions(overlayContainerElement);
-      expect(options.length).toBe(0);
-    });
-
-    it('should close the panel when pressing escape', fakeAsync(() => {
-      const trigger = filterField._autocompleteTrigger;
-      const input = getInput(fixture);
-
-      input.focus();
-      flush();
-      advanceFilterfieldCycle();
-
-      expect(document.activeElement).toBe(input);
-      expect(trigger.panelOpen).toBe(true);
-
-      dispatchKeyboardEvent(input, 'keydown', ESCAPE);
-      flush();
-      fixture.detectChanges();
-
-      expect(document.activeElement).toBe(input);
-      expect(trigger.panelOpen).toBe(false);
-    }));
-
-    it('should not show options if the autocomplete is marked as async', fakeAsync(() => {
-      filterField.focus();
-      advanceFilterfieldCycle();
-
-      getAndClickOption(overlayContainerElement, 3);
-
-      const options = getOptions(overlayContainerElement);
-      expect(options.length).toBe(0);
-    }));
-
-    it('should add partial update to the autocomplete', fakeAsync(() => {
-      const DATA = {
-        autocomplete: [
-          {
-            name: 'AUT',
-            autocomplete: [
-              { name: 'Linz' },
-              { name: 'Vienna' },
-              { name: 'Graz' },
-            ],
-          },
-          {
-            name: 'CH (async, partial)',
-            async: true,
-            autocomplete: [],
-          },
-        ],
-      };
-
-      const DATA_PARTIAL = {
-        name: 'CH (async, partial)',
-        autocomplete: [
-          { name: 'Zürich' },
-          { name: 'Genf' },
-          { name: 'Basel' },
-          { name: 'Bern' },
-        ],
-        partial: true,
-      };
-
-      const DATA_PARTIAL_2 = {
-        name: 'CH (async, partial)',
-        autocomplete: [
-          { name: 'Zug' },
-          { name: 'Schaffhausen' },
-          { name: 'Luzern' },
-          { name: 'St. Gallen' },
-        ],
-        partial: true,
-      };
-
-      fixture.componentInstance.dataSource.data = DATA;
-      fixture.detectChanges();
-      filterField.focus();
-      advanceFilterfieldCycle(true, true);
-
-      getAndClickOption(overlayContainerElement, 1);
-
-      let options = getOptions(overlayContainerElement);
-      expect(options).toHaveLength(0);
-
-      fixture.componentInstance.dataSource.data = DATA_PARTIAL;
-      fixture.detectChanges();
-      advanceFilterfieldCycle(true, true);
-      tick();
-
-      options = getOptions(overlayContainerElement);
-      expect(options).toHaveLength(4);
-      expect(options[0].textContent).toContain('Zürich');
-      expect(options[1].textContent).toContain('Genf');
-      expect(options[2].textContent).toContain('Basel');
-      expect(options[3].textContent).toContain('Bern');
-
-      fixture.componentInstance.dataSource.data = DATA_PARTIAL_2;
-      fixture.detectChanges();
-      advanceFilterfieldCycle(true, true);
-      tick();
-
-      options = getOptions(overlayContainerElement);
-      expect(options).toHaveLength(4);
-      expect(options[0].textContent).toContain('Zug');
-      expect(options[1].textContent).toContain('Schaffhausen');
-      expect(options[2].textContent).toContain('Luzern');
-      expect(options[3].textContent).toContain('St. Gallen');
-    }));
-
-    it('should have the correct prefix when a filter is set and gets deleted in flight', () => {
-      filterField.focus();
-      advanceFilterfieldCycle();
-
-      // Set a filter first
-      getAndClickOption(overlayContainerElement, 1);
-      advanceFilterfieldCycle();
-      getAndClickOption(overlayContainerElement, 0);
-      advanceFilterfieldCycle();
-
-      // Get in flight of the next filter
-      getAndClickOption(overlayContainerElement, 0);
-      advanceFilterfieldCycle();
-
-      let category = fixture.debugElement.query(
-        By.css('.dt-filter-field-category'),
-      );
-      expect(category.nativeElement.textContent.trim()).toEqual('AUT');
-
-      // While in flight, delete the first tag
-      const tags = getFilterTags(fixture);
-      const { deleteButton } = getTagButtons(tags[0]);
-      deleteButton.click();
-      advanceFilterfieldCycle();
-
-      // Expect the category to still be there.
-      category = fixture.debugElement.query(
-        By.css('.dt-filter-field-category'),
-      );
-      expect(category).not.toBe(null);
-      expect(category.nativeElement.textContent.trim()).toEqual('AUT');
-
-      // Expect the options to be the same.
-      const options = getOptions(overlayContainerElement);
-      expect(options).toHaveLength(2);
-      expect(options[0].textContent).toContain('Upper Austria');
-      expect(options[1].textContent).toContain('Vienna');
-    });
-
-    it('should mark the input as readonly while loading async data', () => {
-      const DATA = {
-        autocomplete: [
-          {
-            name: 'AUT',
-            async: true,
-            autocomplete: [],
-          },
-        ],
-      };
-      const ASYNC_DATA = {
-        name: 'AUT',
-        autocomplete: [
-          {
-            name: 'Linz',
-          },
-        ],
-      };
-
-      const input = getInput(fixture);
-
-      fixture.componentInstance.dataSource.data = DATA;
-      fixture.detectChanges();
-      filterField.focus();
-      advanceFilterfieldCycle();
-
-      // No readonly attribute should be present at the beginning.
-      expect(input.readOnly).toBeFalsy();
-
-      getAndClickOption(overlayContainerElement, 0);
-
-      // readonly should be added while waiting for the data to be loaded
-      expect(input.readOnly).toBeTruthy();
-
-      fixture.componentInstance.dataSource.data = ASYNC_DATA;
-      fixture.detectChanges();
-      advanceFilterfieldCycle(true, true);
-
-      // readonly should be removed after the async data is loaded
-      expect(input.readOnly).toBeFalsy();
-    });
-  });
-
-  describe('programmatic setting', () => {
-    beforeEach(() => {
-      fixture.componentInstance.dataSource.data = TEST_DATA_EDITMODE;
-      advanceFilterfieldCycle();
-    });
-
-    it('should set the autocomplete filter programmatically', () => {
-      // Autocomplete filter for AUT -> Upper Austria -> Cities -> Linz
+    describe('tags', () => {
       const autocompleteFilter = [
         TEST_DATA_EDITMODE.autocomplete[0],
         (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
         (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
           .autocomplete[0].options[0],
       ];
-      filterField.filters = [autocompleteFilter];
-      fixture.detectChanges();
+      beforeEach(() => {
+        fixture.componentInstance.dataSource.data = TEST_DATA_EDITMODE;
+        zone.simulateZoneExit();
+        fixture.detectChanges();
 
-      const tags = getFilterTags(fixture);
-      expect(tags[0].key).toBe('AUT');
-      expect(tags[0].separator).toBe(':');
-      expect(tags[0].value).toBe('Linz');
-    });
+        // Autocomplete filter for AUT -> Upper Austria -> Cities -> Linz
 
-    it('should set the freetext filter programmatically', () => {
-      // Custom free text for Free -> Custom free text
-      const freeTextFilter = [
-        TEST_DATA_EDITMODE.autocomplete[2],
-        'Custom free text',
-      ];
-      filterField.filters = [freeTextFilter];
-      fixture.detectChanges();
+        filterField.filters = [autocompleteFilter];
+        fixture.detectChanges();
+      });
 
-      const tags = getFilterTags(fixture);
-      expect(tags[0].key).toBe('Free');
-      expect(tags[0].separator).toBe('~');
-      expect(tags[0].value).toBe('Custom free text');
-    });
+      it('should return a tag from a filter instance', () => {
+        const tagInst = filterField.getTagForFilter(autocompleteFilter);
+        expect(tagInst).toBeDefined();
+        expect(tagInst!.data.key).toBe('AUT');
+        expect(tagInst!.data.value).toBe('Linz');
+      });
 
-    it('should set the range filter programmatically (range operator)', () => {
-      // Range filter preset with range operator, second unit and range from 15 to 80
-      const rangeFilter = [
-        TEST_DATA_EDITMODE.autocomplete[3],
-        { operator: 'range', unit: 's', range: [15, 80] },
-      ];
-      filterField.filters = [rangeFilter];
-      fixture.detectChanges();
-
-      const tags = getFilterTags(fixture);
-      expect(tags[0].key).toBe('Requests per minute');
-      expect(tags[0].separator).toBe(':');
-      expect(tags[0].value).toBe('15s - 80s');
-    });
-
-    it('should set the range filter programmatically (greater-equal operator)', () => {
-      // Range filter preset with greater-equal operator, second unit and value of 75
-      const rangeFilter = [
-        TEST_DATA_EDITMODE.autocomplete[3],
-        { operator: 'greater-equal', unit: 's', range: 75 },
-      ];
-      filterField.filters = [rangeFilter];
-      fixture.detectChanges();
-
-      const tags = getFilterTags(fixture);
-      expect(tags[0].key).toBe('Requests per minute');
-      expect(tags[0].separator).toBe('≥');
-      expect(tags[0].value).toBe('75s');
-    });
-
-    it('should set a filter which has the same shape but a different reference', () => {
-      filterField.filters = [
-        [
+      it('should return null if no tag is found for the filter given', () => {
+        const notIncludedAutocomplete = [
           {
             name: 'USA',
             autocomplete: [{ name: 'Los Angeles' }, { name: 'San Fran' }],
           },
-          { name: 'Los Angeles' },
-        ],
-      ];
-      fixture.detectChanges();
-      const tags = getFilterTags(fixture);
-      expect(tags[0].key).toBe('USA');
-      expect(tags[0].separator).toBe(':');
-      expect(tags[0].value).toBe('Los Angeles');
-    });
-
-    it('should set a filter that is not part of the current data set', () => {
-      filterField.filters = [
-        [
-          {
-            name: 'Spain',
-            autocomplete: [{ name: 'Madrid' }, { name: 'Barcelona' }],
-          },
-          { name: 'Madrid' },
-        ],
-      ];
-      fixture.detectChanges();
-      const tags = getFilterTags(fixture);
-      expect(tags[0].key).toBe('Spain');
-      expect(tags[0].separator).toBe(':');
-      expect(tags[0].value).toBe('Madrid');
-    });
-
-    it('should set a filter that has async parts', () => {
-      filterField.filters = [
-        [
-          TEST_DATA_EDITMODE.autocomplete[4],
-          (TEST_DATA_EDITMODE_ASYNC as any).autocomplete[0],
-        ],
-      ];
-      fixture.detectChanges();
-      const tags = getFilterTags(fixture);
-      expect(tags[0].key).toBe('DE (async)');
-      expect(tags[0].separator).toBe(':');
-      expect(tags[0].value).toBe('Berlin');
-    });
-  });
-
-  describe('clear all', () => {
-    beforeEach(() => {
-      fixture.componentInstance.dataSource.data = TEST_DATA_EDITMODE;
-      advanceFilterfieldCycle(false);
-    });
-
-    it('should not display the clear all button if no filters are set', () => {
-      // Check if the clear all is initially not visible.
-      expect(isClearAllVisible(fixture)).toBe(false);
-
-      const autocompleteFilter = [
-        TEST_DATA_EDITMODE.autocomplete[0],
-        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
-        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
-          .autocomplete[0].options[0],
-      ];
-      filterField.filters = [autocompleteFilter];
-      fixture.detectChanges();
-
-      // After setting the filters, there should be a clear all button visible.
-      expect(isClearAllVisible(fixture)).toBe(true);
-    });
-
-    // the user is in the edit mode of a filter
-    it('should not display the clear all button if the filter field is focused', () => {
-      const autocompleteFilter = [
-        TEST_DATA_EDITMODE.autocomplete[0],
-        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
-        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
-          .autocomplete[0].options[0],
-      ];
-      filterField.filters = [autocompleteFilter];
-      fixture.detectChanges();
-
-      filterField.focus();
-      advanceFilterfieldCycle();
-
-      expect(isClearAllVisible(fixture)).toBe(false);
-    });
-
-    // the user is in the edit mode of a filter
-    it('should not display the clear all button if the current def is not the root def or a panel is open', () => {
-      const autocompleteFilter = [
-        TEST_DATA_EDITMODE.autocomplete[0],
-        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
-        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
-          .autocomplete[0].options[0],
-      ];
-      filterField.filters = [autocompleteFilter];
-      fixture.detectChanges();
-
-      filterField.focus();
-      advanceFilterfieldCycle();
-
-      const options = getOptions(overlayContainerElement);
-      const autOption = options[0];
-      autOption.click();
-
-      expect(isClearAllVisible(fixture)).toBe(false);
-    });
-
-    it('should not display the clear all button if no label is provided', () => {
-      const autocompleteFilter = [
-        TEST_DATA_EDITMODE.autocomplete[0],
-        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
-        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
-          .autocomplete[0].options[0],
-      ];
-      filterField.filters = [autocompleteFilter];
-      fixture.componentInstance.clearAllLabel = '';
-      fixture.detectChanges();
-
-      expect(isClearAllVisible(fixture)).toBe(false);
-    });
-
-    it('should reset the entire filter field', () => {
-      // Autocomplete filter for AUT -> Upper Austria -> Cities -> Linz
-      const autocompleteFilter = [
-        TEST_DATA_EDITMODE.autocomplete[0],
-        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
-        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
-          .autocomplete[0].options[0],
-      ];
-      filterField.filters = [autocompleteFilter];
-      fixture.detectChanges();
-
-      const tagsBefore = getFilterTags(fixture);
-      expect(tagsBefore.length).toBe(1);
-      expect(tagsBefore[0].key).toBe('AUT');
-      expect(tagsBefore[0].separator).toBe(':');
-      expect(tagsBefore[0].value).toBe('Linz');
-
-      const clearAllButtonEl = getClearAll(fixture);
-      clearAllButtonEl!.click();
-      fixture.detectChanges();
-
-      const tagsAfter = getFilterTags(fixture);
-      expect(tagsAfter.length).toBe(0);
-    });
-
-    it('should emit a filter-changed event with all removed filters in the removed array', () => {
-      const spy = jest.fn();
-      const subscription = filterField.filterChanges.subscribe(spy);
-
-      const autocompleteFilter = [
-        TEST_DATA_EDITMODE.autocomplete[0],
-        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
-        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
-          .autocomplete[0].options[0],
-      ];
-      filterField.filters = [autocompleteFilter];
-      fixture.detectChanges();
-
-      const clearAllButtonEl = getClearAll(fixture);
-      clearAllButtonEl!.click();
-      fixture.detectChanges();
-
-      expect(spy).toHaveBeenNthCalledWith(1, {
-        source: expect.any(DtFilterField),
-        added: [],
-        removed: [autocompleteFilter],
-        filters: [],
+          'Los Angeles',
+        ];
+        const tagInst = filterField.getTagForFilter(notIncludedAutocomplete);
+        expect(tagInst).toBeNull();
       });
 
-      subscription.unsubscribe();
+      it('should disable the edit button on the tag when editable is set to false', () => {
+        const tagInst = filterField.getTagForFilter(autocompleteFilter);
+        tagInst!.editable = false;
+        fixture.detectChanges();
+        const tags = getFilterTags(fixture);
+        const { label, deleteButton } = getTagButtons(tags[0]);
+        expect(label.disabled).toBeTruthy();
+        expect(deleteButton.disabled).toBeFalsy();
+      });
+
+      it('should disable the delete button on the tag when deletable is set to false', () => {
+        const tagInst = filterField.getTagForFilter(autocompleteFilter);
+        tagInst!.deletable = false;
+        fixture.detectChanges();
+        const tags = getFilterTags(fixture);
+        const { label, deleteButton } = getTagButtons(tags[0]);
+        expect(label.disabled).toBeFalsy();
+        expect(deleteButton).toBeNull();
+      });
+
+      it('should disable the entire tag when disabled is set to true', () => {
+        const tagInst = filterField.getTagForFilter(autocompleteFilter);
+        tagInst!.disabled = true;
+        fixture.detectChanges();
+        const tags = getFilterTags(fixture);
+        const { label, deleteButton } = getTagButtons(tags[0]);
+        expect(label.disabled).toBeTruthy();
+        expect(deleteButton).toBeNull();
+      });
+
+      it('should keep the deletable/editable flags on the tags when a tag is edited', () => {
+        // Custom free text for Free -> Custom free text
+        const freeTextFilter = [
+          TEST_DATA_EDITMODE.autocomplete[2],
+          'Custom free text',
+        ];
+        filterField.filters = [autocompleteFilter, freeTextFilter];
+        fixture.detectChanges();
+
+        const autoTagInst = filterField.getTagForFilter(autocompleteFilter);
+        autoTagInst!.editable = false;
+        const freeTextTagInst = filterField.getTagForFilter(freeTextFilter);
+        freeTextTagInst!.deletable = false;
+        fixture.detectChanges();
+        const tags = getFilterTags(fixture);
+        const {
+          label: autoLabel,
+          deleteButton: autoDeleteButton,
+        } = getTagButtons(tags[0]);
+        expect(autoLabel.disabled).toBeTruthy();
+        expect(autoDeleteButton.disabled).toBeFalsy();
+
+        const {
+          label: freeTextLabel,
+          deleteButton: freeTextDeleteButton,
+        } = getTagButtons(tags[0]);
+        expect(freeTextLabel.disabled).toBeTruthy();
+        expect(freeTextDeleteButton.disabled).toBeFalsy();
+
+        // enter editmode
+        freeTextLabel.click();
+        advanceFilterfieldCycle();
+
+        // cancel editmode
+        dispatchFakeEvent(document, 'click');
+        advanceFilterfieldCycle();
+
+        expect(autoLabel.disabled).toBeTruthy();
+        expect(autoDeleteButton.disabled).toBeFalsy();
+
+        expect(freeTextLabel.disabled).toBeTruthy();
+        expect(freeTextDeleteButton.disabled).toBeFalsy();
+      });
+
+      it('should keep the deletable/editable flags on the tags when a tag is deleted', () => {
+        // Custom free text for Free -> Custom free text
+        const freeTextFilter = [
+          TEST_DATA_EDITMODE.autocomplete[2],
+          'Custom free text',
+        ];
+        filterField.filters = [autocompleteFilter, freeTextFilter];
+        fixture.detectChanges();
+
+        const autoTagInst = filterField.getTagForFilter(autocompleteFilter);
+        autoTagInst!.editable = false;
+        const freeTextTagInst = filterField.getTagForFilter(freeTextFilter);
+        freeTextTagInst!.deletable = false;
+        fixture.detectChanges();
+        const tags = getFilterTags(fixture);
+        const {
+          label: autoLabel,
+          deleteButton: autoDeleteButton,
+        } = getTagButtons(tags[0]);
+        expect(autoLabel.disabled).toBeTruthy();
+        expect(autoDeleteButton.disabled).toBeFalsy();
+
+        const {
+          label: freeTextLabel,
+          deleteButton: freeTextDeleteButton,
+        } = getTagButtons(tags[0]);
+        expect(freeTextLabel.disabled).toBeTruthy();
+        expect(freeTextDeleteButton.disabled).toBeFalsy();
+
+        // delete tag
+        autoDeleteButton.click();
+        advanceFilterfieldCycle();
+
+        expect(freeTextLabel.disabled).toBeTruthy();
+        expect(freeTextDeleteButton.disabled).toBeFalsy();
+      });
+
+      it('should not delete a non deletable tag when clicking the clear all', () => {
+        const tagInst = filterField.getTagForFilter(autocompleteFilter);
+        tagInst!.deletable = false;
+        fixture.detectChanges();
+        const clearAll = getClearAll(fixture);
+        clearAll!.click();
+        fixture.detectChanges();
+
+        const tags = getFilterTags(fixture);
+        expect(tags.length).toBe(1);
+      });
     });
 
-    it('should not remove filter where the corresponding tag has deletable set to false', () => {
-      const autocompleteFilter = [
-        TEST_DATA_EDITMODE.autocomplete[0],
-        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
-        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
-          .autocomplete[0].options[0],
-      ];
-      filterField.filters = [autocompleteFilter];
-      filterField.tagData[0].deletable = false;
+    describe('data-source switching', () => {
+      it('should cancel the edit mode if the data source is switched', () => {
+        filterField.focus();
+        advanceFilterfieldCycle();
 
-      fixture.detectChanges();
+        const options = getOptions(overlayContainerElement);
+        options[0].click();
+        advanceFilterfieldCycle();
 
-      const clearAllButtonEl = getClearAll(fixture);
-      clearAllButtonEl!.click();
-      fixture.detectChanges();
+        let category = fixture.debugElement.query(
+          By.css('.dt-filter-field-category'),
+        );
 
-      expect(filterField.filters.length).toBe(1);
+        expect(category.nativeElement.textContent.trim()).toBe('AUT');
+        expect(filterField.filters.length).toBe(1);
+        expect(filterField.filters[0][0].name).toBe('AUT');
+
+        fixture.componentInstance.dataSource.data = TEST_DATA_EDITMODE;
+        advanceFilterfieldCycle();
+
+        category = fixture.debugElement.query(
+          By.css('.dt-filter-field-category'),
+        );
+
+        expect(category).toBeNull();
+        expect(filterField.filters.length).toBe(0);
+      });
+
+      it('should not remove the current filter if the data is changed when the filterChanges event fires', () => {
+        const filterChangesSubscription = filterField.filterChanges.subscribe(
+          () => {
+            fixture.componentInstance.dataSource.data = FILTER_FIELD_TEST_DATA_ASYNC;
+          },
+        );
+
+        filterField.focus();
+        advanceFilterfieldCycle();
+
+        let options = getOptions(overlayContainerElement);
+        options[0].click();
+        advanceFilterfieldCycle();
+
+        options = getOptions(overlayContainerElement);
+
+        zone.simulateZoneExit();
+
+        options[1].click();
+        advanceFilterfieldCycle();
+
+        expect(filterField.filters.length).toBe(1);
+
+        filterChangesSubscription.unsubscribe();
+      });
     });
 
-    it('should not emit a filter-changed event if every tag-data is set to non-deletable', () => {
-      const spy = jest.fn();
-      const subscription = filterField.filterChanges.subscribe(spy);
-
-      const autocompleteFilter = [
-        TEST_DATA_EDITMODE.autocomplete[0],
-        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
-        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
-          .autocomplete[0].options[0],
-      ];
-      filterField.filters = [autocompleteFilter];
-      filterField.tagData[0].deletable = false;
-
-      fixture.detectChanges();
-
-      const clearAllButtonEl = getClearAll(fixture);
-      clearAllButtonEl!.click();
-      fixture.detectChanges();
-
-      expect(spy).not.toHaveBeenCalled();
-
-      subscription.unsubscribe();
-    });
-  });
-
-  describe('tags', () => {
-    const autocompleteFilter = [
-      TEST_DATA_EDITMODE.autocomplete[0],
-      (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
-      (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
-        .autocomplete[0].options[0],
-    ];
-    beforeEach(() => {
-      fixture.componentInstance.dataSource.data = TEST_DATA_EDITMODE;
-      zone.simulateZoneExit();
-      fixture.detectChanges();
-
+    describe('tag parser function override by injection token configuration', () => {
       // Autocomplete filter for AUT -> Upper Austria -> Cities -> Linz
-
-      filterField.filters = [autocompleteFilter];
-      fixture.detectChanges();
-    });
-
-    it('should return a tag from a filter instance', () => {
-      const tagInst = filterField.getTagForFilter(autocompleteFilter);
-      expect(tagInst).toBeDefined();
-      expect(tagInst!.data.key).toBe('AUT');
-      expect(tagInst!.data.value).toBe('Linz');
-    });
-
-    it('should return null if no tag is found for the filter given', () => {
-      const notIncludedAutocomplete = [
-        {
-          name: 'USA',
-          autocomplete: [{ name: 'Los Angeles' }, { name: 'San Fran' }],
-        },
-        'Los Angeles',
+      const autocompleteFilter = [
+        TEST_DATA_EDITMODE.autocomplete[0],
+        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
+        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
+          .autocomplete[0].options[0],
       ];
-      const tagInst = filterField.getTagForFilter(notIncludedAutocomplete);
-      expect(tagInst).toBeNull();
+
+      let fixtureCustom: ComponentFixture<TestAppCustomParserConfig>;
+      beforeEach(() => {
+        fixtureCustom = createComponent(TestAppCustomParserConfig);
+        filterField = fixtureCustom.debugElement.query(
+          By.directive(DtFilterField),
+        ).componentInstance;
+
+        fixtureCustom.componentInstance.dataSource.data = TEST_DATA_EDITMODE;
+        advanceFilterfieldCycle();
+
+        // Set filters as a starting point
+        filterField.filters = [autocompleteFilter];
+        fixtureCustom.detectChanges();
+      });
+
+      it('should have the correct filters set as a starting point', () => {
+        const tags = getFilterTags(fixtureCustom);
+        expect(tags[0].key).toBe('AUT.Upper Austria');
+        expect(tags[0].separator).toBe(':');
+        expect(tags[0].value).toBe('Linz');
+      });
+
+      it('should be able to edit and reach one level of depth', () => {
+        const tags = fixtureCustom.debugElement.queryAll(
+          By.css('.dt-filter-field-tag-label'),
+        );
+        tags[0].nativeElement.click();
+        advanceFilterfieldCycle();
+
+        // Open first level of AUT (first tag)
+        const options = getOptions(overlayContainerElement);
+        // Make sure that the autocomplete actually opened.
+        expect(options.length).toBe(2);
+
+        // Select Vienna
+        options[1].click();
+        advanceFilterfieldCycle();
+
+        // Read the filters again and make expectations
+        const filterTags = getFilterTags(fixtureCustom);
+
+        expect(filterTags[0].key).toBe('AUT');
+        expect(filterTags[0].separator).toBe(':');
+        expect(filterTags[0].value).toBe('Vienna');
+      });
+
+      it('should be able to edit and reach two levels of depth', () => {
+        const tags = fixtureCustom.debugElement.queryAll(
+          By.css('.dt-filter-field-tag-label'),
+        );
+        tags[0].nativeElement.click();
+        advanceFilterfieldCycle();
+
+        // Open first level of AUT (first tag)
+        const options = getOptions(overlayContainerElement);
+        // Make sure that the autocomplete actually opened.
+        expect(options.length).toBe(2);
+
+        // Select Upper Austria again
+        options[0].click();
+        advanceFilterfieldCycle();
+
+        // Open cities of Upper Austria
+        const cities = getOptions(overlayContainerElement);
+        // Make sure that the autocomplete actually opened.
+        expect(cities.length).toBe(3);
+
+        // Select Wels
+        cities[1].click();
+        advanceFilterfieldCycle();
+
+        // Read the filters again and make expectations
+        const filterTags = getFilterTags(fixtureCustom);
+
+        expect(filterTags[0].key).toBe('AUT.Upper Austria');
+        expect(filterTags[0].separator).toBe(':');
+        expect(filterTags[0].value).toBe('Wels');
+      });
     });
 
-    it('should disable the edit button on the tag when editable is set to false', () => {
-      const tagInst = filterField.getTagForFilter(autocompleteFilter);
-      tagInst!.editable = false;
-      fixture.detectChanges();
-      const tags = getFilterTags(fixture);
-      const { label, deleteButton } = getTagButtons(tags[0]);
-      expect(label.disabled).toBeTruthy();
-      expect(deleteButton.disabled).toBeFalsy();
-    });
-
-    it('should disable the delete button on the tag when deletable is set to false', () => {
-      const tagInst = filterField.getTagForFilter(autocompleteFilter);
-      tagInst!.deletable = false;
-      fixture.detectChanges();
-      const tags = getFilterTags(fixture);
-      const { label, deleteButton } = getTagButtons(tags[0]);
-      expect(label.disabled).toBeFalsy();
-      expect(deleteButton).toBeNull();
-    });
-
-    it('should disable the entire tag when disabled is set to true', () => {
-      const tagInst = filterField.getTagForFilter(autocompleteFilter);
-      tagInst!.disabled = true;
-      fixture.detectChanges();
-      const tags = getFilterTags(fixture);
-      const { label, deleteButton } = getTagButtons(tags[0]);
-      expect(label.disabled).toBeTruthy();
-      expect(deleteButton).toBeNull();
-    });
-
-    it('should keep the deletable/editable flags on the tags when a tag is edited', () => {
-      // Custom free text for Free -> Custom free text
-      const freeTextFilter = [
-        TEST_DATA_EDITMODE.autocomplete[2],
-        'Custom free text',
+    describe('tag parser function override by input', () => {
+      // Autocomplete filter for AUT -> Upper Austria -> Cities -> Linz
+      const autocompleteFilter = [
+        TEST_DATA_EDITMODE.autocomplete[0],
+        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
+        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
+          .autocomplete[0].options[0],
       ];
-      filterField.filters = [autocompleteFilter, freeTextFilter];
-      fixture.detectChanges();
 
-      const autoTagInst = filterField.getTagForFilter(autocompleteFilter);
-      autoTagInst!.editable = false;
-      const freeTextTagInst = filterField.getTagForFilter(freeTextFilter);
-      freeTextTagInst!.deletable = false;
-      fixture.detectChanges();
-      const tags = getFilterTags(fixture);
-      const {
-        label: autoLabel,
-        deleteButton: autoDeleteButton,
-      } = getTagButtons(tags[0]);
-      expect(autoLabel.disabled).toBeTruthy();
-      expect(autoDeleteButton.disabled).toBeFalsy();
+      let fixtureCustom: ComponentFixture<TestAppCustomParserInput>;
+      beforeEach(() => {
+        fixtureCustom = createComponent(TestAppCustomParserInput);
+        filterField = fixtureCustom.debugElement.query(
+          By.directive(DtFilterField),
+        ).componentInstance;
 
-      const {
-        label: freeTextLabel,
-        deleteButton: freeTextDeleteButton,
-      } = getTagButtons(tags[0]);
-      expect(freeTextLabel.disabled).toBeTruthy();
-      expect(freeTextDeleteButton.disabled).toBeFalsy();
+        fixtureCustom.componentInstance.dataSource.data = TEST_DATA_EDITMODE;
+        advanceFilterfieldCycle();
 
-      // enter editmode
-      freeTextLabel.click();
-      advanceFilterfieldCycle();
+        // Set filters as a starting point
+        filterField.filters = [autocompleteFilter];
+        fixtureCustom.detectChanges();
+      });
 
-      // cancel editmode
-      dispatchFakeEvent(document, 'click');
-      advanceFilterfieldCycle();
+      it('should have the correct filters set as a starting point', () => {
+        const tags = getFilterTags(fixtureCustom);
+        expect(tags[0].key).toBe('AUT.Upper Austria');
+        expect(tags[0].separator).toBe(':');
+        expect(tags[0].value).toBe('Linz');
+      });
 
-      expect(autoLabel.disabled).toBeTruthy();
-      expect(autoDeleteButton.disabled).toBeFalsy();
+      it('should be able to edit and reach one level of depth', () => {
+        const tags = fixtureCustom.debugElement.queryAll(
+          By.css('.dt-filter-field-tag-label'),
+        );
+        tags[0].nativeElement.click();
+        advanceFilterfieldCycle();
 
-      expect(freeTextLabel.disabled).toBeTruthy();
-      expect(freeTextDeleteButton.disabled).toBeFalsy();
-    });
+        // Open first level of AUT (first tag)
+        const options = getOptions(overlayContainerElement);
+        // Make sure that the autocomplete actually opened.
+        expect(options.length).toBe(2);
 
-    it('should keep the deletable/editable flags on the tags when a tag is deleted', () => {
-      // Custom free text for Free -> Custom free text
-      const freeTextFilter = [
-        TEST_DATA_EDITMODE.autocomplete[2],
-        'Custom free text',
-      ];
-      filterField.filters = [autocompleteFilter, freeTextFilter];
-      fixture.detectChanges();
+        // Select Vienna
+        options[1].click();
+        advanceFilterfieldCycle();
 
-      const autoTagInst = filterField.getTagForFilter(autocompleteFilter);
-      autoTagInst!.editable = false;
-      const freeTextTagInst = filterField.getTagForFilter(freeTextFilter);
-      freeTextTagInst!.deletable = false;
-      fixture.detectChanges();
-      const tags = getFilterTags(fixture);
-      const {
-        label: autoLabel,
-        deleteButton: autoDeleteButton,
-      } = getTagButtons(tags[0]);
-      expect(autoLabel.disabled).toBeTruthy();
-      expect(autoDeleteButton.disabled).toBeFalsy();
+        // Read the filters again and make expectations
+        const filterTags = getFilterTags(fixtureCustom);
 
-      const {
-        label: freeTextLabel,
-        deleteButton: freeTextDeleteButton,
-      } = getTagButtons(tags[0]);
-      expect(freeTextLabel.disabled).toBeTruthy();
-      expect(freeTextDeleteButton.disabled).toBeFalsy();
+        expect(filterTags[0].key).toBe('AUT');
+        expect(filterTags[0].separator).toBe(':');
+        expect(filterTags[0].value).toBe('Vienna');
+      });
 
-      // delete tag
-      autoDeleteButton.click();
-      advanceFilterfieldCycle();
+      it('should be able to edit and reach two levels of depth', () => {
+        const tags = fixtureCustom.debugElement.queryAll(
+          By.css('.dt-filter-field-tag-label'),
+        );
+        tags[0].nativeElement.click();
+        advanceFilterfieldCycle();
 
-      expect(freeTextLabel.disabled).toBeTruthy();
-      expect(freeTextDeleteButton.disabled).toBeFalsy();
-    });
+        // Open first level of AUT (first tag)
+        const options = getOptions(overlayContainerElement);
+        // Make sure that the autocomplete actually opened.
+        expect(options.length).toBe(2);
 
-    it('should not delete a non deletable tag when clicking the clear all', () => {
-      const tagInst = filterField.getTagForFilter(autocompleteFilter);
-      tagInst!.deletable = false;
-      fixture.detectChanges();
-      const clearAll = getClearAll(fixture);
-      clearAll!.click();
-      fixture.detectChanges();
+        // Select Upper Austria again
+        options[0].click();
+        advanceFilterfieldCycle();
 
-      const tags = getFilterTags(fixture);
-      expect(tags.length).toBe(1);
-    });
-  });
+        // Open cities of Upper Austria
+        const cities = getOptions(overlayContainerElement);
+        // Make sure that the autocomplete actually opened.
+        expect(cities.length).toBe(3);
 
-  describe('data-source switching', () => {
-    it('should cancel the edit mode if the data source is switched', () => {
-      filterField.focus();
-      advanceFilterfieldCycle();
+        // Select Wels
+        cities[1].click();
+        advanceFilterfieldCycle();
 
-      const options = getOptions(overlayContainerElement);
-      options[0].click();
-      advanceFilterfieldCycle();
+        // Read the filters again and make expectations
+        const filterTags = getFilterTags(fixtureCustom);
 
-      let category = fixture.debugElement.query(
-        By.css('.dt-filter-field-category'),
-      );
-
-      expect(category.nativeElement.textContent.trim()).toBe('AUT');
-      expect(filterField.filters.length).toBe(1);
-      expect(filterField.filters[0][0].name).toBe('AUT');
-
-      fixture.componentInstance.dataSource.data = TEST_DATA_EDITMODE;
-      advanceFilterfieldCycle();
-
-      category = fixture.debugElement.query(
-        By.css('.dt-filter-field-category'),
-      );
-
-      expect(category).toBeNull();
-      expect(filterField.filters.length).toBe(0);
-    });
-
-    it('should not remove the current filter if the data is changed when the filterChanges event fires', () => {
-      const filterChangesSubscription = filterField.filterChanges.subscribe(
-        () => {
-          fixture.componentInstance.dataSource.data = FILTER_FIELD_TEST_DATA_ASYNC;
-        },
-      );
-
-      filterField.focus();
-      advanceFilterfieldCycle();
-
-      let options = getOptions(overlayContainerElement);
-      options[0].click();
-      advanceFilterfieldCycle();
-
-      options = getOptions(overlayContainerElement);
-
-      zone.simulateZoneExit();
-
-      options[1].click();
-      advanceFilterfieldCycle();
-
-      expect(filterField.filters.length).toBe(1);
-
-      filterChangesSubscription.unsubscribe();
-    });
-  });
-
-  describe('tag parser function override by injection token configuration', () => {
-    // Autocomplete filter for AUT -> Upper Austria -> Cities -> Linz
-    const autocompleteFilter = [
-      TEST_DATA_EDITMODE.autocomplete[0],
-      (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
-      (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
-        .autocomplete[0].options[0],
-    ];
-
-    let fixtureCustom: ComponentFixture<TestAppCustomParserConfig>;
-    beforeEach(() => {
-      fixtureCustom = createComponent(TestAppCustomParserConfig);
-      filterField = fixtureCustom.debugElement.query(
-        By.directive(DtFilterField),
-      ).componentInstance;
-
-      fixtureCustom.componentInstance.dataSource.data = TEST_DATA_EDITMODE;
-      advanceFilterfieldCycle();
-
-      // Set filters as a starting point
-      filterField.filters = [autocompleteFilter];
-      fixtureCustom.detectChanges();
-    });
-
-    it('should have the correct filters set as a starting point', () => {
-      const tags = getFilterTags(fixtureCustom);
-      expect(tags[0].key).toBe('AUT.Upper Austria');
-      expect(tags[0].separator).toBe(':');
-      expect(tags[0].value).toBe('Linz');
-    });
-
-    it('should be able to edit and reach one level of depth', () => {
-      const tags = fixtureCustom.debugElement.queryAll(
-        By.css('.dt-filter-field-tag-label'),
-      );
-      tags[0].nativeElement.click();
-      advanceFilterfieldCycle();
-
-      // Open first level of AUT (first tag)
-      const options = getOptions(overlayContainerElement);
-      // Make sure that the autocomplete actually opened.
-      expect(options.length).toBe(2);
-
-      // Select Vienna
-      options[1].click();
-      advanceFilterfieldCycle();
-
-      // Read the filters again and make expectations
-      const filterTags = getFilterTags(fixtureCustom);
-
-      expect(filterTags[0].key).toBe('AUT');
-      expect(filterTags[0].separator).toBe(':');
-      expect(filterTags[0].value).toBe('Vienna');
-    });
-
-    it('should be able to edit and reach two levels of depth', () => {
-      const tags = fixtureCustom.debugElement.queryAll(
-        By.css('.dt-filter-field-tag-label'),
-      );
-      tags[0].nativeElement.click();
-      advanceFilterfieldCycle();
-
-      // Open first level of AUT (first tag)
-      const options = getOptions(overlayContainerElement);
-      // Make sure that the autocomplete actually opened.
-      expect(options.length).toBe(2);
-
-      // Select Upper Austria again
-      options[0].click();
-      advanceFilterfieldCycle();
-
-      // Open cities of Upper Austria
-      const cities = getOptions(overlayContainerElement);
-      // Make sure that the autocomplete actually opened.
-      expect(cities.length).toBe(3);
-
-      // Select Wels
-      cities[1].click();
-      advanceFilterfieldCycle();
-
-      // Read the filters again and make expectations
-      const filterTags = getFilterTags(fixtureCustom);
-
-      expect(filterTags[0].key).toBe('AUT.Upper Austria');
-      expect(filterTags[0].separator).toBe(':');
-      expect(filterTags[0].value).toBe('Wels');
-    });
-  });
-
-  describe('tag parser function override by input', () => {
-    // Autocomplete filter for AUT -> Upper Austria -> Cities -> Linz
-    const autocompleteFilter = [
-      TEST_DATA_EDITMODE.autocomplete[0],
-      (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
-      (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
-        .autocomplete[0].options[0],
-    ];
-
-    let fixtureCustom: ComponentFixture<TestAppCustomParserInput>;
-    beforeEach(() => {
-      fixtureCustom = createComponent(TestAppCustomParserInput);
-      filterField = fixtureCustom.debugElement.query(
-        By.directive(DtFilterField),
-      ).componentInstance;
-
-      fixtureCustom.componentInstance.dataSource.data = TEST_DATA_EDITMODE;
-      advanceFilterfieldCycle();
-
-      // Set filters as a starting point
-      filterField.filters = [autocompleteFilter];
-      fixtureCustom.detectChanges();
-    });
-
-    it('should have the correct filters set as a starting point', () => {
-      const tags = getFilterTags(fixtureCustom);
-      expect(tags[0].key).toBe('AUT.Upper Austria');
-      expect(tags[0].separator).toBe(':');
-      expect(tags[0].value).toBe('Linz');
-    });
-
-    it('should be able to edit and reach one level of depth', () => {
-      const tags = fixtureCustom.debugElement.queryAll(
-        By.css('.dt-filter-field-tag-label'),
-      );
-      tags[0].nativeElement.click();
-      advanceFilterfieldCycle();
-
-      // Open first level of AUT (first tag)
-      const options = getOptions(overlayContainerElement);
-      // Make sure that the autocomplete actually opened.
-      expect(options.length).toBe(2);
-
-      // Select Vienna
-      options[1].click();
-      advanceFilterfieldCycle();
-
-      // Read the filters again and make expectations
-      const filterTags = getFilterTags(fixtureCustom);
-
-      expect(filterTags[0].key).toBe('AUT');
-      expect(filterTags[0].separator).toBe(':');
-      expect(filterTags[0].value).toBe('Vienna');
-    });
-
-    it('should be able to edit and reach two levels of depth', () => {
-      const tags = fixtureCustom.debugElement.queryAll(
-        By.css('.dt-filter-field-tag-label'),
-      );
-      tags[0].nativeElement.click();
-      advanceFilterfieldCycle();
-
-      // Open first level of AUT (first tag)
-      const options = getOptions(overlayContainerElement);
-      // Make sure that the autocomplete actually opened.
-      expect(options.length).toBe(2);
-
-      // Select Upper Austria again
-      options[0].click();
-      advanceFilterfieldCycle();
-
-      // Open cities of Upper Austria
-      const cities = getOptions(overlayContainerElement);
-      // Make sure that the autocomplete actually opened.
-      expect(cities.length).toBe(3);
-
-      // Select Wels
-      cities[1].click();
-      advanceFilterfieldCycle();
-
-      // Read the filters again and make expectations
-      const filterTags = getFilterTags(fixtureCustom);
-
-      expect(filterTags[0].key).toBe('AUT.Upper Austria');
-      expect(filterTags[0].separator).toBe(':');
-      expect(filterTags[0].value).toBe('Wels');
+        expect(filterTags[0].key).toBe('AUT.Upper Austria');
+        expect(filterTags[0].separator).toBe(':');
+        expect(filterTags[0].value).toBe('Wels');
+      });
     });
   });
 });

--- a/libs/examples/src/filter-field/BUILD.bazel
+++ b/libs/examples/src/filter-field/BUILD.bazel
@@ -30,6 +30,7 @@ ng_module(
     deps = [
         "//libs/barista-components/filter-field:compile",
         "//libs/barista-components/input:compile",
+        "@npm//rxjs",
         "@npm//@angular/core",
         "@npm//@angular/forms",
     ],

--- a/libs/examples/src/filter-field/filter-field-unique-example/filter-field-unique-example.ts
+++ b/libs/examples/src/filter-field/filter-field-unique-example/filter-field-unique-example.ts
@@ -14,18 +14,20 @@
  * limitations under the License.
  */
 
-import { Component } from '@angular/core';
-
+import { AfterViewInit, Component, OnDestroy, ViewChild } from '@angular/core';
 import {
+  DtFilterField,
   DtFilterFieldDefaultDataSource,
   DtFilterFieldDefaultDataSourceType,
 } from '@dynatrace/barista-components/filter-field';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'dt-example-filter-field-unique',
   templateUrl: 'filter-field-unique-example.html',
 })
-export class DtExampleFilterFieldUnique {
+export class DtExampleFilterFieldUnique implements AfterViewInit, OnDestroy {
   private DATA: DtFilterFieldDefaultDataSourceType = {
     autocomplete: [
       {
@@ -56,4 +58,25 @@ export class DtExampleFilterFieldUnique {
   };
 
   _dataSource = new DtFilterFieldDefaultDataSource(this.DATA);
+
+  @ViewChild(DtFilterField) filterField: DtFilterField;
+
+  private readonly _destroy$ = new Subject<void>();
+
+  ngAfterViewInit(): void {
+    this.filterField.interactionStateChange
+      .pipe(takeUntil(this._destroy$))
+      .subscribe((state) => {
+        console.log('interaction state: ', state);
+        console.log(
+          'interaction state member: ',
+          this.filterField.interactionState,
+        );
+      });
+  }
+
+  ngOnDestroy(): void {
+    this._destroy$.next();
+    this._destroy$.complete();
+  }
 }


### PR DESCRIPTION
### <strong>Pull Request</strong>

The interaction state represents whether the user currently is interacting with the filter-field or not.
_Adds a Member `interactionState` and an Output `interactionStateChange`_

- Feel free to give feedback on the naming!

#### Type of PR

Feature (non-breaking change which adds functionality)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
