### PR TITLE
fix(stacked-series-chart): Clear when using stack mode.

### DIFF
--- a/apps/dev/src/stacked-series-chart/stacked-series-chart-demo.component.html
+++ b/apps/dev/src/stacked-series-chart/stacked-series-chart-demo.component.html
@@ -91,14 +91,7 @@
     </dt-button-group>
     <br />
     <br />
-    <!-- TODO: APM-282124 Allow clearing the selection on stack mode from the outside -->
-    <button
-      dt-button
-      (click)="clearSelection()"
-      [disabled]="selectionMode === 'stack'"
-    >
-      Clear selection
-    </button>
+    <button dt-button (click)="clearSelection()">Clear selection</button>
 
     <pre>{{ selected | json }}</pre>
   </div>

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.spec.ts
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.spec.ts
@@ -326,6 +326,22 @@ describe('DtStackedSeriesChart', () => {
 
       expect(selectedChangeSpy).not.toHaveBeenCalled();
     });
+
+    it('should clear the selection from the outside on stack mode', () => {
+      rootComponent.selectionMode = 'stack';
+      rootComponent.selected = [
+        stackedSeriesChartDemoDataCoffee[1],
+        stackedSeriesChartDemoDataCoffee[1].nodes[1],
+      ];
+      fixture.detectChanges();
+
+      expect(getSelectedSlice() !== null).toBe(true);
+
+      rootComponent.selected = [];
+      fixture.detectChanges();
+
+      expect(getSelectedSlice()).toBe(null);
+    });
   });
 
   describe('Value Display Mode', () => {

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.ts
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.ts
@@ -289,8 +289,8 @@ export class DtStackedSeriesChart implements OnDestroy, OnInit {
     return this._selected;
   }
   set selected([series, node]: DtStackedSeriesChartSelection | []) {
-    // if selected node is different than current
-    if (this._selected[1] !== node) {
+    // if selected node or series are different than current
+    if (this._selected[0] !== series || this._selected[1] !== node) {
       this._toggleSelect(series, node);
     }
   }


### PR DESCRIPTION
**In this PR**
[APM-282124] Clearing selection from the outside was not working on the new stack mode. Issue fixed and a button to check it on dev environment added**

You can close https://github.com/dynatrace-oss/barista/pull/1971 and merge this one
