### PR TITLE
fix(overlay): Fixes an issue where multiple overlay container were created when lazyloading the module.

### DIFF
--- a/libs/barista-components/overlay/src/overlay-module.ts
+++ b/libs/barista-components/overlay/src/overlay-module.ts
@@ -45,7 +45,7 @@ const EXPORTED_DECLARATIONS = [DtOverlayContainer, DtOverlayTrigger];
   declarations: [...EXPORTED_DECLARATIONS],
   entryComponents: [DtOverlayContainer],
   providers: [
-    { provide: OverlayContainer, useClass: FullscreenOverlayContainer },
+    { provide: OverlayContainer, useExisting: FullscreenOverlayContainer },
   ],
 })
 export class DtOverlayModule {}


### PR DESCRIPTION
### <strong>Pull Request</strong>

When using the overlay in two or more modules that are being loaded lazily, there are multiple overlay containers created, which mess with the z-index order of the created overlays within.

Thanks @bartoszbobin  @piotrl for figuring this out.

Fixes APM-275769

#### Type of PR

Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
