### PR TITLE
feat(autocomplete): Added paged keyboard scrolling for autocomplete.

### DIFF
--- a/libs/barista-components/autocomplete/src/autocomplete-trigger.ts
+++ b/libs/barista-components/autocomplete/src/autocomplete-trigger.ts
@@ -21,6 +21,8 @@ import {
   ESCAPE,
   TAB,
   UP_ARROW,
+  PAGE_UP,
+  PAGE_DOWN,
 } from '@angular/cdk/keycodes';
 import {
   Overlay,
@@ -476,7 +478,11 @@ export class DtAutocompleteTrigger<T>
       const prevActiveItem = this.autocomplete._keyManager.activeItem;
       const isArrowKey = keyCode === UP_ARROW || keyCode === DOWN_ARROW;
 
-      if (this.panelOpen || keyCode === TAB) {
+      if (this.panelOpen && keyCode === PAGE_UP) {
+        this.autocomplete._scrollPageUp();
+      } else if (this.panelOpen && keyCode === PAGE_DOWN) {
+        this.autocomplete._scrollPageDown();
+      } else if (this.panelOpen || keyCode === TAB) {
         this.autocomplete._keyManager.onKeydown(event);
       } else if (isArrowKey && this._canOpen()) {
         this.openPanel();

--- a/libs/barista-components/autocomplete/src/autocomplete.ts
+++ b/libs/barista-components/autocomplete/src/autocomplete.ts
@@ -301,6 +301,30 @@ export class DtAutocomplete<T>
 
   /**
    * @internal
+   * Scrolls the autocomplete up a page.
+   * Default page scroll is 300px
+   */
+  _scrollPageUp(): void {
+    const panelHeight = this._panel.nativeElement.getBoundingClientRect()
+      .height;
+    const newScrollPosition = Math.max(this._getScrollTop() - panelHeight, 0);
+    this._setScrollTop(newScrollPosition);
+  }
+
+  /**
+   * @internal
+   * Scrolls the autocomplete down a page.
+   * Default page scroll is 300px
+   */
+  _scrollPageDown(): void {
+    const panelHeight = this._panel.nativeElement.getBoundingClientRect()
+      .height;
+    const newScrollPosition = this._getScrollTop() + panelHeight;
+    this._setScrollTop(newScrollPosition);
+  }
+
+  /**
+   * @internal
    * Emits the `select` event.
    */
   _emitSelectEvent(option: DtOption<T>): void {


### PR DESCRIPTION
### <strong>Pull Request</strong>

Fixes APM-275314

Adds paged scrolling behavior to the autocomplete listbox. This is not in the listbox aria keyboard specs, but nevertheless could be quite helpful to navigate long ists. 

PageUp / PageDown only change the scroll position of the listbox and not the actually highlighted selection (actual selection is handled in the keymanager). 


#### Type of PR
Feature

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
