### PR TITLE
chore(combobox): Add example for form control usage.

### DIFF
--- a/apps/demos/src/app-routing.module.ts
+++ b/apps/demos/src/app-routing.module.ts
@@ -86,6 +86,7 @@ import {
   DtExampleConsumptionError,
   DtExampleConsumptionWarning,
   DtExampleComboboxSimple,
+  DtExampleComboboxFormControl,
   DtExampleContainerBreakpointObserverDefault,
   DtExampleContainerBreakpointObserverIfElse,
   DtExampleContainerBreakpointObserverIf,
@@ -488,6 +489,10 @@ const ROUTES: Routes = [
   {
     path: 'combobox-simple-example',
     component: DtExampleComboboxSimple,
+  },
+  {
+    path: 'combobox-form-control-example',
+    component: DtExampleComboboxFormControl,
   },
   {
     path: 'combobox-custom-option-height-example',

--- a/apps/demos/src/barista-examples.a11y.ts
+++ b/apps/demos/src/barista-examples.a11y.ts
@@ -59,6 +59,7 @@ const BLOCKLIST: string[] = [
   // for similar reasons as the select and filter field
   // are disabled.
   'combobox-simple-example',
+  'combobox-form-control-example',
   'combobox-custom-option-height-example',
 ];
 

--- a/apps/demos/src/nav-items.ts
+++ b/apps/demos/src/nav-items.ts
@@ -316,6 +316,10 @@ export const DT_DEMOS_EXAMPLE_NAV_ITEMS = [
         route: '/combobox-simple-example',
       },
       {
+        name: 'combobox-form-control-example',
+        route: '/combobox-form-control-example',
+      },
+      {
         name: 'combobox-custom-option-height-example',
         route: '/combobox-custom-option-height-example',
       },

--- a/libs/barista-components/experimental/combobox/README.md
+++ b/libs/barista-components/experimental/combobox/README.md
@@ -77,3 +77,10 @@ configured using the `DT_OPTION_CONFIG` injection token. Note that the
 automatically change the height of the options.
 
 <ba-live-example name="DtExampleComboboxCustomOptionHeight"></ba-live-example>
+
+## Combobox bound to a form control
+
+For now, in case the combobox needs to be bound to a form control, you can add
+the DefaultValueAccessor directive as in the following example:
+
+<ba-live-example name="DtExampleComboboxFormControl"></ba-live-example>

--- a/libs/barista-components/experimental/combobox/src/combobox.ts
+++ b/libs/barista-components/experimental/combobox/src/combobox.ts
@@ -275,6 +275,9 @@ export class DtCombobox<T>
   @ContentChildren(DtOption, { descendants: true })
   _options: QueryList<DtOption<T>>;
 
+  /** @internal `View -> model callback called when value changes` */
+  _onChange: (value: T) => void = () => {};
+
   /** Whether the selection is currently empty. */
   get empty(): boolean {
     return !this._selectionModel || this._selectionModel.isEmpty();
@@ -520,6 +523,14 @@ export class DtCombobox<T>
       );
       this._writeValue();
     });
+  }
+
+  /**
+   * Saves a callback function to be invoked when the select's value
+   * changes from user input. Part of the ControlValueAccessor.
+   */
+  registerOnChange(fn: (value: T) => void): void {
+    this._onChange = fn;
   }
 
   /** Updates the selection by value using selection model and keymanager to handle the active item */

--- a/libs/examples/src/combobox/BUILD.bazel
+++ b/libs/examples/src/combobox/BUILD.bazel
@@ -15,6 +15,7 @@ ng_module(
     angular_assets = [
         "combobox-custom-option-height-example/combobox-custom-option-height-example.html",
         "combobox-simple-example/combobox-simple-example.html",
+        "combobox-form-control-example/combobox-form-control-example.html",
         ":styles_custom_option_height_example",
     ],
     module_name = "@dynatrace/barista-examples/combobox",
@@ -25,6 +26,7 @@ ng_module(
         "//libs/barista-components/experimental/combobox:compile",
         "@npm//@angular/common",
         "@npm//@angular/core",
+        "@npm//@angular/forms",
         "@npm//rxjs",
     ],
 )

