### PR TITLE
feat(icon): Remove log for missing loading resources.

### DIFF
--- a/libs/barista-components/icon/src/icon.ts
+++ b/libs/barista-components/icon/src/icon.ts
@@ -106,7 +106,7 @@ export class DtIcon implements OnChanges {
             // We do not break the app when an icon could not be loaded
             // so do only a log here
             (err: Error) => {
-              iconLogger.warn(
+              iconLogger.info(
                 `Error retrieving icon: ${this.name} ${err.message}`,
               );
             },


### PR DESCRIPTION
* Previous fix PR #2172 improved spam a lot, we have now instead 500 logs daily, only 1-2
* But still we have them daily, preferably we'd like to not see it again as a hiccup ;)
* Suggestion: Keep severity as INFO instead WARN