### PR TITLE
fix(table): Fixes an issue with rapid unsubscription if the dtOrder is immediately destroyed.

### DIFF
--- a/libs/barista-components/table/src/order/order-directive.ts
+++ b/libs/barista-components/table/src/order/order-directive.ts
@@ -92,7 +92,7 @@ export class DtOrder<T>
   _disabledChange = new BehaviorSubject<boolean>(false);
 
   /** Subscription of the drop list dropped event emitter */
-  private _dropListSubscription: Subscription;
+  private _dropListSubscription: Subscription = Subscription.EMPTY;
 
   constructor(
     @Host() readonly _dropList: CdkDropList<T[]>,


### PR DESCRIPTION
### <strong>Pull Request</strong>
Fixes APM-296415

#### Type of PR

Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
