### PR TITLE
fix(context-dialog): Fixes an issue that the scroll container of the …

### DIFF
--- a/libs/barista-components/context-dialog/src/context-dialog.ts
+++ b/libs/barista-components/context-dialog/src/context-dialog.ts
@@ -111,8 +111,6 @@ export const DT_CONTEXT_DIALOG_CONFIG = new InjectionToken<OverlayConfig>(
   'dt-context-dialog-config',
 );
 
-const DT_CONTEXT_DIALOG_DEFAULT_MAX_WIDTH = 328;
-
 @Component({
   selector: 'dt-context-dialog',
   templateUrl: 'context-dialog.html',
@@ -310,12 +308,15 @@ export class DtContextDialog
       scrollStrategy: this._overlay.scrollStrategies.block(),
       backdropClass: 'cdk-overlay-transparent-backdrop',
       hasBackdrop: true,
-      maxWidth: DT_CONTEXT_DIALOG_DEFAULT_MAX_WIDTH,
     };
 
     const overlayConfig = this._userConfig
       ? { ...defaultConfig, ...this._userConfig }
       : defaultConfig;
+
+    const hasFlexibleDimensions =
+      this._userConfig?.maxWidth === undefined &&
+      this._userConfig?.maxHeight === undefined;
 
     const positionStrategy = this._overlay
       .position()
@@ -324,7 +325,7 @@ export class DtContextDialog
       .setOrigin(this._trigger.elementRef)
       // We need to falsify the flexibleDimension here in case a maxWidth is set
       // https://github.com/angular/components/blob/master/src/cdk/overlay/position/flexible-connected-position-strategy.ts#L914
-      .withFlexibleDimensions(overlayConfig.maxWidth === undefined)
+      .withFlexibleDimensions(hasFlexibleDimensions)
       .withPush(false)
       .withGrowAfterOpen(false)
       .withViewportMargin(0)


### PR DESCRIPTION
…context-dialog did not properly resize for large content.

The issue is a bit strange, the cdk overlay ignores maxHeight and maxWidth different when flexibleDimensions is set to true. We need to have it set to true except when the user provides a maxWidth or maxHeight. The defaultWidth we previously set was ignored by the cdk anyway in the past since we had flexibledimensions always set to true. Current master always set it to false since the config was always defined due to the defaultConfig. Setting the flexibleDimensions to false breaks the overflow. Since basically none of our consumers need to set a specific maxWidth i'd suggest to make the flexibleDimensions based on whether maxWidth or maxHeight are set.

### <strong>Pull Request</strong>

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
