### PR TITLE
fix(filter-field): Fixes the defaultSearch not being displayed anymore

### DIFF
--- a/libs/barista-components/filter-field/src/filter-field-util.ts
+++ b/libs/barista-components/filter-field/src/filter-field-util.ts
@@ -78,24 +78,22 @@ export function filterAutocompleteDef(
 export function filterFreeTextDef(
   def: DtNodeDef,
   filterText?: string,
-): DtNodeDef | null {
+): DtNodeDef {
   const suggestions = def.freeText!.suggestions
     ? def.freeText!.suggestions.filter((option) =>
         filterOptionDef(option, new Set(), filterText),
       )
     : [];
 
-  return def.freeText!.async || suggestions.length
-    ? dtFreeTextDef(
-        def.data,
-        def,
-        suggestions,
-        def.freeText!.validators || [],
-        isDefined(def.freeText!.unique) ? def.freeText!.unique! : false,
-        false,
-        !!def.freeText!.async,
-      )
-    : null;
+  return dtFreeTextDef(
+    def.data,
+    def,
+    suggestions,
+    def.freeText!.validators || [],
+    isDefined(def.freeText!.unique) ? def.freeText!.unique! : false,
+    false,
+    !!def.freeText!.async,
+  );
 }
 
 /**


### PR DESCRIPTION
### <strong>Pull Request</strong>

Fixes the defaultSearch not being displayed anymore after regression by version 9.3.0

#### Type of PR

Bugfix (non-breaking change which fixes an issue)

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
