### PR TITLE
Fix Filter-field multiselect id generation; Clearing multiselect on delete

### DIFF
--- a/apps/components-e2e/src/components/sunburst-chart/BUILD.bazel
+++ b/apps/components-e2e/src/components/sunburst-chart/BUILD.bazel
@@ -1,4 +1,3 @@
-
 load("//tools/bazel_rules:index.bzl", "ng_module")
 
 package(default_visibility = ["//apps/components-e2e:__subpackages__"])
@@ -15,6 +14,7 @@ ng_module(
     angular_assets = ["sunburst-chart.html"],
     tsconfig = "//apps/components-e2e:tsconfig-app",
     deps = [
+        "//libs/barista-components/overlay:compile",
         "//libs/barista-components/sunburst-chart:compile",
         "//libs/barista-components/theming:compile",
         "@npm//@angular/common",

--- a/apps/components-e2e/src/components/sunburst-chart/sunburst-chart.module.ts
+++ b/apps/components-e2e/src/components/sunburst-chart/sunburst-chart.module.ts
@@ -17,6 +17,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { Route, RouterModule } from '@angular/router';
+import { DtOverlayModule } from '@dynatrace/barista-components/overlay';
 import { DtSunburstChartModule } from '@dynatrace/barista-components/sunburst-chart';
 import { DtE2ESunburstChart } from './sunburst-chart';
 
@@ -24,7 +25,12 @@ const routes: Route[] = [{ path: '', component: DtE2ESunburstChart }];
 
 @NgModule({
   declarations: [DtE2ESunburstChart],
-  imports: [CommonModule, RouterModule.forChild(routes), DtSunburstChartModule],
+  imports: [
+    CommonModule,
+    DtOverlayModule,
+    RouterModule.forChild(routes),
+    DtSunburstChartModule,
+  ],
   exports: [],
   providers: [],
 })

--- a/libs/barista-components/filter-field/src/filter-field.ts
+++ b/libs/barista-components/filter-field/src/filter-field.ts
@@ -1478,6 +1478,8 @@ export class DtFilterField<T = any>
       }
       this._resetEditMode();
       this._closeFilterPanels();
+
+      this._multiSelect._setInitialSelection([]);
       this._stateChanges.next();
       this._changeDetectorRef.markForCheck();
     }
@@ -1798,11 +1800,17 @@ export class DtFilterField<T = any>
     const ids = new Set<string>();
     for (const currentFilter of this._filters) {
       let currentId = '';
-      for (const value of currentFilter) {
+
+      for (const [index, value] of currentFilter.entries()) {
         if (isDtAutocompleteValue(value)) {
           const id = peekOptionId(value, currentId);
           ids.add(id);
-          currentId = id;
+
+          // In case of multiSelect filter type, the id must not be concatenated.
+          // So it'll only use the first value which is the parent
+          if (!isDtMultiSelectValue(currentFilter[0]) || index === 0) {
+            currentId = id;
+          }
         }
       }
     }

--- a/libs/examples/src/sunburst-chart/BUILD.bazel
+++ b/libs/examples/src/sunburst-chart/BUILD.bazel
@@ -20,8 +20,8 @@ ng_module(
     tsconfig = "//libs/examples:tsconfig_lib",
     deps = [
         "//libs/barista-components/button:compile",
-        "//libs/barista-components/overlay:compile",
         "//libs/barista-components/formatters:compile",
+        "//libs/barista-components/overlay:compile",
         "//libs/barista-components/sunburst-chart:compile",
         "//libs/barista-components/theming:compile",
         "@npm//@angular/core",

--- a/libs/examples/src/sunburst-chart/BUILD.bazel
+++ b/libs/examples/src/sunburst-chart/BUILD.bazel
@@ -20,6 +20,7 @@ ng_module(
     tsconfig = "//libs/examples:tsconfig_lib",
     deps = [
         "//libs/barista-components/button:compile",
+        "//libs/barista-components/overlay:compile",
         "//libs/barista-components/formatters:compile",
         "//libs/barista-components/sunburst-chart:compile",
         "//libs/barista-components/theming:compile",

--- a/libs/examples/src/sunburst-chart/sunburst-chart-examples.module.ts
+++ b/libs/examples/src/sunburst-chart/sunburst-chart-examples.module.ts
@@ -16,6 +16,7 @@
 
 import { NgModule } from '@angular/core';
 import { DtButtonModule } from '@dynatrace/barista-components/button';
+import { DtOverlayModule } from '@dynatrace/barista-components/overlay';
 import { DtSunburstChartModule } from '@dynatrace/barista-components/sunburst-chart';
 import { DtThemingModule } from '@dynatrace/barista-components/theming';
 import { DtExampleSunburstChartCustomColor } from './sunburst-chart-custom-color-example/sunburst-chart-custom-color-example';
@@ -29,6 +30,7 @@ import { DtFormattersModule } from '@dynatrace/barista-components/formatters';
     DtButtonModule,
     DtThemingModule,
     DtFormattersModule,
+    DtOverlayModule,
   ],
   declarations: [
     DtExampleSunburstChartDefault,


### PR DESCRIPTION
### <strong>Pull Request</strong>

- Fixing method for generating multiselect filter type uid, for avoid creating a non-existent hierarchy.
- Clearing the list of selected options in multiselect when the field is deleted
- Adding **DtOverlay as sunburst dependency**

#### Type of PR

Bugfix (non-breaking change which fixes an issue)
