### PR TITLE
Add hover events to stacked series graph

### DIFF
--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.html
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.html
@@ -25,7 +25,6 @@
     class="dt-stacked-series-chart-series-axis"
     *ngIf="mode === 'column'"
   ></div>
-
   <ng-container
     *ngFor="let track of _tracks; let i = index; trackBy: _trackByFn"
   >
@@ -69,7 +68,7 @@
         (click)="_toggleNodeSelect(track.origin, slice.origin)"
         (mouseenter)="_handleOnSeriesMouseEnter($event, slice)"
         (mousemove)="_handleOnSeriesMouseMove($event)"
-        (mouseleave)="_handleOnSeriesMouseLeave()"
+        (mouseleave)="_handleOnSeriesMouseLeave(slice)"
       >
       </span>
     </div>
@@ -103,6 +102,8 @@
     *ngFor="let legend of _legends; let i = index"
     [class.dt-stacked-series-chart-legend-item-hidden]="!legend.visible"
     (click)="_toggleLegend(legend)"
+    (mouseenter)="_handleOnLegendMouseEnter(legend)"
+    (mouseleave)="_handleOnLegendMouseLeave(legend)"
     [style]="_sanitizeCSS([['--dt-stacked-series-chart-color', legend.color]])"
   >
     <dt-legend-symbol class="dt-stacked-series-chart-legend-symbol">

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.spec.ts
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.spec.ts
@@ -43,6 +43,7 @@ import {
   DtStackedSeriesChartValueDisplayMode,
   DtStackedSeriesChartSelectionMode,
   DtStackedSeriesChartLabelAxisMode,
+  DtStackedSeriesHoverData,
 } from './stacked-series-chart.util';
 
 describe('DtStackedSeriesChart', () => {
@@ -668,6 +669,55 @@ describe('DtStackedSeriesChart', () => {
       expect(overlayPane).toBeNull();
     });
   });
+
+  describe('Hover events reporting', () => {
+    it('should emit hoverStart with hovered series data upon mouseenter event', () => {
+      const firstSlice = getAllSlices()[0];
+
+      dispatchFakeEvent(firstSlice.nativeElement, 'mouseenter');
+      fixture.detectChanges();
+
+      expect(rootComponent.hoverStart).toMatchObject({
+        value: stackedSeriesChartDemoDataCoffee[0].nodes[0].value,
+        stackName: stackedSeriesChartDemoDataCoffee[0].nodes[0].label,
+        seriesName: stackedSeriesChartDemoDataCoffee[0].label,
+        color: '#7c38a1',
+        selected: false,
+        visible: true,
+        hoveredIn: 'stack',
+      });
+    });
+
+    it('should emit hoverEnd with hovered series data upon mouseleave event', () => {
+      const firstSlice = getAllSlices()[0];
+
+      dispatchFakeEvent(firstSlice.nativeElement, 'mouseleave');
+      fixture.detectChanges();
+
+      expect(rootComponent.hoverEnd).toMatchObject({
+        value: stackedSeriesChartDemoDataCoffee[0].nodes[0].value,
+        stackName: stackedSeriesChartDemoDataCoffee[0].nodes[0].label,
+        seriesName: stackedSeriesChartDemoDataCoffee[0].label,
+        color: '#7c38a1',
+        selected: false,
+        visible: true,
+        hoveredIn: 'stack',
+      });
+    });
+    it('should emit hoveredIn as "legend" upon hovering the legend and not the stacks', () => {
+      const firstLegendItem = getAllLegendItems()[0];
+
+      dispatchFakeEvent(firstLegendItem.nativeElement, 'mouseenter');
+      fixture.detectChanges();
+
+      expect(rootComponent.hoverStart).toMatchObject({
+        seriesName: stackedSeriesChartDemoDataCoffee[0].nodes[0].label,
+        color: '#7c38a1',
+        visible: true,
+        hoveredIn: 'legend',
+      });
+    });
+  });
 });
 
 /** Test component that contains an DtStackedSeriesChart. */
