### PR TITLE
fix(overlay): Fixes an issue with the overlay origin positioning.

### DIFF
--- a/libs/barista-components/overlay/src/overlay.ts
+++ b/libs/barista-components/overlay/src/overlay.ts
@@ -141,11 +141,13 @@ export class DtOverlay implements OnDestroy {
     let originPoint: { x: number; y: number };
     // We need to get the x & y values of the origin
     if (origin instanceof Element) {
-      originPoint = { x: origin.clientTop, y: origin.clientLeft };
+      const { x, y } = origin.getBoundingClientRect();
+      originPoint = { x, y };
     } else if (origin instanceof ElementRef) {
+      const { x, y } = origin.nativeElement.getBoundingClientRect();
       originPoint = {
-        x: origin.nativeElement.clientTop,
-        y: origin.nativeElement.clientLeft,
+        x,
+        y,
       };
     } else {
       originPoint = origin;


### PR DESCRIPTION
### <strong>Pull Request</strong>
Somehow the clientLeft and clientTop values where constantly reported as 0. Falling back to boundingClientRect should do the trick.

Fixes APM-291653


#### Type of PR
Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
