### PR TITLE
chore(filter-field): Fixes an issue with the multi-select example within barista app.

### DIFF
--- a/libs/examples/src/filter-field/index.ts
+++ b/libs/examples/src/filter-field/index.ts
@@ -28,3 +28,4 @@ export * from './filter-field-programmatic-filters-example/filter-field-programm
 export * from './filter-field-readonly-non-editable-tags-example/filter-field-readonly-non-editable-tags-example';
 export * from './filter-field-unique-example/filter-field-unique-example';
 export * from './filter-field-validator-example/filter-field-validator-example';
+export * from './filter-field-multi-select-example/filter-field-multi-select-example';


### PR DESCRIPTION
Example was missing from the barrel export, which made it hard for barista to  instantiate it at runtime. 

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
