### PR TITLE
fix(overlay): Overlay never reopens if closed via scrolling.

### DIFF
--- a/libs/barista-components/overlay/src/overlay-ref.ts
+++ b/libs/barista-components/overlay/src/overlay-ref.ts
@@ -66,6 +66,7 @@ export class DtOverlayRef<T> {
     private _config: DtOverlayConfig,
   ) {
     containerInstance._onDomExit.pipe(take(1)).subscribe(() => {
+      this.dismiss();
       this._overlayRef.dispose();
       this._pinned = false;
       this._afterExit.next();


### PR DESCRIPTION
### <strong>Pull Request</strong>

If a pinned tooltip is closed automatically by scrolling then it cannot be reopend.
Can be reproduced [here](https://barista.dynatrace.com/components/overlay) by:
1 - clicking on the first overlay trigger
2 - Scrolling down to close the overlay
3 - Trying to open the overlay again

Fixes APM-291840

#### Type of PR

Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
