### PR TITLE
fix(inline-editor): Move the error-state hints to a cdk overlay to escape overflow handling.

### DIFF
--- a/libs/barista-components/inline-editor/src/inline-editor-module.ts
+++ b/libs/barista-components/inline-editor/src/inline-editor-module.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { OverlayModule } from '@angular/cdk/overlay';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
@@ -31,6 +32,7 @@ import { DtInlineEditor } from './inline-editor';
 @NgModule({
   imports: [
     CommonModule,
+    OverlayModule,
     DtLoadingDistractorModule,
     DtButtonModule,
     DtInputModule,

--- a/libs/barista-components/inline-editor/src/inline-editor.html
+++ b/libs/barista-components/inline-editor/src/inline-editor.html
@@ -14,7 +14,11 @@
 <dt-loading-spinner *ngIf="saving"></dt-loading-spinner>
 
 <div *ngIf="editing || saving">
-  <div class="dt-inline-editor-edit-body">
+  <div
+    class="dt-inline-editor-edit-body"
+    cdkOverlayOrigin
+    #origin="cdkOverlayOrigin"
+  >
     <div class="dt-inline-editor-infix">
       <input
         dtInput
@@ -48,13 +52,22 @@
       </button>
     </div>
   </div>
-  <div class="dt-inline-editor-errors-subscript">
+  <ng-template
+    cdkConnectedOverlay
+    [cdkConnectedOverlayOrigin]="origin"
+    [cdkConnectedOverlayOpen]="_getDisplayedError()"
+  >
     <div
-      class="dt-inline-editor-errors"
-      *ngIf="_getDisplayedError()"
-      [@transitionErrors]="_errorAnimationState"
+      class="dt-inline-editor-errors-subscript"
+      [style.width.px]="_inputWidth"
     >
-      <ng-content select="dt-error"></ng-content>
+      <div
+        class="dt-inline-editor-errors"
+        *ngIf="_getDisplayedError()"
+        [@transitionErrors]="_errorAnimationState"
+      >
+        <ng-content select="dt-error"></ng-content>
+      </div>
     </div>
-  </div>
+  </ng-template>
 </div>

--- a/libs/barista-components/inline-editor/src/inline-editor.spec.ts
+++ b/libs/barista-components/inline-editor/src/inline-editor.spec.ts
@@ -22,12 +22,7 @@ import { PlatformModule } from '@angular/cdk/platform';
 import { HttpXhrBackend } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, ViewChild } from '@angular/core';
-import {
-  TestBed,
-  tick,
-  fakeAsync,
-  ComponentFixture,
-} from '@angular/core/testing';
+import { TestBed, tick, fakeAsync, inject } from '@angular/core/testing';
 import {
   FormsModule,
   ReactiveFormsModule,
@@ -51,8 +46,11 @@ import {
   dispatchFakeEvent,
   dispatchKeyboardEvent,
 } from '@dynatrace/testing/browser';
+import { OverlayContainer } from '@angular/cdk/overlay';
 
 describe('DtInlineEditor', () => {
+  let overlayContainerElement: HTMLElement;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
@@ -81,6 +79,10 @@ describe('DtInlineEditor', () => {
     });
 
     TestBed.compileComponents();
+
+    inject([OverlayContainer], (oc: OverlayContainer) => {
+      overlayContainerElement = oc.getContainerElement();
+    })();
   });
 
   it('should create controls', fakeAsync(() => {
@@ -192,9 +194,7 @@ describe('DtInlineEditor', () => {
     expect(inputElement.getAttribute('aria-invalid')).toBe('false');
 
     // Expected zero error messages to have been rendered.
-    expect(
-      fixture.debugElement.nativeElement.querySelectorAll('dt-error').length,
-    ).toBe(0);
+    expect(overlayContainerElement.querySelectorAll('dt-error').length).toBe(0);
 
     component.errorState = true;
     dispatchFakeEvent(inputElement, 'input');
@@ -203,9 +203,7 @@ describe('DtInlineEditor', () => {
     expect(inputElement.getAttribute('aria-invalid')).toBe('true');
 
     // Expected one error messages to have been rendered.
-    expect(
-      fixture.debugElement.nativeElement.querySelectorAll('dt-error').length,
-    ).toBe(1);
+    expect(overlayContainerElement.querySelectorAll('dt-error').length).toBe(1);
   }));
 
   it('should call save method and apply changes', fakeAsync(() => {
@@ -325,30 +323,30 @@ describe('DtInlineEditor', () => {
     ).nativeElement;
 
     // Expected zero error messages to have been rendered.
-    expect(getErrorHtmlElement(fixture)).toBe(null);
+    expect(getErrorHtmlElement(overlayContainerElement)).toBe(null);
 
     inputElement.value = 'bar';
     dispatchFakeEvent(inputElement, 'input');
     fixture.detectChanges();
 
     // Expected one error messages to have been rendered.
-    expect(getErrorHtmlElement(fixture)!.textContent!.trim()).toBe(
-      "Value must include the string 'barista'",
-    );
+    expect(
+      getErrorHtmlElement(overlayContainerElement)!.textContent!.trim(),
+    ).toBe("Value must include the string 'barista'");
 
     inputElement.value = 'barista';
     dispatchFakeEvent(inputElement, 'input');
     fixture.detectChanges();
 
     // Expected one error messages to have been rendered.
-    expect(getErrorHtmlElement(fixture)).toBe(null);
+    expect(getErrorHtmlElement(overlayContainerElement)).toBe(null);
   }));
 });
 
-function getErrorHtmlElement<T>(
-  fixture: ComponentFixture<T>,
+function getErrorHtmlElement(
+  overlayContainerElement: HTMLElement,
 ): HTMLElement | null {
-  return fixture.debugElement.nativeElement.querySelector('dt-error');
+  return overlayContainerElement.querySelector('dt-error');
 }
 
 @Component({

--- a/libs/barista-components/inline-editor/src/inline-editor.ts
+++ b/libs/barista-components/inline-editor/src/inline-editor.ts
@@ -183,6 +183,9 @@ export class DtInlineEditor
     return this._mode === MODES.SAVING;
   }
 
+  /** @internal Measured input width to match it for the error overlay width */
+  _inputWidth: number = 0;
+
   /** @internal Wether the input is focused or not */
   _inputFocused = false;
 
@@ -193,6 +196,8 @@ export class DtInlineEditor
   @ViewChildren(DtInput) _input: QueryList<DtInput>;
   /** @internal the edit button */
   @ViewChild('edit') _editButtonReference: ElementRef;
+  /** @internal Root of the error overlay */
+  @ViewChild('origin', { read: ElementRef }) origin: ElementRef;
   /** @internal list of all errors passed as content children */
   @ContentChildren(DtError) _errorChildren: QueryList<DtError>;
 
@@ -287,8 +292,14 @@ export class DtInlineEditor
     this._mode = MODES.EDITING;
     this._onTouched();
     this._focusWhenStable();
-
     this._changeDetectorRef.markForCheck();
+    this._executeOnStable(() => {
+      if (this.origin) {
+        this._inputWidth =
+          this.origin.nativeElement.getBoundingClientRect().width;
+        this._changeDetectorRef.markForCheck();
+      }
+    });
   }
 
   /** Saves and quits the edit mode */


### PR DESCRIPTION
### <strong>Pull Request</strong>
Move the error validation flap to a cdk overlay, so it will escape  the overflow handling.

Fixes APM-327558

Please choose the type appropriate for the changes below: <br>

#### Type of PR
Bugfix

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
