### PR TITLE
fix(radial-chart): Display of rounded percentage with precision

### DIFF
--- a/libs/barista-components/radial-chart/README.md
+++ b/libs/barista-components/radial-chart/README.md
@@ -52,14 +52,14 @@ You can specify the position of the radial chart by adjusting the value of the
 
 ## DtRadialChartSeries inputs
 
-| Name            | Type      | Default                             | Description                                                      |
-| --------------- | --------- | ----------------------------------- | ---------------------------------------------------------------- |
-| `value`         | `number`  | -                                   | The series value (required).                                     |
-| `name`          | `string`  | -                                   | The series name (required).                                      |
-| `color`         | `string`  | `DT_CHART_COLOR_PALETTE_ORDERED[i]` | The color in which the series is displayed within the chart.     |
-| `valueRelative` | `number`  | -                                   | Numeric percentage value based on this node vs sum of top level. |
-| `selected`      | `boolean` | false                               | Marks series as selected.                                        |
-| `active`        | `boolean` | true                                | Marks series as activated through legend.                        |
+| Name              | Type      | Default                             | Description                                                      |
+| ----------------- | --------- | ----------------------------------- | ---------------------------------------------------------------- |
+| `value`           | `number`  | -                                   | The series value (required).                                     |
+| `name`            | `string`  | -                                   | The series name (required).                                      |
+| `color`           | `string`  | `DT_CHART_COLOR_PALETTE_ORDERED[i]` | The color in which the series is displayed within the chart.     |
+| `valuePercentage` | `number`  | -                                   | Numeric percentage value based on this node vs sum of top level. |
+| `selected`        | `boolean` | false                               | Marks series as selected.                                        |
+| `active`          | `boolean` | true                                | Marks series as activated through legend.                        |
 
 #### Outputs
 

--- a/libs/barista-components/radial-chart/src/radial-chart.html
+++ b/libs/barista-components/radial-chart/src/radial-chart.html
@@ -31,7 +31,7 @@
       <strong>{{
         valueDisplayMode === 'absolute'
           ? series.value
-          : (series.valueRelative * 100 | dtPercent)
+          : (series.valuePercentage | dtPercent: precision)
       }}</strong>
       {{ series.name }}
     </dt-legend-item>

--- a/libs/barista-components/radial-chart/src/utils/radial-chart-interfaces.ts
+++ b/libs/barista-components/radial-chart/src/utils/radial-chart-interfaces.ts
@@ -29,7 +29,7 @@ export interface DtRadialChartRenderData {
   selectionPath: string;
   color: string;
   value: number;
-  valueRelative: number;
+  valuePercentage: number;
   ariaLabel: string;
   origin: DtRadialChartSeries;
 }

--- a/libs/barista-components/radial-chart/src/utils/radial-chart-utils.spec.ts
+++ b/libs/barista-components/radial-chart/src/utils/radial-chart-utils.spec.ts
@@ -15,7 +15,13 @@
  */
 
 // tslint:disable: no-magic-numbers
-import { getSum, getEndAngle, generatePieArcData } from './radial-chart-utils';
+import {
+  getSum,
+  getEndAngle,
+  generatePieArcData,
+  getPercentages,
+  getRoundedPercentages,
+} from './radial-chart-utils';
 
 const FULL_CIRCLE = Math.PI * 2;
 
@@ -90,6 +96,30 @@ describe('DtRadialChart util functions', () => {
       expect(arcData[0].value).toBe(20);
       expect(arcData[1].value).toBe(11);
       expect(arcData[2].value).toBe(35);
+    });
+  });
+
+  describe('getPercentages', () => {
+    it('should return percentages with precision 2 when total is higher than the sum of values', () => {
+      const values = [10, 21, 8];
+      const total = 75;
+      const percentages = getPercentages(values, total, 2);
+      expect(percentages).toEqual([13.33, 28, 10.67]);
+    });
+
+    it('should return percentages with precision 2 when total is equal to sum of values', () => {
+      const values = [10, 21, 8];
+      const total = 39;
+      const percentages = getPercentages(values, total, 2);
+      expect(percentages).toEqual([25.64, 53.85, 20.51]);
+    });
+  });
+
+  describe('getRoundedPercentages', () => {
+    it('should return rounded percentages with precision 0', () => {
+      const values = [10, 21, 8];
+      const percentages = getRoundedPercentages(values, 0);
+      expect(percentages).toEqual([26, 54, 20]);
     });
   });
 });

--- a/libs/barista-components/radial-chart/src/utils/radial-chart-utils.ts
+++ b/libs/barista-components/radial-chart/src/utils/radial-chart-utils.ts
@@ -85,3 +85,63 @@ export function generatePathData(
     endAngle,
   });
 }
+
+/**
+ * Returns an array of percentages with decimal precision.
+ */
+export function getPercentages(
+  values: number[],
+  total: number,
+  precision: number,
+): number[] {
+  const sumAllValues = getSum(values);
+  if (total > sumAllValues) {
+    return values.map((value) => +((value / total) * 100).toFixed(precision));
+  }
+
+  return getRoundedPercentages(values, precision);
+}
+
+/**
+ * Returns an array of rounded percentages so that the sum of
+ * all values is equal to 100.
+ */
+export function getRoundedPercentages(
+  values: number[],
+  precision: number,
+): number[] {
+  const sumAllValues = getSum(values);
+  const precisionPower = Math.pow(10, precision);
+
+  // Temp object to keep the percentage with precision decimals and initial position.
+  const tempPercentages = values.map((value, i) => ({
+    percentage: (value / sumAllValues) * 100 * precisionPower,
+    position: i,
+  }));
+
+  // Difference between the total and the sum of the rounded values.
+  const diff =
+    Math.pow(10, precision + 2) -
+    tempPercentages.reduce((sum, x) => sum + Math.floor(x.percentage), 0);
+
+  // Sorting the items in decimal decreasing order.
+  tempPercentages.sort(
+    (x, y) =>
+      Math.floor(x.percentage) -
+      x.percentage -
+      (Math.floor(y.percentage) - y.percentage),
+  );
+
+  // Distributing the difference to the first items.
+  const distributedPercentages = tempPercentages.map((x, i) => ({
+    percentage:
+      i < diff ? Math.floor(x.percentage) + 1 : Math.floor(x.percentage),
+    position: x.position,
+  }));
+
+  // Sorting the items in the initial position.
+  distributedPercentages.sort((x, y) => x.position - y.position);
+
+  // Returning the array of percentages taking into account the precision.
+  return distributedPercentages.map((x) => x.percentage / precisionPower);
+}


### PR DESCRIPTION
### <strong>Pull Request</strong>

This PR fixes the issues with the **radial-chart** legend percentages described in #1959 .

#### Type of PR

Bugfix (non-breaking change which fixes an issue)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
