### PR TITLE
fix(filter-field): Multiselect keyboard interaction not working correctly

### DIFF
--- a/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
@@ -340,11 +340,11 @@ test('should choose a multiselect node with the keyboard and submit the correct 
   await testController
     // Select the multiselect node
     .pressKey('down down down enter')
-    // Wait for a certain amout fo time to let the filterfield refresh
+    // Wait for a certain amount of time to let the filterfield refresh
     .wait(250)
     // Select the desired option
     .pressKey('down space enter')
-    // Wait for a certain amout fo time to let the filterfield refresh
+    // Wait for a certain amount of time to let the filterfield refresh
     .wait(250);
 
   const tags = await getFilterfieldTags();

--- a/libs/barista-components/filter-field/src/filter-field-multi-select/filter-field-multi-select-trigger.ts
+++ b/libs/barista-components/filter-field/src/filter-field-multi-select/filter-field-multi-select-trigger.ts
@@ -55,7 +55,8 @@ import { DtFilterFieldMultiSelect } from './filter-field-multi-select';
 })
 export class DtFilterFieldMultiSelectTrigger<T>
   extends DtFilterFieldElementTrigger<DtFilterFieldMultiSelect<T>>
-  implements OnDestroy {
+  implements OnDestroy
+{
   /** The filter-field multiSelect panel to be attached to this trigger. */
   @Input('dtFilterFieldMultiSelect')
   get element(): DtFilterFieldMultiSelect<T> {
@@ -106,7 +107,6 @@ export class DtFilterFieldMultiSelectTrigger<T>
   openPanel(): void {
     if (!this.element._isOpen) {
       super.openPanel();
-      this._element.focus();
     }
   }
 

--- a/libs/barista-components/filter-field/src/filter-field-multi-select/filter-field-multi-select.ts
+++ b/libs/barista-components/filter-field/src/filter-field-multi-select/filter-field-multi-select.ts
@@ -63,7 +63,8 @@ export class DtFilterFieldMultiSelectSubmittedEvent<T> {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DtFilterFieldMultiSelect<T>
-  implements DtFilterFieldElement<T>, AfterViewInit {
+  implements DtFilterFieldElement<T>, AfterViewInit
+{
   /**
    * Whether the first option should be highlighted when the multi-select panel is opened.
    * Can be configured globally through the `DT_MULTI_SELECT_DEFAULT_OPTIONS` token.
@@ -190,9 +191,11 @@ export class DtFilterFieldMultiSelect<T>
         takeUntil(this._destroy$),
       )
       .subscribe((option) => {
-        this._ngZone?.run(() => {
-          this._keyManager.setActiveItem(option);
-        });
+        if (!option.disabled) {
+          this._ngZone?.run(() => {
+            this._keyManager.setActiveItem(option);
+          });
+        }
       });
   }
 
@@ -330,6 +333,9 @@ export class DtFilterFieldMultiSelect<T>
   }
 
   focus(): void {
-    this._keyManager.setActiveItem(this._options.first);
+    const firstOption = this._options.find((option) => !option.disabled);
+    if (firstOption) {
+      this._keyManager.setActiveItem(firstOption);
+    }
   }
 }


### PR DESCRIPTION
### <strong>Pull Request</strong>

This PR consist on fixing the keyboard interaction for the filter of type multiselect, described in APM-307773. To sumarize, it fixes the 4 following issues when interacting with multiselect:

1. The filter input adds an space when the user is selecting an option by using the space bar

Before: https://gyazo.com/d20a0570729b61498c736040ac345a70
After: https://gyazo.com/0386b9104c5cc92879bf0e445e35227c

2. The filter keeps the focus on the first element, even if it is disabled, and making selectable when the user presses space

Before: https://gyazo.com/ab2287e2e91e859bf038d1d83a412a65
After: https://gyazo.com/d73b8e37410663cb299e6d8c08b63de9

3. The user can select a disabled option if he/she moves the pointer to the option and presses space bar

Before: https://gyazo.com/6c484ab8afdc290575604ab5c0c696cd
After: https://gyazo.com/f038646aafea31d6ec274e5cc8f2a906

4. The filter doesn't focus on the first option when the suggestions are async

Before: https://gyazo.com/46e1dfc78960d0b694258489994a0fe1
After: https://gyazo.com/d279cc39a7db382ecceac54dc3cf55ba

#### Type of PR

Bugfix (non-breaking change which fixes an issue)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
