### PR TITLE
fix(stacked-series-chart): Fixes the initial display of the Y axis.

### DIFF
--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.ts
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.ts
@@ -42,7 +42,7 @@ import {
 import { formatCount } from '@dynatrace/barista-components/formatters';
 import { DtColors, DtTheme } from '@dynatrace/barista-components/theming';
 import { scaleLinear } from 'd3-scale';
-import { merge, Subject } from 'rxjs';
+import { merge, ReplaySubject, Subject } from 'rxjs';
 import { first, tap, switchMapTo, takeUntil } from 'rxjs/operators';
 import { DtStackedSeriesChartNode } from '..';
 import { DtStackedSeriesChartOverlay } from './stacked-series-chart-overlay.directive';
@@ -330,7 +330,7 @@ export class DtStackedSeriesChart implements OnDestroy, OnInit {
   _tracks: DtStackedSeriesChartFilledSeries[] = [];
 
   /** Indicates when ticks should be recalculated */
-  private _shouldUpdateTicks = new Subject();
+  private _shouldUpdateTicks = new ReplaySubject();
 
   /** Subject to be called upon component destroy to remove pending subscriptions */
   private readonly _destroy$ = new Subject<void>();


### PR DESCRIPTION
### <strong>Pull Request</strong>

The Y axis in a stacked series chart is not correctly rendered when the chart is loaded with `[visibleValueAxis]="true"`

![image](https://user-images.githubusercontent.com/27827642/119699051-168f0700-be52-11eb-83c9-7c6589d0340c.png)

The rendering of this Y axis is done based on a `Subject` that is triggered on `set` functions. However, the subscription to the `Subject` is done after setting all parameters, so the rendering is not performed.

This PR consists on changing the type to `ReplaySubject`, so that all events happening before the subscription will be also considered and the Y axis will be correctly displayed.

![image](https://user-images.githubusercontent.com/27827642/119699970-00ce1180-be53-11eb-8246-2e6c2f4263ba.png)

#### Type of PR

Bugfix (non-breaking change which fixes an issue)
