### PR TITLE
fix(tooltip): Fixed positioning of heatmaps tooltip.

### DIFF
--- a/libs/barista-components/chart/src/tooltip/chart-tooltip-position.ts
+++ b/libs/barista-components/chart/src/tooltip/chart-tooltip-position.ts
@@ -84,8 +84,8 @@ const getHighchartsTooltipPosition = (
     const xAxis = data.points![0].series!.xAxis;
     x = xAxis.toPixels(point.x as number, false);
   } else if (isHeatmap) {
-    x = (data.point!.point as any).plotX;
-    y = (data.point!.point as any).plotY;
+    x = (data.point!.point as any).plotX + plotBackgroundInfo.left;
+    y = (data.point!.point as any).plotY + plotBackgroundInfo.top;
   } else {
     x = (data.points![0].point as any).tooltipPos![0] + plotBackgroundInfo.left;
   }


### PR DESCRIPTION
### What went wrong?
Position of heatmap's tooltip sometimes is not so close to selected bucket.

#### Expected behavior.
Should respect the distance to selected bucket

#### Solution.
Space occupied by the axis label was not taken into account 

#### Type of PR
Bugfix

#### Demo
Before:
![Screenshot 2021-11-10 at 12 52 42](https://user-images.githubusercontent.com/91270881/141111118-0d38151c-99d7-420d-a999-1365e928ff7d.png)

After:
![Screenshot 2021-11-10 at 12 52 26](https://user-images.githubusercontent.com/91270881/141111140-7acc6e96-5de9-44bb-ad3e-6ec6e2e53ffa.png)