### PR TITLE
fix(quick-filter): Preserve the focus when opening and closing.

### DIFF
--- a/libs/barista-components/quick-filter/src/quick-filter.html
+++ b/libs/barista-components/quick-filter/src/quick-filter.html
@@ -20,6 +20,7 @@
       *ngIf="drawer.opened"
       class="dt-quick-filter-close"
       aria-label="Closes the quick filter bar"
+      (mousedown)="_onCloseDrawerMouseDown()"
       (click)="drawer.close()"
     >
       ◀︎
@@ -50,6 +51,7 @@
       *ngIf="!drawer.opened"
       class="dt-quick-filter-open"
       aria-label="Opens the quick filter bar"
+      (mousedown)="_onOpenDrawerMouseDown()"
       (click)="drawer.open()"
     >
       ▶︎


### PR DESCRIPTION
Preserve the keyboard focus in the content area and drawer area when opening and closing the drawer.


