### PR TITLE
fix(sunburst-chart): Fix tooltip flicker on click

### DIFF
--- a/apps/dev/src/sunburst-chart/sunburst-chart-demo.component.scss
+++ b/apps/dev/src/sunburst-chart/sunburst-chart-demo.component.scss
@@ -1,3 +1,7 @@
 :host {
   display: block;
 }
+
+dt-sunburst-chart {
+  max-width: 800px;
+}

--- a/apps/dev/src/sunburst-chart/sunburst-chart-demo.component.ts
+++ b/apps/dev/src/sunburst-chart/sunburst-chart-demo.component.ts
@@ -45,7 +45,7 @@ export class SunburstChartDemo {
   }
 
   openOverlay(): void {
-    this.chart.openOverlay(this.chart._slices[0]);
+    this.chart.openOverlay(this.chart._slices[3]);
   }
   closeOverlay(): void {
     this.chart.closeOverlay();

--- a/libs/barista-components/sunburst-chart/src/sunburst-chart.html
+++ b/libs/barista-components/sunburst-chart/src/sunburst-chart.html
@@ -9,9 +9,7 @@
   <g
     *ngFor="let slice of _slices"
     dt-sunburst-chart-segment
-    (mouseenter)="_handleOnMouseEnter($event, slice.data)"
-    (mousemove)="_handleOnMouseMove($event)"
-    (mouseleave)="closeOverlay()"
+    [overlayTemplate]="_overlay"
     [slice]="slice"
     [valueAsAbsolute]="_valueAsAbsolute"
     [attr.style]="

--- a/libs/barista-components/sunburst-chart/src/sunburst-chart.spec.ts
+++ b/libs/barista-components/sunburst-chart/src/sunburst-chart.spec.ts
@@ -389,36 +389,25 @@ describe('DtSunburstChart', () => {
       expect(overlayContainer).toBeDefined();
     });
 
-    it('should display an overlay when hovering over a slice', () => {
-      const firstSlice = fixture.debugElement.query(By.css(selectors.segment));
-
-      dispatchFakeEvent(firstSlice.nativeElement, 'mouseenter');
+    it('should display and hide an overlay when calledff', () => {
+      component.openOverlay(component.slices[0]);
       fixture.detectChanges();
 
-      const overlayPane = overlayContainerElement.querySelector(
+      let overlayPane = overlayContainerElement.querySelector(
         selectors.overlay,
       );
       expect(overlayPane).toBeDefined();
 
       const overlayContent = (overlayPane!.textContent ?? '').trim();
       expect(overlayContent).toBe('Purple');
-    });
 
-    it('should remove the overlay when moving the mouse away from the slice', () => {
-      const firstSlice = fixture.debugElement.query(By.css(selectors.slice));
-      let overlayPane = overlayContainerElement.querySelector(
-        selectors.overlay,
-      );
-
-      dispatchFakeEvent(firstSlice.nativeElement, 'mouseenter');
+      component.closeOverlay();
       fixture.detectChanges();
-      overlayPane = overlayContainerElement.querySelector(selectors.overlay);
 
-      dispatchFakeEvent(firstSlice.nativeElement, 'mouseleave');
-      fixture.detectChanges();
-      overlayPane = overlayContainerElement.querySelector(selectors.overlay);
-
-      expect(overlayPane).toBeNull();
+      // we cannot check if it disappeared because of the animation, so let's check for an alternative
+      expect(
+        overlayPane?.attributes.getNamedItem('attr.aria-hidden'),
+      ).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
#### Bugfix (non-breaking change which fixes an issue)

Currently tooltip gets repositioned on segment click and before any other mouse move.
Now the overlay has been moved to the segment without manual handling.
Also, to preserve the possibility of opening the overlay from the outside I've kept the functionality in the main component

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
