### PR TITLE
Stacked series chart clear fix

### DIFF
--- a/apps/dev/src/stacked-series-chart/stacked-series-chart-demo.component.html
+++ b/apps/dev/src/stacked-series-chart/stacked-series-chart-demo.component.html
@@ -89,6 +89,16 @@
       <dt-button-group-item value="node">Node</dt-button-group-item>
       <dt-button-group-item value="stack">Stack</dt-button-group-item>
     </dt-button-group>
+    <br />
+    <br />
+    <!-- TODO: APM-282124 Allow clearing the selection on stack mode from the outside -->
+    <button
+      dt-button
+      (click)="clearSelection()"
+      [disabled]="selectionMode === 'stack'"
+    >
+      Clear selection
+    </button>
 
     <pre>{{ selected | json }}</pre>
   </div>

--- a/apps/dev/src/stacked-series-chart/stacked-series-chart-demo.component.html
+++ b/apps/dev/src/stacked-series-chart/stacked-series-chart-demo.component.html
@@ -2,7 +2,7 @@
   [series]="series"
   [selectable]="selectable"
   [selectionMode]="selectionMode"
-  [(selected)]="selected"
+  [selected]="selected"
   [valueDisplayMode]="valueDisplayMode"
   [visibleLabel]="visibleLabel"
   [visibleLegend]="visibleLegend"
@@ -91,14 +91,7 @@
     </dt-button-group>
     <br />
     <br />
-    <!-- TODO: APM-282124 Allow clearing the selection on stack mode from the outside -->
-    <button
-      dt-button
-      (click)="clearSelection()"
-      [disabled]="selectionMode === 'stack'"
-    >
-      Clear selection
-    </button>
+    <button dt-button (click)="clearSelection()">Clear selection</button>
 
     <pre>{{ selected | json }}</pre>
   </div>