--- a/libs/examples/src/combobox/combobox-examples.module.ts
+++ b/libs/examples/src/combobox/combobox-examples.module.ts
@@ -16,12 +16,24 @@
 import { NgModule } from '@angular/core';
 import { DtComboboxModule } from '@dynatrace/barista-components/experimental/combobox';
 import { DtExampleComboboxSimple } from './combobox-simple-example/combobox-simple-example';
+import { DtExampleComboboxFormControl } from './combobox-form-control-example/combobox-form-control-example';
 import { DtOptionModule } from '@dynatrace/barista-components/core';
 import { CommonModule } from '@angular/common';
 import { DtExampleComboboxCustomOptionHeight } from './combobox-custom-option-height-example/combobox-custom-option-height-example';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 @NgModule({
-  imports: [DtComboboxModule, DtOptionModule, CommonModule],
-  declarations: [DtExampleComboboxSimple, DtExampleComboboxCustomOptionHeight],
+  imports: [
+    DtComboboxModule,
+    FormsModule,
+    ReactiveFormsModule,
+    DtOptionModule,
+    CommonModule,
+  ],
+  declarations: [
+    DtExampleComboboxSimple,
+    DtExampleComboboxFormControl,
+    DtExampleComboboxCustomOptionHeight,
+  ],
 })
 export class DtComboboxExamplesModule {}

--- a/libs/examples/src/combobox/combobox-form-control-example/combobox-form-control-example.html
+++ b/libs/examples/src/combobox/combobox-form-control-example/combobox-form-control-example.html
@@ -1,0 +1,17 @@
+<dt-combobox
+  placeholder="Start typing or open dropdown for top list"
+  aria-label="A simple combobox example with form control"
+  panelClass="my-demo-overlay-class"
+  [value]="_initialValue"
+  [loading]="_loading"
+  [displayWith]="_displayWith"
+  [formControl]="reporterCtrl"
+  ngDefaultControl
+  (openedChange)="openedChanged($event)"
+  (valueChange)="valueChanged($event)"
+  (filterChange)="filterChanged($event)"
+>
+  <dt-option *ngFor="let option of _options" [value]="option">
+    {{ option.name }}
+  </dt-option>
+</dt-combobox>

--- a/libs/examples/src/combobox/combobox-form-control-example/combobox-form-control-example.ts
+++ b/libs/examples/src/combobox/combobox-form-control-example/combobox-form-control-example.ts
@@ -1,0 +1,90 @@
+import { FormControl, Validators } from '@angular/forms';
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ChangeDetectorRef, Component, ViewChild } from '@angular/core';
+import { take } from 'rxjs/operators';
+import { timer } from 'rxjs';
+import {
+  DtCombobox,
+  DtComboboxFilterChange,
+} from '@dynatrace/barista-components/experimental/combobox';
+
+interface ExampleComboboxOption {
+  readonly name: string;
+  readonly value: string;
+}
+
+const allOptions: ExampleComboboxOption[] = [
+  { name: 'Value 1', value: '[value: Value 1]' },
+  { name: 'Value 2', value: '[value: Value 2]' },
+  { name: 'Value 3', value: '[value: Value 3]' },
+];
+
+/**
+ * Factory function for generating a filter function for a given filter string.
+ *
+ * @param filter Text to filter options for
+ */
+function optionFilter(
+  filter: string,
+): (option: ExampleComboboxOption) => boolean {
+  return (option: ExampleComboboxOption): boolean => {
+    return option.value.toLowerCase().indexOf(filter.toLowerCase()) >= 0;
+  };
+}
+
+@Component({
+  selector: 'dt-example-form-control-combobox',
+  templateUrl: './combobox-form-control-example.html',
+})
+export class DtExampleComboboxFormControl {
+  @ViewChild(DtCombobox) combobox: DtCombobox<any>;
+
+  reporterCtrl: FormControl;
+
+  _initialValue = allOptions[0];
+  _options = [...allOptions];
+  _loading = false;
+  _displayWith = (option: ExampleComboboxOption) => option.name;
+
+  constructor(private _changeDetectorRef: ChangeDetectorRef) {
+    this.reporterCtrl = new FormControl('Value 1', Validators.required);
+  }
+
+  openedChanged(event: boolean): void {
+    console.log(`openedChanged: '${event}'`);
+  }
+
+  valueChanged(event: ExampleComboboxOption): void {
+    this._options = [...allOptions].filter(optionFilter(event.value));
+  }
+
+  filterChanged(event: DtComboboxFilterChange): void {
+    if (!event.isResetEvent) {
+      this._loading = true;
+      this._changeDetectorRef.markForCheck();
+    }
+
+    timer(1500)
+      .pipe(take(1))
+      .subscribe(() => {
+        this._options = allOptions.filter(optionFilter(event.filter));
+        this._loading = false;
+        this._changeDetectorRef.markForCheck();
+      });
+  }
+}

