### PR TITLE
fix(tag): Fix remove button hover background overflow

### DIFF
--- a/libs/barista-components/tag/src/tag.scss
+++ b/libs/barista-components/tag/src/tag.scss
@@ -25,19 +25,24 @@ $remove-icon-size: 16px;
   }
 
   .dt-tag-remove-button {
-    width: 22px;
-    height: 22px;
-    margin-left: 8px;
-    padding-right: 24px;
+    display: flex;
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    margin: 0 4px;
+    align-items: center;
+    justify-content: center;
 
     ::ng-deep {
-      .dt-icon {
+      .dt-button-icon {
         height: $remove-icon-size;
         width: $remove-icon-size;
-      }
-
-      .dt-button-icon {
         margin-top: 0;
+
+        .dt-icon,
+        svg {
+          vertical-align: top;
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes overflow of background for remove button on hover beyond tag element

Before:
![before](https://user-images.githubusercontent.com/23279624/161077571-b62d443e-adf3-418d-9f48-94eb293c7c24.png)

After:
![after](https://user-images.githubusercontent.com/23279624/161077609-abed0980-33f0-4ccf-b567-6cd2723ed175.png)