@@ -691,6 +741,8 @@ describe('DtStackedSeriesChart', () => {
       [visibleValueAxis]="visibleValueAxis"
       [mode]="mode"
       [maxTrackSize]="maxTrackSize"
+      (hoverStart)="hoverStart = $event"
+      (hoverEnd)="hoverEnd = $event"
     >
       <ng-template dtStackedSeriesChartOverlay let-tooltip *ngIf="hasOverlay">
         <div>
@@ -720,6 +772,9 @@ class TestApp {
   theme = 'blue';
   hasOverlay: boolean = true;
   @ViewChild(DtStackedSeriesChart) stackedSeriesChart: DtStackedSeriesChart;
+
+  hoverStart: DtStackedSeriesHoverData;
+  hoverEnd: DtStackedSeriesHoverData;
 }
 
 /** Test component that contains an DtStackedSeriesChart. */

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.util.ts
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.util.ts
@@ -72,7 +72,6 @@ export interface DtStackedSeriesChartTooltipData {
   origin: DtStackedSeriesChartNode;
   /** Original parent series */
   seriesOrigin: DtStackedSeriesChartSeries;
-
   /** Numeric percentage value based on this node vs sum of top level */
   valueRelative: number;
   /** Color for this node in this state */
@@ -86,6 +85,53 @@ export interface DtStackedSeriesChartTooltipData {
   /** Text for a11y */
   ariaLabel?: string;
 }
+
+/** Format from which to extend for hover event outputs, detailing the origin inside the component where the hover event took place. */
+type HoverTrackableData = {
+  /** Possible origins for hover events on the stacked series chart component. */
+  hoveredIn: 'legend' | 'stack';
+};
+
+/** Output data extracted from hovered series. */
+type DtStackedSeriesSeriesTrackableData = {
+  /** Label of the node hovered upon */
+  seriesName: string;
+  /** Color used for this node. */
+  color: string;
+  /** If node is visible. */
+  visible: boolean;
+};
+
+/** Output data extracted from hovered stacks. */
+type DtStackedSeriesStackTrackableData = {
+  stackName: string;
+  /** Numeric percentage value based on this node vs sum of top level. */
+  value: number;
+  /** If node is currently selected. */
+  selected: boolean;
+  /** If node was hovered over the legend or the stack. */
+  hoveredIn: 'stack';
+};
+
+/** Output data for hover events taking place on the chart legend, containing only information of the hovered series. */
+export interface DtStackedSeriesLegendHoverData
+  extends DtStackedSeriesSeriesTrackableData,
+    HoverTrackableData {
+  hoveredIn: 'legend';
+}
+
+/** Output data for hover events taking place on the chart itself, containing information of both the hovered stack and the specific hovered series. */
+export interface DtStackedSeriesStackHoverData
+  extends DtStackedSeriesSeriesTrackableData,
+    DtStackedSeriesStackTrackableData,
+    HoverTrackableData {
+  hoveredIn: 'stack';
+}
+
+/** Output type for hovent output events, providing information on the hovered series and, when applicable, the hovered stack to the container component. */
+export type DtStackedSeriesHoverData =
+  | DtStackedSeriesLegendHoverData
+  | DtStackedSeriesStackHoverData;
 
 /** For single track only, format of value to be displayed in legend */
 export type DtStackedSeriesChartValueDisplayMode =


### PR DESCRIPTION
#### Type of PR
Feature (non-breaking change which adds functionality)

#### Checklist

- [X] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

#### Description

This PR includes functionality to enable the tracking of hover events on the stacked series chart. This component now presents two output events, **hoverStart** and **hoverEnd**, which emit the data of the series the user has hovered over, and wether the hover event took place on the graph itself or on the legend. When the event takes place over the graph, the outputs will include data on both the series and the stack.

![image](https://user-images.githubusercontent.com/59490817/117135154-d387c980-ada6-11eb-8632-d954b6ccf528.png)
