### PR TITLE
docs(workspace): Fix escapes in API show-more formatting and datepick…

### DIFF
--- a/libs/barista-components/experimental/datepicker/README.md
+++ b/libs/barista-components/experimental/datepicker/README.md
@@ -77,14 +77,14 @@ class MyModule {}
 
 ### Calendar Body
 
-| Name           | Type                   | Default | Description                                                                                                                                              |
-| -------------- | ---------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| activeDate     | `T `                   | `today` | The date to display in this month view (everything other than the month and year is ignored).                                                            |
-| startAt        | `T \| null`            | `null`  | A date representing the period (month or year) to start the calendar with.                                                                               |
-| minDate        | `T \| null`            | `null`  | The minimum valid date.                                                                                                                                  |
-| maxDate        | `T \| null`            | `null`  | The maximum valid date.                                                                                                                                  |
-| dateFilter     | `(date: T) => boolean` | `null`  | Function used to filter whether a date is selectable or not.                                                                                             |
-| ariaLabelledby | `string`               | `null`  | Used for the aria-labelledby and aria-describedby properties of the calendar body. If not provided, the month and year are used as label ad description. |
+| Name           | Type                   | Default | Description                                                                                                                                               |
+| -------------- | ---------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| activeDate     | `T`                    | `today` | The date to display in this month view (everything other than the month and year is ignored).                                                             |
+| startAt        | `T \| null`            | `null`  | A date representing the period (month or year) to start the calendar with.                                                                                |
+| minDate        | `T \| null`            | `null`  | The minimum valid date.                                                                                                                                   |
+| maxDate        | `T \| null`            | `null`  | The maximum valid date.                                                                                                                                   |
+| dateFilter     | `(date: T) => boolean` | `null`  | Function used to filter whether a date is selectable or not.                                                                                              |
+| ariaLabelledby | `string`               | `null`  | Used for the aria-labelledby and aria-describedby properties of the calendar body. If not provided, the month and year are used as label and description. |
 
 ## Outputs
 

--- a/libs/barista-components/show-more/README.md
+++ b/libs/barista-components/show-more/README.md
@@ -24,11 +24,11 @@ the content to add a show more label above the arrow icon.
 ## Inputs
 
 | Name                | Type          | Default     | Description                                                                                                                                               |
-| ------------------- | ------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| ------------------- | ------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `<ng-content>`      |               |             | The text which gets displayed above the arrow.                                                                                                            |
 | `showLess`          | `boolean`     | `false`     | Whether on click the content that has been expanded is collapsed again. When `true` the show more arrow points upwards and the show more label is hidden. |
 | `ariaLabelShowLess` | `string`      | `Show less` | The aria label for the show less button without text.                                                                                                     |
-| `(changed)`         | `event<void>` |             | The event which gets fired when the state changes. The event is fired when the user clicks on the component, as well as using SPACE or ENTER keys.        |     |
+| `(changed)`         | `event<void>` |             | The event which gets fired when the state changes. The event is fired when the user clicks on the component, as well as using SPACE or ENTER keys.        |
 
 ## Show more in use
 


### PR DESCRIPTION
Fixes show-more documentation formatting for the inputs table and a typo in the datepicker readme file.

### <strong>Pull Request</strong>


#### Type of PR

Documentation update (changes to documentation)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
