### PR TITLE
fix(context-dialog): Fixes an overflow issue with long content when positioning moved to bottom.

### DIFF
--- a/libs/barista-components/context-dialog/src/context-dialog.scss
+++ b/libs/barista-components/context-dialog/src/context-dialog.scss
@@ -79,7 +79,7 @@ $context-dialog-top-header-padding: 8px;
 // and there is no footer, adjust the padding and margin of the content.
 ::ng-deep.dt-context-dialog-panel-bottom
   .dt-context-dialog-panel
-  .dt-context-dialog-content:not(:last-child) {
+  .dt-context-dialog-content:not(:nth-last-child(2)) {
   margin: 0;
   padding: $panel-padding;
 }


### PR DESCRIPTION
### <strong>Pull Request</strong>

At some point the dt-context-dialog-content was the last element if there was no footer and the css selector corrected against the overflow situation with the close button.
After a html structure change, the content was never the last child, as the button was rendered unconditionally afterwards.

#### Type of PR
Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
