### PR TITLE
feat(components): Increase coverage of translatable messages.

### DIFF
--- a/libs/barista-components/experimental/datepicker/src/calendar.html
+++ b/libs/barista-components/experimental/datepicker/src/calendar.html
@@ -6,6 +6,7 @@
     (click)="_addMonths(-12)"
     class="dt-calendar-header-button dt-calendar-header-button-prev-year"
     aria-label="Previous Year"
+    i18n-aria-label
   >
     <dt-icon name="learn-more"></dt-icon>
   </button>
@@ -16,6 +17,7 @@
     (click)="_addMonths(-1)"
     class="dt-calendar-header-button dt-calendar-header-button-prev-month"
     aria-label="Previous Month"
+    i18n-aria-label
   >
     <dt-icon name="dropdownclosed"></dt-icon>
   </button>
@@ -34,6 +36,7 @@
     [disabled]="_isNextMonthOutsideMinMaxRange()"
     class="dt-calendar-header-button dt-calendar-header-button-next-month"
     aria-label="Next Month"
+    i18n-aria-label
   >
     <dt-icon name="dropdownclosed"></dt-icon>
   </button>
@@ -44,6 +47,7 @@
     (click)="_addMonths(12)"
     class="dt-calendar-header-button dt-calendar-header-button-next-year"
     aria-label="Next Year"
+    i18n-aria-label
   >
     <dt-icon name="learn-more"></dt-icon>
   </button>
@@ -64,6 +68,7 @@
   *ngIf="showTodayButton"
   variant="secondary"
   (click)="_setTodayDate()"
+  i18n
 >
   Today
 </button>

--- a/libs/barista-components/filter-field/src/filter-field-range/filter-field-range.html
+++ b/libs/barista-components/filter-field/src/filter-field-range/filter-field-range.html
@@ -8,7 +8,7 @@
       [(value)]="_selectedOperator"
       class="dt-filter-field-range-operators"
     >
-      <dt-button-group-item *ngIf="_hasRangeOperator" value="range"
+      <dt-button-group-item *ngIf="_hasRangeOperator" value="range" i18n
         >Range</dt-button-group-item
       >
       <dt-button-group-item *ngIf="_hasLowerEqualOperator" value="lower-equal"

--- a/libs/barista-components/quick-filter/src/quick-filter-group.html
+++ b/libs/barista-components/quick-filter/src/quick-filter-group.html
@@ -13,7 +13,7 @@
     [name]="_nodeDef.option?.uid"
     (change)="_unsetGroup()"
   >
-    Any
+    <ng-container i18n>Any</ng-container>
   </dt-radio-button>
 
   <ng-container *ngIf="!isDetail; else virtualScroll">
@@ -49,7 +49,7 @@
     }"
   ></ng-container>
 
-  <button class="dt-show-more" (click)="_showMore()">View more</button>
+  <button class="dt-show-more" (click)="_showMore()" i18n>View more</button>
 </ng-container>
 
 <ng-template #checkBox let-item>
@@ -74,7 +74,7 @@
 </ng-template>
 
 <ng-template #defaultShowMoreText let-count>
-  <p class="dt-quick-filter-show-more-text">
+  <p class="dt-quick-filter-show-more-text" i18n>
     +{{ count }} options in the filter field
   </p>
 </ng-template>

--- a/libs/barista-components/quick-filter/src/quick-filter.html
+++ b/libs/barista-components/quick-filter/src/quick-filter.html
@@ -28,7 +28,7 @@
     <ng-container *ngIf="_isDetailView$ | async; else quickFilterHeader">
       <button class="dt-back-to-quick-filter" (click)="_goBackFromDetail()">
         <dt-icon name="left"></dt-icon>
-        Back to quick filters
+        <ng-container i18n>Back to quick filters</ng-container>
       </button>
     </ng-container>
 

--- a/libs/barista-components/tag/src/tag-add/tag-add-button.ts
+++ b/libs/barista-components/tag/src/tag-add/tag-add-button.ts
@@ -24,6 +24,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
       dt-button
       (click)="handleClick($event)"
       [disabled]="!this.valid"
+      i18n
     >
       Add
     </button>

--- a/libs/barista-components/tag/src/tag-list/tag-list.html
+++ b/libs/barista-components/tag/src/tag-list/tag-list.html
@@ -7,7 +7,9 @@
     ></ng-template>
   </div>
   <div class="dt-tag-list-more-btn" *ngIf="_toDisplayMoreButton()" #moreBtn>
-    <a (click)="_expand()" class="dt-link">{{ _hiddenTagCount }} More...</a>
+    <a (click)="_expand()" class="dt-link" i18n
+      >{{ _hiddenTagCount }} More...</a
+    >
   </div>
   <ng-template
     [ngTemplateOutlet]="dtAddTag"


### PR DESCRIPTION
### Goal

this PR increases coverage of i18n messages understood by Angular. Avoids "parts" of the product UI being untranslated.

### Technical details

* Since Angular 11 and Ivy i18n, Angular understands libraries when extracting and building messages
* catched all through tslint `template-i18n` rule, however I didn't enable it as we have same `tslint.json` and no `tslint.spec.json` that would disable this rule for `.spec.ts` (producing many false positives)

#### Type of PR

Feature (non-breaking change which adds functionality)
