### PR TITLE
fix(quick-filter): Trigger resize event when sidebar open state changes.

### DIFF
--- a/libs/barista-components/chart/src/chart.ts
+++ b/libs/barista-components/chart/src/chart.ts
@@ -194,7 +194,8 @@ class TooltipState {
   ],
 })
 export class DtChart
-  implements AfterViewInit, OnDestroy, OnChanges, AfterContentInit {
+  implements AfterViewInit, OnDestroy, OnChanges, AfterContentInit
+{
   /** Options to configure the chart. */
   @Input()
   get options(): Observable<DtChartOptions> | DtChartOptions {
@@ -355,8 +356,8 @@ export class DtChart
     );
   }
 
-  private readonly _heatfieldActiveChanges: Observable<DtChartHeatfieldActiveChange> = defer(
-    () => {
+  private readonly _heatfieldActiveChanges: Observable<DtChartHeatfieldActiveChange> =
+    defer(() => {
       if (this._heatfields) {
         return merge<DtChartHeatfieldActiveChange>(
           ...this._heatfields.map((heatfield) => heatfield.activeChange),
@@ -367,8 +368,7 @@ export class DtChart
         take(1),
         switchMap(() => this._heatfieldActiveChanges),
       );
-    },
-  );
+    });
 
   constructor(
     private _changeDetectorRef: ChangeDetectorRef,
@@ -474,16 +474,15 @@ export class DtChart
 
     this._heatfieldSelectionModelSubscription.unsubscribe();
     this._heatfieldSelectionModel = new SelectionModel<DtChartHeatfield>();
-    this._heatfieldSelectionModelSubscription = this._heatfieldSelectionModel.changed.subscribe(
-      (event) => {
+    this._heatfieldSelectionModelSubscription =
+      this._heatfieldSelectionModel.changed.subscribe((event) => {
         event.added.forEach((heatfield) => {
           heatfield.active = true;
         });
         event.removed.forEach((heatfield) => {
           heatfield.active = false;
         });
-      },
-    );
+      });
   }
 
   ngOnDestroy(): void {
@@ -669,9 +668,10 @@ export class DtChart
   private _notifyAfterRender(): void {
     this._ngZone.runOutsideAngular(() => {
       this._afterRender.next();
-      const plotBackground = this._container.nativeElement.querySelector<SVGRectElement>(
-        HIGHCHARTS_PLOT_BACKGROUND,
-      );
+      const plotBackground =
+        this._container.nativeElement.querySelector<SVGRectElement>(
+          HIGHCHARTS_PLOT_BACKGROUND,
+        );
 
       // set the offset of the plotBackground in relation to the chart
       this._setPlotBackgroundOffset(plotBackground);

--- a/libs/barista-components/quick-filter/src/quick-filter.html
+++ b/libs/barista-components/quick-filter/src/quick-filter.html
@@ -11,7 +11,11 @@
   class="dt-quick-filter-drawer"
   [class.dt-quick-filter-detail]="_isDetailView$ | async"
 >
-  <dt-drawer #drawer [opened]="_sidebarOpened">
+  <dt-drawer
+    #drawer
+    [opened]="_sidebarOpened"
+    (openChange)="_onOpenChange($event)"
+  >
     <button
       *ngIf="drawer.opened"
       class="dt-quick-filter-close"

--- a/libs/barista-components/quick-filter/src/quick-filter.module.ts
+++ b/libs/barista-components/quick-filter/src/quick-filter.module.ts
@@ -19,6 +19,10 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { DtButtonModule } from '@dynatrace/barista-components/button';
 import { DtCheckboxModule } from '@dynatrace/barista-components/checkbox';
+import {
+  DtTriggerableViewportResizer,
+  DtViewportResizer,
+} from '@dynatrace/barista-components/core';
 import { DtDrawerModule } from '@dynatrace/barista-components/drawer';
 import { DtFilterFieldModule } from '@dynatrace/barista-components/filter-field';
 import { DtIconModule } from '@dynatrace/barista-components/icon';
@@ -45,5 +49,8 @@ const COMPONENTS = [DtQuickFilter, DtQuickFilterSubTitle, DtQuickFilterTitle];
   ],
   exports: COMPONENTS,
   declarations: [...COMPONENTS, DtQuickFilterGroup],
+  providers: [
+    { provide: DtViewportResizer, useClass: DtTriggerableViewportResizer },
+  ],
 })
 export class DtQuickFilterModule {}

--- a/libs/barista-components/quick-filter/src/quick-filter.spec.ts
+++ b/libs/barista-components/quick-filter/src/quick-filter.spec.ts
@@ -28,6 +28,10 @@ import {
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { DtCheckbox } from '@dynatrace/barista-components/checkbox';
+import {
+  DtTriggerableViewportResizer,
+  DtViewportResizer,
+} from '@dynatrace/barista-components/core';
 import { DtDrawer } from '@dynatrace/barista-components/drawer';
 import { DtFilterField } from '@dynatrace/barista-components/filter-field';
 import { DtIconModule } from '@dynatrace/barista-components/icon';
@@ -50,6 +54,7 @@ describe('dt-quick-filter', () => {
   let instanceDebugElement: DebugElement;
   let quickFilterInstance: DtQuickFilter;
   let zone: MockNgZone;
+  let viewportResizer: DtTriggerableViewportResizer;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -73,6 +78,13 @@ describe('dt-quick-filter', () => {
           },
         },
         { provide: NgZone, useFactory: () => (zone = new MockNgZone()) },
+        {
+          provide: DtViewportResizer,
+          useFactory: () =>
+            (viewportResizer = new DtTriggerableViewportResizer(
+              <DtViewportResizer>(<unknown>undefined),
+            )),
+        },
       ],
     });
     TestBed.compileComponents();
@@ -85,9 +97,8 @@ describe('dt-quick-filter', () => {
       instanceDebugElement = fixture.debugElement.query(
         By.directive(DtQuickFilter),
       );
-      quickFilterInstance = instanceDebugElement.injector.get<DtQuickFilter>(
-        DtQuickFilter,
-      );
+      quickFilterInstance =
+        instanceDebugElement.injector.get<DtQuickFilter>(DtQuickFilter);
     });
 
     it('should have an empty filters array if no dataSource is set', () => {
@@ -107,16 +118,14 @@ describe('dt-quick-filter', () => {
       instanceDebugElement = fixture.debugElement.query(
         By.directive(DtQuickFilter),
       );
-      quickFilterInstance = instanceDebugElement.injector.get<DtQuickFilter>(
-        DtQuickFilter,
-      );
+      quickFilterInstance =
+        instanceDebugElement.injector.get<DtQuickFilter>(DtQuickFilter);
 
       filterFieldDebugElement = fixture.debugElement.query(
         By.directive(DtFilterField),
       );
-      filterFieldInstance = filterFieldDebugElement.injector.get<DtFilterField>(
-        DtFilterField,
-      );
+      filterFieldInstance =
+        filterFieldDebugElement.injector.get<DtFilterField>(DtFilterField);
       drawerDebugElement = fixture.debugElement.query(By.directive(DtDrawer));
       drawerInstance = drawerDebugElement.injector.get<DtDrawer>(DtDrawer);
     });
@@ -143,12 +152,10 @@ describe('dt-quick-filter', () => {
 
       fixture.detectChanges();
 
-      fixture.componentInstance._dataSource = new DtQuickFilterDefaultDataSource(
-        FILTER_FIELD_TEST_DATA,
-        {
+      fixture.componentInstance._dataSource =
+        new DtQuickFilterDefaultDataSource(FILTER_FIELD_TEST_DATA, {
           showInSidebar: (node) => node.name !== 'Not in Quickfilter',
-        },
-      );
+        });
       fixture.detectChanges();
       groups = getGroupHeadlines(fixture.debugElement);
 
@@ -181,9 +188,8 @@ describe('dt-quick-filter', () => {
 
     it('should propagate currentFilterChanges event when emitted on the filter field', fakeAsync(() => {
       const spy = jest.fn();
-      const subscription = quickFilterInstance.currentFilterChanges.subscribe(
-        spy,
-      );
+      const subscription =
+        quickFilterInstance.currentFilterChanges.subscribe(spy);
       zone.simulateZoneExit();
 
       filterFieldInstance.currentFilterChanges.emit();
@@ -202,6 +208,20 @@ describe('dt-quick-filter', () => {
 
       expect(spy).toHaveBeenCalledTimes(1);
       subscription.unsubscribe();
+    }));
+
+    it('should trigger resizer when openChange event occurs', fakeAsync(() => {
+      const resizerSpy = jest.fn();
+      const resizerSubscription = viewportResizer
+        .change()
+        .subscribe(resizerSpy);
+      zone.simulateZoneExit();
+
+      drawerInstance.openChange.emit(true);
+      flush();
+
+      expect(resizerSpy).toHaveBeenCalledTimes(1);
+      resizerSubscription.unsubscribe();
     }));
 
     it('should propagate inputChange event when emitted on the filter field', fakeAsync(() => {
@@ -300,13 +320,17 @@ describe('dt-quick-filter', () => {
 
     it('should have the appropriate texts', () => {
       expect(
-        (groupDebugElement.query(By.css('.dt-quick-filter-show-more-text'))
-          .nativeElement as HTMLParagraphElement).textContent,
+        (
+          groupDebugElement.query(By.css('.dt-quick-filter-show-more-text'))
+            .nativeElement as HTMLParagraphElement
+        ).textContent,
       ).toEqual(' There are 2 States available ');
 
       expect(
-        (groupDebugElement.query(By.css('.dt-show-more'))
-          .nativeElement as HTMLButtonElement).textContent,
+        (
+          groupDebugElement.query(By.css('.dt-show-more'))
+            .nativeElement as HTMLButtonElement
+        ).textContent,
       ).toEqual('View more');
     });
   });

--- a/libs/barista-components/quick-filter/src/quick-filter.ts
+++ b/libs/barista-components/quick-filter/src/quick-filter.ts
@@ -62,6 +62,10 @@ import {
 import { createQuickFilterStore, QuickFilterState } from './state/store';
 import { DtDrawer } from '@dynatrace/barista-components/drawer';
 import { coerceBooleanProperty, BooleanInput } from '@angular/cdk/coercion';
+import {
+  DtTriggerableViewportResizer,
+  DtViewportResizer,
+} from '@dynatrace/barista-components/core';
 
 /** Directive that is used to place a title inside the quick filters sidebar */
 @Directive({
@@ -94,7 +98,7 @@ export class DtQuickFilterChangeEvent<T> extends DtFilterFieldChangeEvent<T> {}
  * It contains the partially added or removed filters of the filter field.
  */
 export class DtQuickFilterCurrentFilterChangeEvent<
-  T
+  T,
 > extends DtFilterFieldCurrentFilterChangeEvent<T> {}
 
 @Component({
@@ -257,6 +261,7 @@ export class DtQuickFilter<T = any> implements AfterViewInit, OnDestroy {
   constructor(
     private _zone: NgZone,
     private _elementRef: ElementRef<HTMLElement>,
+    private _viewportResizer: DtViewportResizer,
   ) {}
 
   /** Angular life-cycle hook that will be called after the view is initialized */
@@ -353,6 +358,12 @@ export class DtQuickFilter<T = any> implements AfterViewInit, OnDestroy {
     // Filter only autocomplete filters as we don't use free-text and range in the quick-filter
     this._store.dispatch(setFilters(this._getFilteredValues()));
     this.filterChanges.emit(change);
+  }
+
+  _onOpenChange(_event: boolean): void {
+    if (this._viewportResizer instanceof DtTriggerableViewportResizer) {
+      (<DtTriggerableViewportResizer>this._viewportResizer).trigger();
+    }
   }
 
   /** Get the filter Values from the Filter Field with only the displayable autocompletes */

--- a/tslint.json
+++ b/tslint.json
@@ -27,13 +27,7 @@
     "no-var-keyword": true,
     "member-access": [true, "no-public"],
     "no-debugger": true,
-    "one-line": [
-      true,
-      "check-catch",
-      "check-else",
-      "check-open-brace",
-      "check-whitespace"
-    ],
+    "one-line": [true, "check-catch", "check-else", "check-whitespace"],
     "variable-name": [
       true,
       "ban-keywords",


### PR DESCRIPTION
Provide a triggerable viewport resizer and use it in the quick filter (triggered on 'openChange' event). This means the content child of quick filter (e.g. chart) can receive the resize event.

Fixes APM-256772.

### <strong>Pull Request</strong>

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
