### PR TITLE
docs(confirmation-dialog): Use correct preview image

### DIFF
--- a/libs/barista-components/confirmation-dialog/barista.json
+++ b/libs/barista-components/confirmation-dialog/barista.json
@@ -30,5 +30,5 @@
     "settings",
     "confirmation"
   ],
-  "imageUrl": "https://dt-cdn.net/images/barista-preview-quick-filter-1000-6ce2f220be.png"
+  "imageUrl": "https://dt-cdn.net/images/barista-preview-confirmation-dialog-624-e5b0e4379d.png"
 }


### PR DESCRIPTION
The preview image for confirmation-dialog was incorrect (was using the one for quick filter).