### PR TITLE
Fix/filter field free text edit mode

### DIFF
--- a/libs/barista-components/filter-field/src/filter-field.spec.ts
+++ b/libs/barista-components/filter-field/src/filter-field.spec.ts
@@ -872,6 +872,7 @@ describe('DtFilterField', () => {
       options[0].click();
 
       tick();
+      fixture.detectChanges();
 
       const tags = getFilterTags(fixture);
       tags[0].removeButton.click();
@@ -1760,34 +1761,10 @@ describe('DtFilterField', () => {
       // enter editmode
       freeTextLabel.click();
       advanceFilterfieldCycle();
-
       filterField.focus();
       advanceFilterfieldCycle();
 
-      expect(spy).not.toHaveBeenCalled();
-
-      subscription.unsubscribe();
-    }));
-
-    it('should not emit the current filter change event when the edit button is clicked', fakeAsync(() => {
-      const freeTextFilter = [
-        TEST_DATA_EDITMODE.autocomplete[2],
-        'Custom free text',
-      ];
-      filterField.filters = [autocompleteFilter, freeTextFilter];
-      fixture.detectChanges();
-
-      const tags = getFilterTags(fixture);
-      const { label: freeTextLabel } = getTagButtons(tags[0]);
-      const spy = jest.fn();
-      const subscription = filterField.currentFilterChanges.subscribe(spy);
-
-      // enter editmode
-      freeTextLabel.click();
-      advanceFilterfieldCycle();
-
-      filterField.focus();
-      advanceFilterfieldCycle();
+      tick();
 
       expect(spy).not.toHaveBeenCalled();
 

--- a/libs/barista-components/filter-field/src/filter-field.spec.ts
+++ b/libs/barista-components/filter-field/src/filter-field.spec.ts
@@ -1743,6 +1743,56 @@ describe('DtFilterField', () => {
       const tags = getFilterTags(fixture);
       expect(tags.length).toBe(1);
     });
+
+    it('should not emit the current filter change event when the edit button is clicked', fakeAsync(() => {
+      const freeTextFilter = [
+        TEST_DATA_EDITMODE.autocomplete[2],
+        'Custom free text',
+      ];
+      filterField.filters = [autocompleteFilter, freeTextFilter];
+      fixture.detectChanges();
+
+      const tags = getFilterTags(fixture);
+      const { label: freeTextLabel } = getTagButtons(tags[0]);
+      const spy = jest.fn();
+      const subscription = filterField.currentFilterChanges.subscribe(spy);
+
+      // enter editmode
+      freeTextLabel.click();
+      advanceFilterfieldCycle();
+
+      filterField.focus();
+      advanceFilterfieldCycle();
+
+      expect(spy).not.toHaveBeenCalled();
+
+      subscription.unsubscribe();
+    }));
+
+    it('should not emit the current filter change event when the edit button is clicked', fakeAsync(() => {
+      const freeTextFilter = [
+        TEST_DATA_EDITMODE.autocomplete[2],
+        'Custom free text',
+      ];
+      filterField.filters = [autocompleteFilter, freeTextFilter];
+      fixture.detectChanges();
+
+      const tags = getFilterTags(fixture);
+      const { label: freeTextLabel } = getTagButtons(tags[0]);
+      const spy = jest.fn();
+      const subscription = filterField.currentFilterChanges.subscribe(spy);
+
+      // enter editmode
+      freeTextLabel.click();
+      advanceFilterfieldCycle();
+
+      filterField.focus();
+      advanceFilterfieldCycle();
+
+      expect(spy).not.toHaveBeenCalled();
+
+      subscription.unsubscribe();
+    }));
   });
 
   describe('data-source switching', () => {

--- a/libs/barista-components/filter-field/src/filter-field.ts
+++ b/libs/barista-components/filter-field/src/filter-field.ts
@@ -1326,53 +1326,61 @@ export class DtFilterField<T = any>
   private _handleAutocompleteSelected(
     event: DtAutocompleteSelectedEvent<DtNodeDef>,
   ): void {
-    const submittedOption = event.option.value as
-      | DtAutocompleteValue<T>
-      | DefaultSearchOption<T>;
-    if (isDefaultSearchOption(submittedOption)) {
-      this._peekCurrentFilterValues().push(submittedOption.defaultSearchDef);
-      this._writeInputValue(submittedOption.inputValue);
-      this._handleFreeTextSubmitted();
-      this._switchToRootDef(true);
-    } else if (
-      isDtAutocompleteDef(submittedOption) ||
-      isDtFreeTextDef(submittedOption) ||
-      isDtRangeDef(submittedOption) ||
-      isDtMultiSelectDef(submittedOption)
+    if (
+      isDtFreeTextDef(this._currentDef) &&
+      isDtOptionDef(event.option.value)
     ) {
-      this._peekCurrentFilterValues().push(submittedOption);
-      this._currentDef = submittedOption;
-      this._updateControl();
-      this._updateLoading();
-      this._updateFilterByLabel();
-      this._updateAutocompleteOptionsOrGroups();
-      this._updateDefaultSearchDef();
-      this._emitCurrentFilterChanges([submittedOption], []);
-
-      if (isDtMultiSelectDef(submittedOption)) {
-        this._multiSelect._setInitialSelection([]);
-      }
+      this._inputValue = event.option.value.option.viewValue;
+      this._handleFreeTextSubmitted();
     } else {
-      this._peekCurrentFilterValues().push(submittedOption);
-      this._switchToRootDef(true);
-    }
-    // Reset input value to empty string after handling the value provided by the autocomplete.
-    // Otherwise the value of the autocomplete would be in the input elements and the next options
-    // would be filtered by the input value
-    this._writeInputValue('');
+      const submittedOption = event.option.value as
+        | DtAutocompleteValue<T>
+        | DefaultSearchOption<T>;
+      if (isDefaultSearchOption(submittedOption)) {
+        this._peekCurrentFilterValues().push(submittedOption.defaultSearchDef);
+        this._writeInputValue(submittedOption.inputValue);
+        this._handleFreeTextSubmitted();
+        this._switchToRootDef(true);
+      } else if (
+        isDtAutocompleteDef(submittedOption) ||
+        isDtFreeTextDef(submittedOption) ||
+        isDtRangeDef(submittedOption) ||
+        isDtMultiSelectDef(submittedOption)
+      ) {
+        this._peekCurrentFilterValues().push(submittedOption);
+        this._currentDef = submittedOption;
+        this._updateControl();
+        this._updateLoading();
+        this._updateFilterByLabel();
+        this._updateAutocompleteOptionsOrGroups();
+        this._updateDefaultSearchDef();
+        this._emitCurrentFilterChanges([submittedOption], []);
 
-    // Clear any previous selected option.
-    this._autocomplete._options.forEach((option) => {
-      if (option.selected) {
-        option.deselect();
+        if (isDtMultiSelectDef(submittedOption)) {
+          this._multiSelect._setInitialSelection([]);
+        }
+      } else {
+        this._peekCurrentFilterValues().push(submittedOption);
+        this._switchToRootDef(true);
       }
-    });
+      // Reset input value to empty string after handling the value provided by the autocomplete.
+      // Otherwise the value of the autocomplete would be in the input elements and the next options
+      // would be filtered by the input value
+      this._writeInputValue('');
 
-    // if any changes happen, cancel the edit-mode.
-    this._resetEditMode();
+      // Clear any previous selected option.
+      this._autocomplete._options.forEach((option) => {
+        if (option.selected) {
+          option.deselect();
+        }
+      });
 
-    this._stateChanges.next();
-    this._changeDetectorRef.markForCheck();
+      // if any changes happen, cancel the edit-mode.
+      this._resetEditMode();
+
+      this._stateChanges.next();
+      this._changeDetectorRef.markForCheck();
+    }
   }
 
   /**

--- a/libs/barista-components/filter-field/src/filter-field.ts
+++ b/libs/barista-components/filter-field/src/filter-field.ts
@@ -334,16 +334,15 @@ export class DtFilterField<T = any>
 
       if (this._disabled) {
         this._closeFilterPanels();
+      }
 
-        this._tags.forEach((item) => {
-          this._previousTagDisabledState.set(item, item.disabled);
-          item.disabled = this._disabled;
-        });
-      } else {
-        this._tags.forEach(
-          (item) =>
-            (item.disabled = !!this._previousTagDisabledState.get(item)),
-        );
+      for (const tag of this._tags) {
+        if (this._disabled) {
+          this._previousTagDisabledState.set(tag, tag.disabled);
+          tag.disabled = this._disabled;
+        } else {
+          tag.disabled = !!this._previousTagDisabledState.get(tag);
+        }
       }
 
       this._changeDetectorRef.markForCheck();
@@ -1134,7 +1133,6 @@ export class DtFilterField<T = any>
         this._updateTagData();
         this._isFocused = true;
         this._stateChanges.next();
-        this._emitCurrentFilterChanges([], removed);
         this._changeDetectorRef.markForCheck();
       } else {
         this._removeFilterAndEmit(event.data.filterValues);


### PR DESCRIPTION
- Fixes an issue where the input showed "[object Object]" when editing a free text selected via a suggestion.
- Fixes an issue where the current-filter-change event was emitted incorrectly when editing a free-text.