--- a/apps/dev/src/stacked-series-chart/stacked-series-chart-demo.component.ts
+++ b/apps/dev/src/stacked-series-chart/stacked-series-chart-demo.component.ts
@@ -33,7 +33,7 @@ import { stackedSeriesChartDemoData } from './stacked-series-chart-demo-data';
 export class StackedSeriesChartDemo {
   selectionMode: DtStackedSeriesChartSelectionMode = 'node';
   selectable: boolean = true;
-  selected: [DtStackedSeriesChartSeries, DtStackedSeriesChartNode] = [
+  selected: [DtStackedSeriesChartSeries?, DtStackedSeriesChartNode?] = [
     stackedSeriesChartDemoData[3],
     stackedSeriesChartDemoData[3].nodes[1],
   ];
@@ -55,5 +55,9 @@ export class StackedSeriesChartDemo {
     this.series = multi
       ? stackedSeriesChartDemoData
       : [stackedSeriesChartDemoData[3]];
+  }
+
+  clearSelection(): void {
+    this.selected = [];
   }
 }

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart-column.scss
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart-column.scss
@@ -86,6 +86,7 @@ See stacked-series-chart.layout.md
       left: -$selected-size;
       top: 0;
       bottom: 0;
+      pointer-events: none;
     }
   }
 }

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.spec.ts
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.spec.ts
@@ -101,7 +101,7 @@ describe('DtStackedSeriesChart', () => {
     return track.queryAll(By.css('.dt-stacked-series-chart-slice'))[sliceIndex];
   }
 
-  /** Gets the selected slice */
+  /** Gets the selected track */
   function getSelectedTrack(): DebugElement {
     return fixture.debugElement.query(
       By.css('.dt-stacked-series-chart-track-selected'),
@@ -325,6 +325,33 @@ describe('DtStackedSeriesChart', () => {
       dispatchFakeEvent(sliceByPosition.nativeElement, 'click');
 
       expect(selectedChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it('should unhighlight the node when clearing the selection', () => {
+      rootComponent.selected = [
+        stackedSeriesChartDemoDataCoffee[1],
+        stackedSeriesChartDemoDataCoffee[1].nodes[1],
+      ];
+      fixture.detectChanges();
+
+      expect(getSelectedSlice()).toBeTruthy();
+
+      rootComponent.selected = [];
+      fixture.detectChanges();
+
+      expect(getSelectedSlice()).toBeFalsy();
+    });
+
+    it('should unhighlight the stack when clearing the selection', () => {
+      rootComponent.selected = [stackedSeriesChartDemoDataCoffee[1], undefined];
+      fixture.detectChanges();
+
+      expect(getSelectedTrack()).toBeTruthy();
+
+      rootComponent.selected = [];
+      fixture.detectChanges();
+
+      expect(getSelectedTrack()).toBeFalsy();
     });
   });
 
@@ -688,7 +715,7 @@ class TestApp {
   series: DtStackedSeriesChartSeries[] = stackedSeriesChartDemoDataCoffee;
   selectable: boolean = true;
   selectionMode: DtStackedSeriesChartSelectionMode = 'node';
-  selected: [DtStackedSeriesChartSeries, DtStackedSeriesChartNode] | [] = [];
+  selected: [DtStackedSeriesChartSeries?, DtStackedSeriesChartNode?] | [] = [];
   valueDisplayMode: DtStackedSeriesChartValueDisplayMode;
   max: number;
   fillMode: DtStackedSeriesChartFillMode = 'relative';

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.ts
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.ts
@@ -24,6 +24,7 @@ import {
   Input,
   NgZone,
   OnDestroy,
+  OnInit,
   Optional,
   Output,
   QueryList,
@@ -95,7 +96,7 @@ const TICK_COLUMN_SPACING = 80;
     '[style.--dt-stacked-series-chart-grid-gap]': '_gridGap',
   },
 })
-export class DtStackedSeriesChart implements OnDestroy {
+export class DtStackedSeriesChart implements OnDestroy, OnInit {
   /** Array of series with their nodes. */
   @Input()
   get series(): DtStackedSeriesChartSeries[] {
@@ -336,7 +337,9 @@ export class DtStackedSeriesChart implements OnDestroy {
      */
     private readonly _sanitizer: DomSanitizer,
     @Optional() @SkipSelf() private readonly _theme: DtTheme,
-  ) {
+  ) {}
+
+  ngOnInit(): void {
     if (this._theme) {
       this._theme._stateChanges
         .pipe(takeUntil(this._destroy$))
@@ -350,19 +353,8 @@ export class DtStackedSeriesChart implements OnDestroy {
     merge(this._shouldUpdateTicks, this._resizer.change())
       .pipe(
         tap(() => {
-          // HOTFIX: This If-statement is there to limit the error/exeption for now
-          // that would normally happen here.
-          // A deeper look into the root cause should be done
-          //
-          // Reproduce:
-          // Remove this if statement, run the demos app (`npm run demos `) and
-          // got the "stacked-series-chart-column-example".
-          //
-          // PR that initially introduced this issue:
-          // https://github.com/dynatrace-oss/barista/pull/1916/files
-          // Issue on angular: https://github.com/angular/angular/issues/32756
           if (this.labelAxisMode === 'auto' && this.mode === 'column') {
-            // Recalculate every time the size changes
+            // Recalculate every time the size changes only if we are on these modes
             this._isAnyLabelOverflowing();
             this._changeDetectorRef.detectChanges();
           }

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.ts
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.ts
@@ -289,10 +289,7 @@ export class DtStackedSeriesChart implements OnDestroy, OnInit {
     return this._selected;
   }
   set selected([series, node]: DtStackedSeriesChartSelection | []) {
-    // if selected node is different than current
-    if (this._selected[1] !== node) {
-      this._toggleSelect(series, node);
-    }
+    this._toggleSelect(series, node);
   }
   private _selected: DtStackedSeriesChartSelection | [] = [];
 


### PR DESCRIPTION
**In this PR**
[APM-282124] Clearing selection from the outside was not working on the new stack mode. Issue fixed, unit tests and a button to check it on dev environment added


**Wait for https://github.com/dynatrace-oss/barista/pull/1958 to be merged before reviewing**