### PR TITLE
fix(filter-field): Fixing default checked options in multiselect.

### DIFF
--- a/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
@@ -32,6 +32,8 @@ import {
   multiSelectApply,
   multiSelectPanel,
   switchToSecondDatasource,
+  setupMultiselectEditScenario,
+  options,
 } from './filter-field.po';
 import { Selector } from 'testcafe';
 import { resetWindowSizeToDefault, waitForAngular } from '../../utils';
@@ -404,6 +406,22 @@ test('should choose a multiselect node with the mouse and submit the correct val
     .eql(1)
     .expect(tags[0])
     .match(/SeasoningMustard/);
+});
+
+test('should keep selected an option as it was previously set by default', async (testController: TestController) => {
+  // Switch to second datasource.
+  await testController
+    .click(setupMultiselectEditScenario)
+    // Wait for the filterfield to catch up.
+    .wait(500);
+
+  const tag = await filterTags();
+
+  await testController.click(tag);
+
+  const currentOptionsCount = await options().find('input:checked').count;
+
+  await testController.expect(currentOptionsCount).eql(1);
 });
 
 test('should not apply an empty multiselect node with the mouse', async (testController: TestController) => {

--- a/apps/components-e2e/src/components/filter-field/filter-field.html
+++ b/apps/components-e2e/src/components/filter-field/filter-field.html
@@ -21,3 +21,9 @@
 <button id="setupSecondTestScenario" (click)="setupSecondTestScenario()">
   setupSecondTestScenario
 </button>
+<button
+  id="setupMultiselectEditScenario"
+  (click)="setupMultiselectEditScenario()"
+>
+  setupMultiselectEditScenario
+</button>

--- a/apps/components-e2e/src/components/filter-field/filter-field.po.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.po.ts
@@ -40,6 +40,9 @@ export const input = Selector('input');
 export const switchToFirstDatasource = Selector('#switchToFirstDatasource');
 export const switchToSecondDatasource = Selector('#switchToSecondDatasource');
 export const setupSecondTestScenario = Selector('#setupSecondTestScenario');
+export const setupMultiselectEditScenario = Selector(
+  '#setupMultiselectEditScenario',
+);
 export function clickOption(
   nth: number,
   testController?: TestController,

--- a/apps/components-e2e/src/components/filter-field/filter-field.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.ts
@@ -80,6 +80,16 @@ export class DtE2EFilterField implements OnDestroy {
       });
   }
 
+  setupMultiselectEditScenario(): void {
+    this._dataSource = new DtFilterFieldDefaultDataSource(DATA[1]);
+    const multiselectNoneFilter = [
+      DATA[1].autocomplete[3],
+      (DATA[1].autocomplete[3] as any).multiOptions![0],
+    ];
+
+    this._filterfield.filters = [multiselectNoneFilter];
+  }
+
   formSubmitted = false;
   onSubmit(event: Event): void {
     event.preventDefault();

--- a/libs/barista-components/filter-field/src/filter-field-util.ts
+++ b/libs/barista-components/filter-field/src/filter-field-util.ts
@@ -424,6 +424,9 @@ export function findFilterValuesForSources<T>(
         if (isLastSource) {
           return null;
         }
+        if (isDtMultiSelectDef(def)) {
+          applyDtOptionIds(def);
+        }
         if (isAsyncDtOptionDef(def) || isPartialDtOptionDef(def)) {
           const asyncDef = asyncDefs.get(def);
           if (asyncDef) {

--- a/libs/barista-components/filter-field/src/filter-field.ts
+++ b/libs/barista-components/filter-field/src/filter-field.ts
@@ -1328,6 +1328,10 @@ export class DtFilterField<T = any>
       this._updateAutocompleteOptionsOrGroups();
       this._updateDefaultSearchDef();
       this._emitCurrentFilterChanges([submittedOption], []);
+
+      if (isDtMultiSelectDef(submittedOption)) {
+        this._multiSelect._setInitialSelection([]);
+      }
     } else {
       this._peekCurrentFilterValues().push(submittedOption);
       this._switchToRootDef(true);


### PR DESCRIPTION
### Pull Request
Bugfix (non-breaking change which fixes an issue) 

### Main Goal
Keep default filtered options checked once the user opens the multiselect panel

### Issue
https://user-images.githubusercontent.com/20814335/119834909-a55a5d00-bf00-11eb-9203-04b280505cee.mov

### Fix
https://user-images.githubusercontent.com/20814335/119834848-9a9fc800-bf00-11eb-99d2-185702c89d20.mov

### In this PR
- Set `uid` value for multiselect options in order to properly check if this one is selected
- Updating e2e for checking fixed behaviour