### PR TITLE
fix(key-value-list): Adds a zero-width white space to split the key from the value.

### DIFF
--- a/libs/barista-components/key-value-list/src/key-value-list-item.html
+++ b/libs/barista-components/key-value-list/src/key-value-list-item.html
@@ -2,13 +2,16 @@
   <span>
     <ng-content
       select="dt-key-value-list-key, [dt-key-value-list-key], [dtKeyValueListKey]"
-    ></ng-content>
+    >
+    </ng-content
+    >&#8203;
   </span>
 </dt>
 <dd class="dt-key-value-list-item-value">
   <span>
     <ng-content
       select="dt-key-value-list-value, [dt-key-value-list-value], [dtKeyValueListValue]"
-    ></ng-content>
+    >
+    </ng-content>
   </span>
 </dd>

--- a/libs/barista-components/key-value-list/src/key-value-list.spec.ts
+++ b/libs/barista-components/key-value-list/src/key-value-list.spec.ts
@@ -149,18 +149,18 @@ describe('DtKeyValueList', () => {
     });
 
     it('should display 1st item data properly', () => {
-      expect(getKeyElement(items[0])!.textContent).toBe('Temp');
-      expect(getValueElement(items[0])!.textContent).toBe('1');
+      expect(getKeyElement(items[0])!.textContent).toContain('Temp');
+      expect(getValueElement(items[0])!.textContent).toContain('1');
     });
 
     it('should display 2nd item data properly', () => {
-      expect(getKeyElement(items[1])!.textContent).toBe('Temp1');
-      expect(getValueElement(items[1])!.textContent).toBe('13');
+      expect(getKeyElement(items[1])!.textContent).toContain('Temp1');
+      expect(getValueElement(items[1])!.textContent).toContain('13');
     });
 
     it('should display 3rd item data properly', () => {
-      expect(getKeyElement(items[2])!.textContent).toBe('Temp2');
-      expect(getValueElement(items[2])!.textContent).toBe('28');
+      expect(getKeyElement(items[2])!.textContent).toContain('Temp2');
+      expect(getValueElement(items[2])!.textContent).toContain('28');
     });
   });
 });


### PR DESCRIPTION
### <strong>Pull Request</strong>

In chrome, when double clicking the last word of the value, it selected the first part of the value as well. Because the value is set to display: inline; which chrome interprets as a continuous word.
With the inserted 0-width white space, this forces chrome to separate the words.


#### Type of PR
Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
