### PR TITLE
fix(filter-field): Multiselect with programmatically defined filters is not stable

### DIFF
--- a/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
@@ -421,7 +421,7 @@ test('should keep selected an option as it was previously set by default', async
 
   const currentOptionsCount = await options().find('input:checked').count;
 
-  await testController.expect(currentOptionsCount).eql(1);
+  await testController.expect(currentOptionsCount).eql(2);
 });
 
 test('should not apply an empty multiselect node with the mouse', async (testController: TestController) => {

--- a/apps/components-e2e/src/components/filter-field/filter-field.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.ts
@@ -84,7 +84,8 @@ export class DtE2EFilterField implements OnDestroy {
     this._dataSource = new DtFilterFieldDefaultDataSource(DATA[1]);
     const multiselectNoneFilter = [
       DATA[1].autocomplete[3],
-      (DATA[1].autocomplete[3] as any).multiOptions![0],
+      { name: 'None' },
+      { name: 'Homemade', options: [{ name: 'Ketchup' }] },
     ];
 
     this._filterfield.filters = [multiselectNoneFilter];


### PR DESCRIPTION
### <strong>Pull Request</strong>

This PR fixes the bug in the filter field described in [APM-317632](https://dev-jira.dynatrace.org/browse/APM-317632). For a multiselect filter with grouped suggestions, the definition of pre-selected values programmatically was not working properly.

For example, given the following filter with groupings:
![imagen](https://user-images.githubusercontent.com/27827642/129924219-7773281e-e637-478e-8e9a-71c33619db2a.png)

The user should be able to define pre-selected values:
```
  filters = [
    [
      { name: 'Months', multiOptions: MULTI_SELECT_DATA.autocomplete[1].multiOptions },
      { name: 'All' },
      { name: 'Winter', options: [ { name: 'January' }, { name: 'February' } ] },
      { name: 'Spring', options: [ { name: 'April' } ] },
    ]
  ];
```

Before the fix the component was not selecting the values inside the groups: https://gyazo.com/c64f8ac1f60426608e51865842f63822

After the fix, those values are correctly selected: https://gyazo.com/fdb8fecfd0e097042d16904e0048865d

#### Type of PR

Bugfix (non-breaking change which fixes an issue)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
