### PR TITLE
fix(filter-field): Fix multiselect apply button disabled

### DIFF
--- a/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
@@ -473,3 +473,27 @@ test('should close the multiselect when blurring the filter field mid filter, re
     .expect(multiSelectPanel.exists)
     .notOk();
 });
+
+test('should be able to apply without editing any selection when an option was previously selected', async (testController: TestController) => {
+  // Switch to second datasource.
+  await testController
+    .click(setupMultiselectEditScenario)
+    // Wait for the filterfield to catch up.
+    .wait(500);
+
+  const tag = await filterTags();
+
+  await testController
+    // Click on tag to open the panel
+    .click(tag)
+    .wait(250)
+    // Panel should be open
+    .expect(multiSelectPanel.exists)
+    .ok()
+    // Click on apply button
+    .click(multiSelectApply)
+    .wait(250)
+    // Panel should be closed
+    .expect(multiSelectPanel.exists)
+    .notOk();
+});

--- a/libs/barista-components/filter-field/src/filter-field-multi-select/filter-field-multi-select.ts
+++ b/libs/barista-components/filter-field/src/filter-field-multi-select/filter-field-multi-select.ts
@@ -36,7 +36,6 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { DtOption } from '@dynatrace/barista-components/core';
-import { xor } from 'lodash-es';
 import { merge, Subject } from 'rxjs';
 import { startWith, switchMap, takeUntil } from 'rxjs/operators';
 import { DtFilterFieldElement } from '../shared/filter-field-element';
@@ -292,10 +291,7 @@ export class DtFilterFieldMultiSelect<T>
   }
 
   private _checkApplyDisable(): void {
-    this._applyDisabled =
-      this._currentSelection.size === 0 ||
-      xor(Array.from(this._currentSelection.values()), this._initialSelection)
-        .length === 0;
+    this._applyDisabled = this._currentSelection.size === 0;
   }
 
   private _filterOptions(): void {

--- a/libs/barista-components/filter-field/src/filter-field-multi-select/filter-field-with-multiselect.spec.ts
+++ b/libs/barista-components/filter-field/src/filter-field-multi-select/filter-field-with-multiselect.spec.ts
@@ -564,6 +564,36 @@ describe('DtFilterField', () => {
         expect(filterTags[0].value).toBe('Ketchup, Mustard');
       });
 
+      it('should reset the multiSelect filter when not changing anything and clicking on apply', () => {
+        const tags = fixture.debugElement.queryAll(
+          By.css('.dt-filter-field-tag-label'),
+        );
+        tags[0].nativeElement.click();
+        advanceFilterfieldCycle();
+
+        // Expect the multiSelect filter to be open
+        let multiSelect = getMultiSelect(overlayContainerElement);
+        expect(multiSelect.length).toBe(1);
+
+        // Click the apply button
+        const applyButton = getMultiselectApplyButton(
+          overlayContainerElement,
+        )[0];
+        applyButton.click();
+        fixture.detectChanges();
+
+        // Expect the multiSelect filter to be closed again
+        multiSelect = getMultiSelect(overlayContainerElement);
+        expect(multiSelect.length).toBe(0);
+
+        // Read the filters again and make expectations
+        const filterTags = getFilterTags(fixture);
+
+        expect(filterTags[0].key).toBe('Seasoning');
+        expect(filterTags[0].separator).toBe(':');
+        expect(filterTags[0].value).toBe('Ketchup, Mustard');
+      });
+
       it('should make the edit to the first tag', () => {
         const tags = fixture.debugElement.queryAll(
           By.css('.dt-filter-field-tag-label'),


### PR DESCRIPTION
### <strong>Pull Request</strong>

This PR fixes the bug described in APM-311774. For a multiselect filter, when trying to modify the values of the filter, as long as there are any values already checked, the "Apply" button is disabled if the user doesn't make any change (select or unselect items).

The fix consist on enabling the button when editing, even if the user doesn't make any change. The button will be disabled only in the case there are no items selected.

Before: https://gyazo.com/81520da20f273237f704f6c19fa24272
After: https://gyazo.com/bd69ee33b3f88fd4ba67c6b92cb764c0

#### Type of PR

Bugfix (non-breaking change which fixes an issue)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
