### PR TITLE
feat(sunburst-chart): Added hover output for slices.

### DIFF
--- a/libs/barista-components/sunburst-chart/src/sunburst-chart.html
+++ b/libs/barista-components/sunburst-chart/src/sunburst-chart.html
@@ -17,6 +17,8 @@
       _sanitizeCSS('--dt-sunburst-chart-slice-color', slice.data.color)
     "
     (click)="_select($event, slice)"
+    (mouseenter)="onMouseEnter(slice)"
+    (mouseleave)="onMouseLeave(slice)"
   ></g>
 </svg>
 

--- a/libs/barista-components/sunburst-chart/src/sunburst-chart.spec.ts
+++ b/libs/barista-components/sunburst-chart/src/sunburst-chart.spec.ts
@@ -36,6 +36,7 @@ import { DtSunburstChart } from './sunburst-chart';
 import { sunburstChartMock } from './sunburst-chart.mock';
 import { DtSunburstChartModule } from './sunburst-chart.module';
 import {
+  DtSunburstChartHoverData,
   DtSunburstChartNode,
   DtSunburstChartNodeSlice,
 } from './sunburst-chart.util';
@@ -353,6 +354,38 @@ describe('DtSunburstChart', () => {
         expect(actual.length).toBe(4);
       });
     });
+    describe('Hover events', () => {
+      beforeEach(function (): void {
+        rootComponent.series = sunburstChartMock;
+        fixture.detectChanges();
+      });
+      it('Should emit hover info when hover events start on a slice', () => {
+        const firstSegment = fixture.debugElement.query(
+          By.css(selectors.segment),
+        );
+        dispatchFakeEvent(firstSegment.nativeElement, 'mouseenter');
+        expect(rootComponent.hoverStart).toMatchObject({
+          name: sunburstChartMock[0].label,
+          color: '#fff29a',
+          isCurrent: false,
+          active: false,
+          value: 0.5,
+        });
+      });
+      it('Should emit hover info when hover events end on a slice', () => {
+        const firstSegment = fixture.debugElement.query(
+          By.css(selectors.segment),
+        );
+        dispatchFakeEvent(firstSegment.nativeElement, 'mouseleave');
+        expect(rootComponent.hoverEnd).toMatchObject({
+          name: sunburstChartMock[0].label,
+          color: '#fff29a',
+          isCurrent: false,
+          active: false,
+          value: 0.5,
+        });
+      });
+    });
   });
 
   describe('Overlay', () => {
@@ -425,6 +458,8 @@ describe('DtSunburstChart', () => {
       [selected]="selected"
       [valueDisplayMode]="valueDisplayMode"
       [noSelectionLabel]="noSelectionLabel"
+      (hoverStart)="hoverStart = $event"
+      (hoverEnd)="hoverEnd = $event"
     >
     </dt-sunburst-chart>
   `,
@@ -436,6 +471,9 @@ class TestApp {
   valueDisplayMode;
 
   @ViewChild(DtSunburstChart) sunburstChart: DtSunburstChart;
+
+  hoverStart: DtSunburstChartHoverData;
+  hoverEnd: DtSunburstChartHoverData;
 }
 
 /** Test component that contains an DtSunburstChart with overlay. */
@@ -447,6 +485,8 @@ class TestApp {
       [selected]="selected"
       [valueDisplayMode]="valueDisplayMode"
       [noSelectionLabel]="noSelectionLabel"
+      (hoverStart)="hoverStart = $event"
+      (hoverEnd)="hoverEnd = $event"
     >
       <ng-template dtSunburstChartOverlay let-tooltip>
         <div>
@@ -463,4 +503,7 @@ class TestWithOverlayApp {
   valueDisplayMode;
 
   @ViewChild(DtSunburstChart) sunburstChart: DtSunburstChart;
+
+  hoverStart: DtSunburstChartHoverData;
+  hoverEnd: DtSunburstChartHoverData;
 }

--- a/libs/barista-components/sunburst-chart/src/sunburst-chart.ts
+++ b/libs/barista-components/sunburst-chart/src/sunburst-chart.ts
@@ -47,6 +47,7 @@ import { takeUntil } from 'rxjs/operators';
 import { DtSunburstChartSegment } from './sunburst-chart-segment';
 import { DtSunburstChartOverlay } from './sunburst-chart.directive';
 import {
+  DtSunburstChartHoverData,
   DtSunburstChartNode,
   DtSunburstChartNodeSlice,
   DtSunburstChartTooltipData,
@@ -119,6 +120,12 @@ export class DtSunburstChart implements AfterContentInit, OnDestroy {
   @Output() selectedChange: EventEmitter<
     DtSunburstChartNode[]
   > = new EventEmitter();
+
+  /* Notifies the component container of the start of hover events per series, both in the pie and on the legend  */
+  @Output() hoverStart = new EventEmitter<DtSunburstChartHoverData>();
+
+  /* Notifies the component container of the end of hover events per series, both in the pie and on the legend */
+  @Output() hoverEnd = new EventEmitter<DtSunburstChartHoverData>();
 
   /** @internal Overlay template */
   @ContentChild(DtSunburstChartOverlay, { static: false, read: TemplateRef })
@@ -279,6 +286,35 @@ export class DtSunburstChart implements AfterContentInit, OnDestroy {
    */
   _sanitizeCSS(prop: string, value: string | number | DtColors): SafeStyle {
     return this._sanitizer.bypassSecurityTrustStyle(`${prop}: ${value}`);
+  }
+
+  /**
+   * @internal
+   * Handles the mouseEnter on a series slice.
+   */
+  onMouseEnter(slice: { data: DtSunburstChartTooltipData }): void {
+    this.hoverStart.emit(this._trackSunburstChartHoverEvents(slice.data));
+  }
+
+  /**
+   * @internal
+   * Handles the mouseLeave on a series slice.
+   */
+  onMouseLeave(slice: { data: DtSunburstChartTooltipData }): void {
+    this.hoverEnd.emit(this._trackSunburstChartHoverEvents(slice.data));
+  }
+
+  /** Returns an object with output data type for hover events on the legend */
+  private _trackSunburstChartHoverEvents(
+    slice: DtSunburstChartTooltipData,
+  ): DtSunburstChartHoverData {
+    return {
+      color: slice.color,
+      active: slice.active,
+      name: slice.label,
+      value: slice.valueRelative,
+      isCurrent: slice.isCurrent,
+    };
   }
 
   /** Calculates visible slices based on their state */

--- a/libs/barista-components/sunburst-chart/src/sunburst-chart.util.ts
+++ b/libs/barista-components/sunburst-chart/src/sunburst-chart.util.ts
@@ -110,6 +110,18 @@ export interface DtSunburstChartNodeSlice {
   showLabel: boolean;
 }
 
+/**
+ * Output type for hoverStart and hoverEnd attributes.
+ * Contains the main data of the hovered series.
+ */
+export type DtSunburstChartHoverData = {
+  name: string;
+  value: number;
+  color: string;
+  active: boolean;
+  isCurrent: boolean;
+};
+
 const SVG_SETTINGS = {
   ringWidthRadius: 32,
   borderWidthRadius: 16,


### PR DESCRIPTION
#### Type of PR
Feature (non-breaking change which adds functionality)

#### Checklist

- [X] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

#### Description

This PR includes functionality to enable the tracking of hover events on the sunburst chart. This component now presents two output events, **hoverStart** and **hoverEnd**, which emit the data of the series the user has hovered over.

![image](https://user-images.githubusercontent.com/59490817/117810416-a718f500-b25f-11eb-90c3-390cbac7f7b2.png)