--- a/libs/examples/src/combobox/index.ts
+++ b/libs/examples/src/combobox/index.ts
@@ -15,5 +15,6 @@
  */
 
 export * from './combobox-simple-example/combobox-simple-example';
+export * from './combobox-form-control-example/combobox-form-control-example';
 export * from './combobox-custom-option-height-example/combobox-custom-option-height-example';
 export * from './combobox-examples.module';

--- a/libs/examples/src/index.ts
+++ b/libs/examples/src/index.ts
@@ -86,6 +86,7 @@ import { DtExampleCheckboxIndeterminate } from './checkbox/checkbox-indeterminat
 import { DtExampleCheckboxResponsive } from './checkbox/checkbox-responsive-example/checkbox-responsive-example';
 import { DtExampleComboboxCustomOptionHeight } from './combobox/combobox-custom-option-height-example/combobox-custom-option-height-example';
 import { DtExampleComboboxSimple } from './combobox/combobox-simple-example/combobox-simple-example';
+import { DtExampleComboboxFormControl } from './combobox/combobox-form-control-example/combobox-form-control-example';
 import { DtExampleConfirmationDialogDefault } from './confirmation-dialog/confirmation-dialog-default-example/confirmation-dialog-default-example';
 import { DtExampleConfirmationDialogShowBackdrop } from './confirmation-dialog/confirmation-dialog-show-backdrop-example/confirmation-dialog-show-backdrop-example';
 import { DtExampleConsumptionDefault } from './consumption/consumption-default-example/consumption-default-example';
@@ -468,6 +469,7 @@ export {
   DtExampleCheckboxIndeterminate,
   DtExampleCheckboxResponsive,
   DtExampleComboboxSimple,
+  DtExampleComboboxFormControl,
   DtExampleComboboxCustomOptionHeight,
   DtExampleConfirmationDialogDefault,
   DtExampleConfirmationDialogShowBackdrop,
@@ -792,6 +794,7 @@ export const EXAMPLES_MAP = new Map<string, Type<unknown>>([
   ['DtExampleCheckboxIndeterminate', DtExampleCheckboxIndeterminate],
   ['DtExampleCheckboxResponsive', DtExampleCheckboxResponsive],
   ['DtExampleComboboxSimple', DtExampleComboboxSimple],
+  ['DtExampleComboboxFormControl', DtExampleComboboxFormControl],
   ['DtExampleComboboxCustomOptionHeight', DtExampleComboboxCustomOptionHeight],
   ['DtExampleConfirmationDialogDefault', DtExampleConfirmationDialogDefault],
   [


### PR DESCRIPTION
### <strong>Pull Request</strong>

<hr>
Add an example to show how the combobox can be bound to a form control. 
The DefaultValueAccessor
directive as an alternative for now, in order to prevent value accessor errors. 
Fixes https://dev-jira.dynatrace.org/browse/APM-283084. <br>

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
