### PR TITLE
feat(stacked-series-chart): Show highest value in Y axis.

### DIFF
--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.ts
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.ts
@@ -144,7 +144,9 @@ export class DtStackedSeriesChart implements OnDestroy, OnInit {
   /** Max value in the chart */
   @Input()
   get max(): number | undefined {
-    return this._max !== undefined ? this._max : getTotalMaxValue(this.series);
+    return this._max !== undefined
+      ? this._max
+      : getTotalMaxValue(this._filledSeries);
   }
   set max(value: number | undefined) {
     if (value !== this._max) {
@@ -436,6 +438,7 @@ export class DtStackedSeriesChart implements OnDestroy, OnInit {
       slice.visible = !slice.visible;
       updateNodesVisibility(this._filledSeries, this._legends);
 
+      this._updateTicks();
       this._render();
     }
   }
@@ -596,12 +599,17 @@ export class DtStackedSeriesChart implements OnDestroy, OnInit {
             0.6 +
           1.5,
         relative:
-          (this._axisTicks.slice(-1)[0].valueRelative.toString().length + 1) *
+          // `valueRelative` needs to be formatted to a percentage scale (0-100)
+          // in order to compute the axis size
+          ((this._axisTicks.slice(-1)[0].valueRelative * 100).toString()
+            .length +
+            1) *
             0.6 +
           1.5,
       };
     }
   }
+
   /** Return the width in px of the longest label on the label axis */
   private _getLongestLabelWidth(): number {
     return this.labels.reduce((labelCount: number, label: ElementRef) => {

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.util.spec.ts
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.util.spec.ts
@@ -573,9 +573,15 @@ describe('StackedSeriesChart util', () => {
   });
 
   describe('getTotalMaxValue', () => {
-    it("should return sum of values for node's nodes", () => {
-      const expected = 5;
-      const actual = getTotalMaxValue(series);
+    it("should return rounded sum of values for node's nodes higher to the max value", () => {
+      const legendList = getLegends(stackedSeriesChartDemoDataShows);
+      const seriesList = fillSeries(
+        stackedSeriesChartDemoDataShows,
+        legendList,
+      );
+
+      const expected = 200;
+      const actual = getTotalMaxValue(seriesList);
 
       expect(actual).toEqual(expected);
     });

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.util.ts
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.util.ts
@@ -309,12 +309,31 @@ const getValueForFilled = (nodes: DtStackedSeriesChartTooltipData[]): number =>
   nodes.reduce((total, p) => total + (p?.origin.value ?? 0), 0);
 
 /**
- * @description Get max of all bars sum of values
+ * @description Get sum of visible values for filled nodes
+ *
+ * @param nodes whole set of filled nodes
+ *
+ * @returns sum of visible nodes values
+ */
+const getVisibleValueForFilled = (
+  nodes: DtStackedSeriesChartTooltipData[],
+): number =>
+  nodes.reduce((total, p) => total + (p.visible ? p?.origin.value ?? 0 : 0), 0);
+
+/**
+ * @description Get max of all visible bars sum of values rounded up to the next scaled largest integer.
+ * E.g.: max=3.8 returns 4, max=67 returns 100.
  *
  * @param series whole set of filled series
  *
- * @returns sum of series values
+ * @returns next scaled largest integer of the max bars sum
  */
 export const getTotalMaxValue = (
-  series: DtStackedSeriesChartSeries[],
-): number => Math.max(...series.map((s) => getValue(s.nodes)));
+  series: DtStackedSeriesChartFilledSeries[],
+): number => {
+  const max = Math.max(...series.map((s) => getVisibleValueForFilled(s.nodes)));
+  const length = Math.ceil(max).toString().length;
+  const power = Math.pow(10, length - 1);
+
+  return Math.ceil(max / power) * power;
+};


### PR DESCRIPTION
### <strong>Pull Request</strong>

Implementation of the APM-295667for the stacked series chart.

**1. Displaying a higher value in the Y axis close to the highest series value. Moreover, adjust the Y axis for the visible nodes when the user clicks on an element of the legend in order to hide it**

Before
![image](https://user-images.githubusercontent.com/27827642/121889967-1fb91880-cd1a-11eb-8aa5-2089de9471ae.png)

After
https://gyazo.com/8c703c68b5915e40a8aefffa8c080d32

**2, Fixing the Y axis display when `displayMode = 'percent'`**

Before
![image](https://user-images.githubusercontent.com/27827642/121890972-3a3fc180-cd1b-11eb-8092-485ec9a73059.png)

After
![image](https://user-images.githubusercontent.com/27827642/121890989-4035a280-cd1b-11eb-87ce-d32acc6ee93f.png)


#### Type of PR

Feature (non-breaking change which adds functionality)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
