### PR TITLE
fix(confirmation-dialog): Fixes an issue with blocking space above the confirmation dialog.

### DIFF
--- a/libs/barista-components/confirmation-dialog/src/confirmation-dialog.scss
+++ b/libs/barista-components/confirmation-dialog/src/confirmation-dialog.scss
@@ -2,7 +2,9 @@
 
 .dt-confirmation-dialog-wrapper {
   width: 100%;
-  padding: 16px;
+  margin-left: 16px;
+  margin-right: 16px;
+  margin-bottom: 16px;
 }
 
 .dt-confirmation-dialog-container {


### PR DESCRIPTION
### <strong>Pull Request</strong>

Changes the padding to margin and drops the top spacing

#### Type of PR
Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
