### PR TITLE
feat(stacked-series-chart): Add compact mode.

### DIFF
--- a/apps/components-e2e/src/components/stacked-series-chart/stacked-series-chart.e2e.ts
+++ b/apps/components-e2e/src/components/stacked-series-chart/stacked-series-chart.e2e.ts
@@ -17,9 +17,12 @@
 import { resetWindowSizeToDefault, waitForAngular } from '../../utils';
 import { absoluteBtn, percentBtn } from '../sunburst-chart/sunburst-chart.po';
 import {
+  autoLabelAxisModeBtn,
   barBtn,
   barChart,
   body,
+  chartWidth400Btn,
+  chartContainer,
   columnBtn,
   columnChart,
   fullTrackBtn,
@@ -63,6 +66,8 @@ const hover: MouseActionOptions = {
 
 const selectedSliceClassname = 'dt-stacked-series-chart-slice-selected';
 
+const compactModeClassname = 'dt-stacked-series-chart-series-axis-compact-mode';
+
 fixture('Stacked series chart')
   .page('http://localhost:4200/stacked-series-chart')
   .beforeEach(async () => {
@@ -76,11 +81,11 @@ test('should have the defaults', async (testController) => {
     .expect(barChart)
     .ok()
     .expect(tracks.count)
-    .eql(4)
+    .eql(5)
     .expect(labels.count)
-    .eql(4)
+    .eql(5)
     .expect(slices.count)
-    .eql(8)
+    .eql(10)
     .expect(legend)
     .ok()
     .expect(valueAxis)
@@ -90,7 +95,7 @@ test('should have the defaults', async (testController) => {
     .expect(getLabel(0).textContent)
     .match(/Espresso/)
     .expect(getSlice(0, 0).clientWidth)
-    .within(135, 150)
+    .within(125, 140)
     .expect(getSlice(0, 0).clientHeight)
     .eql(16)
     .expect(getSlice(0, 0).getStyleProperty('background-color'))
@@ -107,11 +112,11 @@ test('should change the mode and fillMode', async (testController) => {
     .expect(columnChart)
     .ok()
     .expect(tracks.count)
-    .eql(4)
+    .eql(5)
     .expect(labels.count)
-    .eql(4)
+    .eql(5)
     .expect(slices.count)
-    .eql(8)
+    .eql(10)
     .expect(ticks.count)
     .eql(6)
     .expect(getLabel(0).textContent)
@@ -119,16 +124,16 @@ test('should change the mode and fillMode', async (testController) => {
     .expect(getSlice(0, 0).clientWidth)
     .eql(16)
     .expect(getSlice(0, 0).clientHeight)
-    .within(60, 70)
+    .within(57, 67)
     .expect(legendItems.count)
     .eql(4)
     // fillMode
     .click(fullTrackBtn)
     .expect(getSlice(0, 0).clientHeight)
-    .within(315, 325)
+    .within(290, 300)
     .click(barBtn)
     .expect(getSlice(0, 0).clientWidth)
-    .within(705, 720);
+    .within(635, 650);
 });
 
 test('should change to single and multitrack with corresponding value display modes', async (testController) => {
@@ -227,10 +232,10 @@ test('should accept a max and toggle track background', async (testController) =
     // max
     .click(max10Btn)
     .expect(getSlice(0, 0).clientWidth)
-    .within(68, 75)
+    .within(60, 71)
     .click(noMaxBtn)
     .expect(getSlice(0, 0).clientWidth)
-    .within(135, 150)
+    .within(125, 140)
 
     // track background
     .expect(getTrack(0).getStyleProperty('background-color'))
@@ -251,4 +256,18 @@ test('should show overlay on hover', async (testController: TestController) => {
     .hover(body, { ...hover, offsetX: 10, offsetY: 10 })
     .expect(overlay.exists)
     .notOk();
+});
+
+test('should switch from full to compact on labelAxisMode auto', async (testController: TestController) => {
+  await testController
+    .click(resetBtn)
+    .click(columnBtn)
+    .expect(chartContainer.classNames)
+    .notContains(compactModeClassname)
+    .click(autoLabelAxisModeBtn)
+    .click(chartWidth400Btn)
+    .resizeWindowToFitDevice('ipad')
+    .wait(250) // Wait for the DtViewportResizer event to trigger
+    .expect(chartContainer.classNames)
+    .contains(compactModeClassname);
 });

--- a/apps/components-e2e/src/components/stacked-series-chart/stacked-series-chart.html
+++ b/apps/components-e2e/src/components/stacked-series-chart/stacked-series-chart.html
@@ -1,5 +1,6 @@
 <dt-stacked-series-chart
-  style="min-height: 400px; width: 800px"
+  style="min-height: 400px"
+  [style.width]="elementWidth"
   id="test-stacked-series-chart"
   [selected]="selected"
   [selectionMode]="selectionMode"
@@ -12,6 +13,7 @@
   [visibleValueAxis]="visibleValueAxis"
   [visibleLegend]="visibleLegend"
   [visibleLabel]="visibleLabel"
+  [labelAxisMode]="labelAxisMode"
   [visibleTrackBackground]="visibleTrackBackground"
   [maxTrackSize]="maxTrackSize"
   [max]="max"
@@ -91,6 +93,21 @@
 </div>
 
 <div>
+  <button (click)="labelAxisMode = 'full'" id="chart-full-label-axis-mode">
+    Full
+  </button>
+  <button
+    (click)="labelAxisMode = 'compact'"
+    id="chart-compact-label-axis-mode"
+  >
+    Compact
+  </button>
+  <button (click)="labelAxisMode = 'auto'" id="chart-auto-label-axis-mode">
+    Auto
+  </button>
+</div>
+
+<div>
   <button
     (click)="visibleTrackBackground = true"
     id="chart-visible-track-background"
@@ -143,4 +160,9 @@
     Select
   </button>
   <button (click)="selected = []" id="chart-unselect">Unselect</button>
+</div>
+
+<div>
+  <button (click)="setElementWidth('800px')" id="chart-width-800">800px</button>
+  <button (click)="setElementWidth('400px')" id="chart-width-400">400px</button>
 </div>

--- a/apps/components-e2e/src/components/stacked-series-chart/stacked-series-chart.po.ts
+++ b/apps/components-e2e/src/components/stacked-series-chart/stacked-series-chart.po.ts
@@ -18,6 +18,7 @@ import { Selector } from 'testcafe';
 
 export const body = Selector('body');
 export const chart = Selector('test-stacked-series-chart');
+export const chartContainer = Selector('.dt-stacked-series-chart-container');
 export const overlay = Selector('.dt-overlay-container');
 export const columnChart = Selector('.dt-stacked-series-chart-column');
 export const barChart = Selector('.dt-stacked-series-chart-bar');
@@ -69,6 +70,12 @@ export const nonVisibleLegendBtn = Selector('#chart-non-visible-legend');
 export const visibleLabelBtn = Selector('#chart-visible-label');
 export const nonVisibleLabelBtn = Selector('#chart-non-visible-label');
 
+export const fullLabelAxisModeBtn = Selector('#chart-full-label-axis-mode');
+export const compactLabelAxisModeBtn = Selector(
+  '#chart-compact-label-axis-mode',
+);
+export const autoLabelAxisModeBtn = Selector('#chart-auto-label-axis-mode');
+
 export const visibleTrackBkgBtn = Selector('#chart-visible-track-background');
 export const nonVisibleTrackBkgBtn = Selector(
   '#chart-non-visible-track-background',
@@ -88,3 +95,6 @@ export const nonSelectableBtn = Selector('#chart-non-selectable');
 
 export const selectBtn = Selector('#chart-select');
 export const unselectBtn = Selector('#chart-unselect');
+
+export const chartWidth800Btn = Selector('#chart-width-800');
+export const chartWidth400Btn = Selector('#chart-width-400');

--- a/apps/components-e2e/src/components/stacked-series-chart/stacked-series-chart.ts
+++ b/apps/components-e2e/src/components/stacked-series-chart/stacked-series-chart.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component } from '@angular/core';
+import { Component, ChangeDetectorRef } from '@angular/core';
 import {
   DtStackedSeriesChartNode,
   DtStackedSeriesChartSeries,
@@ -23,6 +23,7 @@ import {
   DtStackedSeriesChartLegend,
   DtStackedSeriesChartMode,
   DtStackedSeriesChartSelectionMode,
+  DtStackedSeriesChartLabelAxisMode,
 } from '@dynatrace/barista-components/stacked-series-chart';
 import { DtColors } from '@dynatrace/barista-components/theming';
 
@@ -40,6 +41,7 @@ export class DtE2EStackedSeriesChart {
   visibleValueAxis: boolean = true;
   visibleLegend: boolean = true;
   visibleLabel: boolean = true;
+  labelAxisMode: DtStackedSeriesChartLabelAxisMode = 'full';
   visibleTrackBackground: boolean = true;
   maxTrackSize: number = 16;
   max: number | undefined;
@@ -99,6 +101,19 @@ export class DtE2EStackedSeriesChart {
         },
       ],
     },
+    {
+      label: 'Caffé latté (Extra latté)',
+      nodes: [
+        {
+          value: 2,
+          label: 'Coffee',
+        },
+        {
+          value: 3,
+          label: 'Milk',
+        },
+      ],
+    },
   ];
 
   legends: DtStackedSeriesChartLegend[] = [
@@ -110,7 +125,9 @@ export class DtE2EStackedSeriesChart {
 
   usedSeries: DtStackedSeriesChartSeries[] = this.series;
 
-  constructor() {
+  elementWidth = '800px';
+
+  constructor(private changeDetector: ChangeDetectorRef) {
     this.reset();
   }
 
@@ -124,11 +141,18 @@ export class DtE2EStackedSeriesChart {
     this.visibleValueAxis = true;
     this.visibleLegend = true;
     this.visibleLabel = true;
+    this.labelAxisMode = 'full';
     this.visibleTrackBackground = true;
     this.maxTrackSize = 16;
     this.max = undefined;
     this.usedLegends = undefined;
     // force recalculation of legends
     this.usedSeries = this.series.slice();
+    this.elementWidth = '800px';
+  }
+
+  setElementWidth(width: string): void {
+    this.elementWidth = width;
+    this.changeDetector.detectChanges();
   }
 }

--- a/apps/dev/src/stacked-series-chart/stacked-series-chart-demo-data.ts
+++ b/apps/dev/src/stacked-series-chart/stacked-series-chart-demo-data.ts
@@ -67,4 +67,51 @@ export const stackedSeriesChartDemoData = [
       },
     ],
   },
+  {
+    label: 'Caffé latte (Extra latte)',
+    nodes: [
+      {
+        value: 2,
+        label: 'Coffee',
+      },
+      {
+        value: 3,
+        label: 'Milk',
+      },
+    ],
+  },
+  {
+    label: 'Cappuccino',
+    nodes: [
+      {
+        value: 2,
+        label: 'Milk',
+      },
+      {
+        value: 2,
+        label: 'Coffee',
+      },
+    ],
+  },
+  {
+    label: 'Caramel Frappucino',
+    nodes: [
+      {
+        value: 1,
+        label: 'Milk',
+      },
+      {
+        value: 1,
+        label: 'Coffee',
+      },
+      {
+        value: 1,
+        label: 'Caramel',
+      },
+      {
+        value: 1,
+        label: 'Ice',
+      },
+    ],
+  },
 ];

--- a/apps/dev/src/stacked-series-chart/stacked-series-chart-demo.component.html
+++ b/apps/dev/src/stacked-series-chart/stacked-series-chart-demo.component.html
@@ -7,6 +7,7 @@
   [visibleLabel]="visibleLabel"
   [visibleLegend]="visibleLegend"
   [visibleValueAxis]="visibleValueAxis"
+  [labelAxisMode]="labelAxisMode"
   [fillMode]="fillMode"
   [mode]="mode"
   [maxTrackSize]="maxTrackSize"
@@ -54,6 +55,13 @@
 
     <h3>Label</h3>
     <dt-switch [(ngModel)]="visibleLabel">Visible</dt-switch>
+
+    <h3>Label Axis Mode</h3>
+    <dt-button-group [disabled]="mode === 'bar'" [(value)]="labelAxisMode">
+      <dt-button-group-item value="full">Full</dt-button-group-item>
+      <dt-button-group-item value="compact">Compact</dt-button-group-item>
+      <dt-button-group-item value="auto">Auto</dt-button-group-item>
+    </dt-button-group>
 
     <h3>Track</h3>
     <h4>Background</h4>

--- a/apps/dev/src/stacked-series-chart/stacked-series-chart-demo.component.ts
+++ b/apps/dev/src/stacked-series-chart/stacked-series-chart-demo.component.ts
@@ -42,10 +42,11 @@ export class StackedSeriesChartDemo {
   visibleLegend: boolean = true;
   fillMode: DtStackedSeriesChartFillMode = 'relative';
   multiSeries = true;
-  mode: DtStackedSeriesChartMode = 'bar';
+  mode: DtStackedSeriesChartMode = 'column';
   maxTrackSize: number = 16;
   visibleTrackBackground: boolean = true;
   visibleValueAxis: boolean = true;
+  labelAxisMode = 'auto';
 
   series = stackedSeriesChartDemoData;
 

--- a/libs/barista-components/stacked-series-chart/README.md
+++ b/libs/barista-components/stacked-series-chart/README.md
@@ -46,7 +46,7 @@ follow the same order given by the developer
 | `series`                 | `DtStackedSeriesChartSeries[]`                            | -          | Array of series with their nodes.                                                                                                                                                                                     |
 | `selectable`             | `boolean`                                                 | false      | Allow selections to be made on chart                                                                                                                                                                                  |
 | `selected`               | `[DtStackedSeriesChartSeries, DtStackedSeriesChartNode?]` | -          | Current selection [series, node] node will be null if `selectionMode` is `stack`                                                                                                                                      |
-| `selectionMode`          | `DtStackedSeriesChartSelectionMode`                       | 'node'     | Whether to make just the nodes selectable or the whole stack                                                                                                                                                          |
+| `selectionMode`          | `DtStackedSeriesChartSelectionMode`                       | 'node'     | Whether to make just the nodes selectable or the whole stack.                                                                                                                                                         |
 | `max`                    | `number                                                   | undefined` | Max value in the chart. Useful when binding multiple stacked-series-chart.                                                                                                                                            |
 | `fillMode`               | `DtStackedSeriesChartFillMode`                            | -          | Whether each bar should be filled completely or should take into account their siblings and max.                                                                                                                      |
 | `valueDisplayMode`       | `DtStackedSeriesChartValueDisplayMode`                    | `'none'`   | Sets the display mode for the stacked-series-chart values in legend to either 'none' 'percent' or 'absolute'. In single track chart value is displayed also in legend. For axis value 'none' falls back to 'absolute' |
@@ -55,6 +55,7 @@ follow the same order given by the developer
 | `visibleTrackBackground` | `boolean`                                                 | true       | Whether background should be transparent or show a background.                                                                                                                                                        |
 | `visibleLabel`           | `boolean`                                                 | true       | Visibility of series label.                                                                                                                                                                                           |
 | `visibleValueAxis`       | `boolean`                                                 | true       | Visibility of value axis.                                                                                                                                                                                             |
+| `labelAxisMode`          | `DtStackedSeriesChartLabelAxisMode`                       | `full`     | Mode of the label axis, compact would make space for more labels.                                                                                                                                                     |
 | `maxTrackSize`           | `number`                                                  | 16         | Maximum size of the track.                                                                                                                                                                                            |
 
 #### Outputs
@@ -105,6 +106,17 @@ a percentage of the total or not show it.
 | `none`     | Do not display the value in legend                    |
 | `absolute` | Display the value present in DtStackedSeriesChartNode |
 | `percent`  | Display the percentage of the node within that series |
+
+### DtStackedSeriesChartLabelAxisMode
+
+For the `column` mode, it might be interesting to show the labels rotated in
+order that more labels fit in the chart and there is less overlap between them.
+
+| Value     | Description                                                                   |
+| --------- | ----------------------------------------------------------------------------- |
+| `full`    | Labels parallel to the axis                                                   |
+| `compact` | Labels rotated 45º to make space for more                                     |
+| `auto`    | Full mode which turns into compact if a label can fit it's proportional width |
 
 ### DtStackedSeriesChartSeries
 

--- a/libs/barista-components/stacked-series-chart/index.ts
+++ b/libs/barista-components/stacked-series-chart/index.ts
@@ -26,4 +26,5 @@ export {
   DtStackedSeriesChartTooltipData,
   DtStackedSeriesChartSelectionMode,
   DtStackedSeriesChartValueDisplayMode,
+  DtStackedSeriesChartLabelAxisMode,
 } from './src/stacked-series-chart.util';

--- a/libs/barista-components/stacked-series-chart/src/_stacked-series-chart-shared.scss
+++ b/libs/barista-components/stacked-series-chart/src/_stacked-series-chart-shared.scss
@@ -1,6 +1,6 @@
 @import '../../core/src/style/variables';
 
-$gap: 16px;
+$gap: calc(var(--dt-stacked-series-chart-grid-gap) * 1px);
 $bullet-height: 12px;
 $track-color: $gray-200;
 $selected-size: 4px;

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart-column.scss
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart-column.scss
@@ -94,3 +94,33 @@ See stacked-series-chart.layout.md
   .dt-stacked-series-chart-container {
   padding-left: var(--dt-stacked-series-chart-value-axis-size);
 }
+
+.dt-stacked-series-chart-series-axis-compact-mode {
+  .dt-stacked-series-chart-track-label {
+    width: 14px;
+    height: 70px;
+    position: relative;
+
+    &::after {
+      position: absolute;
+      display: block;
+      background: $axis-color;
+      width: 1px;
+      height: 8px;
+      top: -16px;
+      right: 50%;
+      content: ' ';
+    }
+
+    .dt-stacked-series-chart-track-label-content {
+      width: 100px;
+      position: absolute;
+      display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      transform: translate(-80%, 100%) rotate(-45deg);
+      white-space: nowrap;
+      text-align: right;
+    }
+  }
+}

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.html
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.html
@@ -1,6 +1,13 @@
 <div
+  #chartContainer
   class="dt-stacked-series-chart-container"
   [class.dt-stacked-series-chart-label-none]="!visibleLabel"
+  [class.dt-stacked-series-chart-series-axis-compact-mode]="
+    _labelAxisCompactModeEnabled
+  "
+  [class.dt-stacked-series-chart-series-axis-auto-mode]="
+    labelAxisMode === 'auto'
+  "
   [style]="
     _sanitizeCSS([
       ['--dt-stacked-series-chart-track-amount', _tracks.length],
@@ -27,7 +34,14 @@
       class="dt-stacked-series-chart-track-label"
       [style]="_sanitizeCSS([['--dt-stacked-series-chart-track-index', i + 1]])"
     >
-      {{ track.origin.label }}
+      <span
+        #label
+        class="dt-stacked-series-chart-track-label-content"
+        [dtOverlay]="_labelAxisCompactModeEnabled && labelOverlay"
+        [dtOverlayConfig]="{ data: track.origin.label }"
+      >
+        {{ track.origin.label }}
+      </span>
     </span>
 
     <div
@@ -74,12 +88,13 @@
           ['--dt-stacked-series-chart-tick-position', tick.pos + '%']
         ])
       "
-      >{{
+    >
+      {{
         valueDisplayMode === 'percent'
           ? (tick.valueRelative * 100 | dtPercent)
           : (tick.value | dtCount)
-      }}</span
-    >
+      }}
+    </span>
   </div>
 </div>
 
@@ -101,3 +116,7 @@
     {{ legend.label }}
   </dt-legend-item>
 </dt-legend>
+
+<ng-template #labelOverlay let-label>
+  {{ label }}
+</ng-template>

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.scss
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.scss
@@ -81,6 +81,21 @@ See stacked-series-chart.layout.md
   }
 }
 
+.dt-stacked-series-chart-track-label {
+  text-align: center;
+}
+
+.dt-stacked-series-chart-track-label-content {
+  outline: none;
+}
+
+.dt-stacked-series-chart-series-axis-auto-mode {
+  .dt-stacked-series-chart-track-label-content {
+    display: block;
+    white-space: nowrap;
+  }
+}
+
 /** Legend */
 .dt-stacked-series-chart-legend {
   display: flex;

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.spec.ts
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.spec.ts
@@ -42,6 +42,7 @@ import {
   DtStackedSeriesChartSeries,
   DtStackedSeriesChartValueDisplayMode,
   DtStackedSeriesChartSelectionMode,
+  DtStackedSeriesChartLabelAxisMode,
 } from './stacked-series-chart.util';
 
 describe('DtStackedSeriesChart', () => {
@@ -58,6 +59,13 @@ describe('DtStackedSeriesChart', () => {
   };
 
   let selectedChangeSpy;
+
+  /** Gets the root element of the chart. */
+  function getChartContainer(): DebugElement {
+    return fixture.debugElement.query(
+      By.css('.dt-stacked-series-chart-container'),
+    );
+  }
 
   /** Gets all tracks within the rendered chart. */
   function getAllTracks(): DebugElement[] {
@@ -562,6 +570,16 @@ describe('DtStackedSeriesChart', () => {
         const axis = getSeriesAxis();
         expect(axis).toBeFalsy();
       });
+
+      it('should not compact the labels on bar compact mode', () => {
+        rootComponent.labelAxisMode = 'compact';
+        fixture.detectChanges();
+
+        const chartContainer = getChartContainer();
+        expect(
+          chartContainer.nativeElement.getAttribute('class'),
+        ).not.toContain('dt-stacked-series-chart-series-axis-compact-mode');
+      });
     });
 
     describe('Column', () => {
@@ -597,6 +615,16 @@ describe('DtStackedSeriesChart', () => {
       it('should display the series axis', () => {
         const axis = getSeriesAxis();
         expect(axis).toBeTruthy();
+      });
+
+      it('should compact the labels on column compact mode', () => {
+        rootComponent.labelAxisMode = 'compact';
+        fixture.detectChanges();
+
+        const chartContainer = getChartContainer();
+        expect(chartContainer.nativeElement.getAttribute('class')).toContain(
+          'dt-stacked-series-chart-series-axis-compact-mode',
+        );
       });
     });
   });
@@ -643,6 +671,7 @@ describe('DtStackedSeriesChart', () => {
       [visibleLegend]="visibleLegend"
       [visibleTrackBackground]="visibleTrackBackground"
       [visibleLabel]="visibleLabel"
+      [labelAxisMode]="labelAxisMode"
       [visibleValueAxis]="visibleValueAxis"
       [mode]="mode"
       [maxTrackSize]="maxTrackSize"
@@ -667,6 +696,7 @@ class TestApp {
   visibleLegend: boolean = true;
   visibleTrackBackground: boolean = true;
   visibleLabel: boolean = true;
+  labelAxisMode: DtStackedSeriesChartLabelAxisMode = 'full';
   visibleValueAxis: boolean = true;
   mode: DtStackedSeriesChartMode;
   maxTrackSize: number;

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.ts
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.ts
@@ -19,15 +19,18 @@ import {
   ChangeDetectorRef,
   Component,
   ContentChild,
+  ElementRef,
   EventEmitter,
   Input,
   NgZone,
   OnDestroy,
   Optional,
   Output,
+  QueryList,
   SkipSelf,
   TemplateRef,
   ViewChild,
+  ViewChildren,
   ViewEncapsulation,
 } from '@angular/core';
 import { DomSanitizer, SafeStyle } from '@angular/platform-browser';
@@ -36,7 +39,7 @@ import { formatCount } from '@dynatrace/barista-components/formatters';
 import { DtColors, DtTheme } from '@dynatrace/barista-components/theming';
 import { scaleLinear } from 'd3-scale';
 import { merge, Subject } from 'rxjs';
-import { first, switchMapTo, takeUntil } from 'rxjs/operators';
+import { first, tap, switchMapTo, takeUntil } from 'rxjs/operators';
 import { DtStackedSeriesChartNode } from '..';
 import { DtStackedSeriesChartOverlay } from './stacked-series-chart-overlay.directive';
 import {
@@ -54,6 +57,7 @@ import {
   getSeriesWithState,
   getTotalMaxValue,
   updateNodesVisibility,
+  DtStackedSeriesChartLabelAxisMode,
 } from './stacked-series-chart.util';
 import { DtOverlayRef, DtOverlay } from '@dynatrace/barista-components/overlay';
 
@@ -79,6 +83,7 @@ const TICK_COLUMN_SPACING = 80;
     '[class.dt-stacked-series-chart-with-value-axis]': 'visibleValueAxis',
     '[class.dt-stacked-series-chart-bar]': "mode === 'bar'",
     '[class.dt-stacked-series-chart-column]': "mode === 'column'",
+    '[style.--dt-stacked-series-chart-grid-gap]': '_gridGap',
   },
 })
 export class DtStackedSeriesChart implements OnDestroy {
@@ -212,6 +217,20 @@ export class DtStackedSeriesChart implements OnDestroy {
     relative: 0,
   };
 
+  /** Whether to show the label axis rotated to fit more labels */
+  @Input() labelAxisMode: DtStackedSeriesChartLabelAxisMode = 'full';
+  /** @internal  Support only for mode === 'column', wouldn't make sense for 'row' */
+  get _labelAxisCompactModeEnabled(): boolean {
+    return (
+      this.mode === 'column' &&
+      (this.labelAxisMode === 'compact' ||
+        (this.labelAxisMode === 'auto' && this._isAnyLabelOverflowing()))
+    );
+  }
+
+  /** Gap between cells in the grid */
+  _gridGap = 16;
+
   /** Current selection [series, node] */
   @Input()
   get selected(): DtStackedSeriesChartSelection | [] {
@@ -235,7 +254,13 @@ export class DtStackedSeriesChart implements OnDestroy {
   _overlay: TemplateRef<DtStackedSeriesChartTooltipData>;
 
   /** @internal Reference to the root svgElement. */
-  @ViewChild('valueAxis') _valueAxis;
+  @ViewChild('valueAxis') _valueAxis: ElementRef;
+
+  /** @internal Reference to the root element. */
+  @ViewChild('chartContainer') _chartContainer: ElementRef;
+
+  /** @internal Reference to the elements on the label axis. */
+  @ViewChildren('label') labels: QueryList<ElementRef>;
 
   /** Reference to the open overlay. */
   private _overlayRef: DtOverlayRef<DtStackedSeriesChartTooltipData> | null;
@@ -273,6 +298,11 @@ export class DtStackedSeriesChart implements OnDestroy {
 
     merge(this._shouldUpdateTicks, this._resizer.change())
       .pipe(
+        tap(() => {
+          // Recalculate every time the size changes
+          this._isAnyLabelOverflowing();
+          this._changeDetectorRef.detectChanges();
+        }),
         // Shift the updating/rendering to the next CD cycle,
         // because we need the dimensions of axis first, which is rendered in the main cycle.
         switchMapTo(this._zone.onStable.pipe(first())),
@@ -460,5 +490,28 @@ export class DtStackedSeriesChart implements OnDestroy {
           1.5,
       };
     }
+  }
+  /** Return the width in px of the longest label on the label axis */
+  private _getLongestLabelWidth(): number {
+    return this.labels.reduce((labelCount: number, label: ElementRef) => {
+      return label.nativeElement.scrollWidth > labelCount
+        ? label.nativeElement.scrollWidth
+        : labelCount;
+    }, 0);
+  }
+
+  /** Whether there's a label on the label axis that is overflowing its allocated space on the css grid */
+  private _isAnyLabelOverflowing(): boolean {
+    if (
+      !this.labels ||
+      !this.series?.length ||
+      !this._chartContainer?.nativeElement
+    )
+      return false;
+    return (
+      this._getLongestLabelWidth() >
+      this._chartContainer.nativeElement.offsetWidth / this.series.length -
+        this._gridGap
+    );
   }
 }

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.util.ts
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.util.ts
@@ -102,6 +102,9 @@ export type DtStackedSeriesChartMode = 'bar' | 'column';
 /** Whether a single node is selectable or the whole row/column */
 export type DtStackedSeriesChartSelectionMode = 'node' | 'stack';
 
+/** Mode of the label axis to make space to fit a bigger amount */
+export type DtStackedSeriesChartLabelAxisMode = 'full' | 'compact' | 'auto';
+
 /** Selection events object */
 export type DtStackedSeriesChartSelection = [
   DtStackedSeriesChartSeries,


### PR DESCRIPTION
### <strong>Pull Request</strong>

Feature request for **APM-275897**

**Current behaviour**

The labels right now are parallel to the X axis on the `column` mode, which makes impossible to keep the chart in a more compact view since the labels would overlap or the words would get cut from a break line

[![Image from Gyazo](https://i.gyazo.com/79da0b6d698b1b1de5527dc63b9a82a5.gif)](https://gyazo.com/79da0b6d698b1b1de5527dc63b9a82a5)
**Expected behaviour**

Rotate the labels 45 degrees so more can fit and we can make the chart more compact, useful when there are a lot of labels and the size is limited, avoiding the overflow until a certain point (greater than it was before).

[![Image from Gyazo](https://i.gyazo.com/826bf05c03a372a6ebaed22949f61371.gif)](https://gyazo.com/826bf05c03a372a6ebaed22949f61371)

**UPDATE**
`labelAxisMode = auto` has been added which allows an automatic swap between 'full' and 'compact' depending on any label overflowing. Changes pushed and rebased.
Also, now the labels on compact mode will have an overlay since the ellipsis on overflow might make some of them not fully readable.

[![Image from Gyazo](https://i.gyazo.com/19759a1935c22ae36254be7e6b3204ba.gif)](https://gyazo.com/19759a1935c22ae36254be7e6b3204ba)
