### PR TITLE
Supporting text in chart heatfield

### DIFF
--- a/apps/components-e2e/src/components/drawer/drawer.html
+++ b/apps/components-e2e/src/components/drawer/drawer.html
@@ -24,7 +24,11 @@
           </ng-template>
         </dt-chart-tooltip>
 
-        <dt-chart-heatfield [start]="1564546530000" [end]="1564546620000">
+        <dt-chart-heatfield
+          [start]="1564546530000"
+          [end]="1564546620000"
+          text="Problems"
+        >
           Problem 1:
           <br />
           <a class="dt-link">View problem details</a>
@@ -33,6 +37,7 @@
           [start]="1564546530000"
           [end]="1564546960000"
           color="main"
+          text="Overload prevention"
         >
           Overload prevention:
           <br />

--- a/apps/dev/src/chart/chart-demo.component.html
+++ b/apps/dev/src/chart/chart-demo.component.html
@@ -51,7 +51,11 @@
     </ng-template>
   </dt-chart-tooltip>
 
-  <dt-chart-heatfield [start]="1564546530000" [end]="1564546620000">
+  <dt-chart-heatfield
+    [start]="1564546530000"
+    [end]="1564546620000"
+    text="Problems"
+  >
     Problem 1:
     <br />
     <a class="dt-link">View problem details</a>
@@ -60,6 +64,7 @@
     [start]="1564546730000"
     [end]="1564546960000"
     color="main"
+    text="Overload prevention"
   >
     Overload prevention:
     <br />

--- a/libs/barista-components/chart/README.md
+++ b/libs/barista-components/chart/README.md
@@ -303,6 +303,7 @@ an overload. To indicate this use case, add a heatfield with `color` set to
 | `color`           | 'error' &#124; 'main' | `'error'`   | Sets the color of the heatfield.                                            |
 | `text`            | `string`              | `''`        | The text displayed inside the heat field.                                   |
 | `alwaysExpanded`  | `boolean`             | `false`     | Flag to force the size of the marker.                                       |
+| `hideBackdrop`    | `boolean`             | `false`     | Flag to prevent the backdrop to be displayed when active.                   |
 
 To make our components accessible it is obligatory to provide either an
 `aria-label` or `aria-labelledby`.

--- a/libs/barista-components/chart/README.md
+++ b/libs/barista-components/chart/README.md
@@ -301,6 +301,7 @@ an overload. To indicate this use case, add a heatfield with `color` set to
 | `aria-label`      | `string`              | `undefined` | The aria label used for the heatfield button.                               |
 | `aria-labelledby` | `string`              | `undefined` | ARIA reference to a label describing the icon in the consumption component. |
 | `color`           | 'error' &#124; 'main' | `'error'`   | Sets the color of the heatfield.                                            |
+| `text`            | `string`              | `''`        | The text displayed inside the heat field.                                   |
 
 To make our components accessible it is obligatory to provide either an
 `aria-label` or `aria-labelledby`.

--- a/libs/barista-components/chart/README.md
+++ b/libs/barista-components/chart/README.md
@@ -302,6 +302,7 @@ an overload. To indicate this use case, add a heatfield with `color` set to
 | `aria-labelledby` | `string`              | `undefined` | ARIA reference to a label describing the icon in the consumption component. |
 | `color`           | 'error' &#124; 'main' | `'error'`   | Sets the color of the heatfield.                                            |
 | `text`            | `string`              | `''`        | The text displayed inside the heat field.                                   |
+| `alwaysExpanded`  | `boolean`             | `false`     | Flag to force the size of the marker.                                       |
 
 To make our components accessible it is obligatory to provide either an
 `aria-label` or `aria-labelledby`.

--- a/libs/barista-components/chart/src/heatfield/chart-heatfield.html
+++ b/libs/barista-components/chart/src/heatfield/chart-heatfield.html
@@ -7,7 +7,9 @@
   (click)="_toggleActive()"
   [attr.aria-label]="ariaLabel"
   [attr.aria-labelledby]="ariaLabelledBy"
-></button>
+>
+  <span class="dt-chart-heatfield-text">{{ text }}</span>
+</button>
 <ng-template
   cdkConnectedOverlay
   [cdkConnectedOverlayOrigin]="marker"

--- a/libs/barista-components/chart/src/heatfield/chart-heatfield.html
+++ b/libs/barista-components/chart/src/heatfield/chart-heatfield.html
@@ -9,7 +9,9 @@
   [attr.aria-label]="ariaLabel"
   [attr.aria-labelledby]="ariaLabelledBy"
 >
-  <span class="dt-chart-heatfield-text">{{ text }}</span>
+  <span class="dt-chart-heatfield-text" *ngIf="text?.length > 0">{{
+    text
+  }}</span>
 </button>
 <ng-template
   cdkConnectedOverlay
@@ -44,6 +46,7 @@
 
 <div
   class="dt-chart-heatfield-backdrop"
+  [class.dt-chart-heatfield-backdrop-hidden]="hideBackdrop"
   #backdrop
   [style.height.px]="_boundingBox && _boundingBox.height"
 ></div>

--- a/libs/barista-components/chart/src/heatfield/chart-heatfield.html
+++ b/libs/barista-components/chart/src/heatfield/chart-heatfield.html
@@ -1,5 +1,6 @@
 <button
   class="dt-chart-heatfield-marker"
+  [class.dt-chart-heatfield-expanded]="active || alwaysExpanded"
   [class.dt-chart-heatfield-active]="active"
   [style.visibility]="_isValidStartEndRange ? 'visible' : 'hidden'"
   #marker="cdkOverlayOrigin"

--- a/libs/barista-components/chart/src/heatfield/chart-heatfield.scss
+++ b/libs/barista-components/chart/src/heatfield/chart-heatfield.scss
@@ -20,7 +20,7 @@ $animation-delay: 40ms;
 }
 
 .dt-chart-heatfield-marker .dt-chart-heatfield-text {
-  font-size: 6px;
+  font-size: 7.5px;
   font-weight: bold;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -31,7 +31,7 @@ $animation-delay: 40ms;
 
 .dt-chart-heatfield-marker.dt-chart-heatfield-expanded
   .dt-chart-heatfield-text {
-  font-size: 8px;
+  font-size: 10px;
   transform: scaleY(0.666666); // The parent it's scaled to 1.5 when active
   transform-origin: top;
   transition: transform 50ms ease-in-out;
@@ -47,6 +47,10 @@ $animation-delay: 40ms;
   transform-origin: top;
   transform: scaleY(0);
   transition: transform $animation-duration ease-out;
+}
+
+.dt-chart-heatfield-backdrop-hidden {
+  display: none;
 }
 
 .dt-chart-heatfield-active + .dt-chart-heatfield-backdrop {

--- a/libs/barista-components/chart/src/heatfield/chart-heatfield.scss
+++ b/libs/barista-components/chart/src/heatfield/chart-heatfield.scss
@@ -29,14 +29,15 @@ $animation-delay: 40ms;
   color: white;
 }
 
-.dt-chart-heatfield-marker.dt-chart-heatfield-active .dt-chart-heatfield-text {
+.dt-chart-heatfield-marker.dt-chart-heatfield-expanded
+  .dt-chart-heatfield-text {
   font-size: 8px;
   transform: scaleY(0.666666); // The parent it's scaled to 1.5 when active
   transform-origin: top;
   transition: transform 50ms ease-in-out;
 }
 
-.dt-chart-heatfield-marker.dt-chart-heatfield-active {
+.dt-chart-heatfield-marker.dt-chart-heatfield-expanded {
   transform: scaleY(1.5);
   transition: transform 50ms ease-in-out;
 }

--- a/libs/barista-components/chart/src/heatfield/chart-heatfield.scss
+++ b/libs/barista-components/chart/src/heatfield/chart-heatfield.scss
@@ -19,6 +19,23 @@ $animation-delay: 40ms;
   transition: transform $animation-duration ease-in-out $animation-delay;
 }
 
+.dt-chart-heatfield-marker .dt-chart-heatfield-text {
+  font-size: 6px;
+  font-weight: bold;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  display: block;
+  color: white;
+}
+
+.dt-chart-heatfield-marker.dt-chart-heatfield-active .dt-chart-heatfield-text {
+  font-size: 8px;
+  transform: scaleY(0.666666); // The parent it's scaled to 1.5 when active
+  transform-origin: top;
+  transition: transform 50ms ease-in-out;
+}
+
 .dt-chart-heatfield-marker.dt-chart-heatfield-active {
   transform: scaleY(1.5);
   transition: transform 50ms ease-in-out;

--- a/libs/barista-components/chart/src/heatfield/chart-heatfield.spec.ts
+++ b/libs/barista-components/chart/src/heatfield/chart-heatfield.spec.ts
@@ -85,6 +85,7 @@ describe('DtChartHeatfield', () => {
     let fixture: ComponentFixture<SingleHeatfield>;
     let instance: SingleHeatfield;
     let marker: HTMLElement;
+    let backdrop: HTMLElement;
 
     beforeEach(() => {
       fixture = createComponent(SingleHeatfield);
@@ -95,11 +96,14 @@ describe('DtChartHeatfield', () => {
       marker = chartDebug.query(
         By.css('.dt-chart-heatfield-marker'),
       ).nativeElement;
+      backdrop = fixture.debugElement.query(
+        By.css('.dt-chart-heatfield-backdrop'),
+      ).nativeElement;
     });
 
     describe('Positioning', () => {
       it('should scale the heatfield correctly', () => {
-        validatePosition(fixture, 150, 50);
+        validatePosition(backdrop, fixture, 150, 50);
       });
 
       it('should rescale the heatfield correctly on container resize', () => {
@@ -107,7 +111,7 @@ describe('DtChartHeatfield', () => {
         fixture.detectChanges();
         chart._afterRender.next();
         chart.initHeatfield();
-        validatePosition(fixture, 200, 100);
+        validatePosition(backdrop, fixture, 200, 100);
       });
 
       it('should clamp the heatfield to the axisMin', () => {
@@ -117,7 +121,7 @@ describe('DtChartHeatfield', () => {
         chart.axisMax = 200000;
         fixture.detectChanges();
         chart._afterRender.next();
-        validatePosition(fixture, 100, 50);
+        validatePosition(backdrop, fixture, 100, 50);
       });
 
       it('should clamp the heatfield to the axisMax', () => {
@@ -125,7 +129,7 @@ describe('DtChartHeatfield', () => {
         instance.end = 150000;
         fixture.detectChanges();
         chart._afterRender.next();
-        validatePosition(fixture, 550, 50);
+        validatePosition(backdrop, fixture, 550, 50);
       });
 
       it('should clamp the heatfield to the axisMin and axisMax at the same time', () => {
@@ -135,7 +139,7 @@ describe('DtChartHeatfield', () => {
         chart.axisMax = 200000;
         fixture.detectChanges();
         chart._afterRender.next();
-        validatePosition(fixture, 100, 500);
+        validatePosition(backdrop, fixture, 100, 500);
       });
 
       it('should stretch the heatfield to the axisMax when end is undefined', () => {
@@ -144,7 +148,7 @@ describe('DtChartHeatfield', () => {
         chart.axisMax = 200000;
         fixture.detectChanges();
         chart._afterRender.next();
-        validatePosition(fixture, 100, 500);
+        validatePosition(backdrop, fixture, 100, 500);
       });
 
       it('should not render heatfield when start and end are undefined ', () => {
@@ -255,17 +259,13 @@ describe('DtChartHeatfield', () => {
     });
 
     describe('text', () => {
-      let heatfieldNative: HTMLElement;
-
-      beforeEach(() => {
-        heatfieldNative = fixture.debugElement.query(
-          By.css('.dt-chart-heatfield-text'),
-        ).nativeElement;
-      });
-
       it('should display the text received as input', () => {
         instance.text = 'Text to be displayed';
         fixture.detectChanges();
+
+        const heatfieldNative: HTMLElement = fixture.debugElement.query(
+          By.css('.dt-chart-heatfield-text'),
+        ).nativeElement;
         expect(heatfieldNative.textContent).toContain('Text to be displayed');
       });
     });
@@ -278,6 +278,17 @@ describe('DtChartHeatfield', () => {
         fixture.detectChanges();
         expect(marker.classList).toContain('dt-chart-heatfield-expanded');
         expect(marker.classList).not.toContain('dt-chart-heatfield-active');
+      });
+    });
+
+    describe('hideBackdrop', () => {
+      it('should prevent the backdrop to be displayed when the marker is active', () => {
+        instance.hideBackdrop = true;
+        marker.click();
+        fixture.detectChanges();
+        expect(backdrop.classList).toContain(
+          'dt-chart-heatfield-backdrop-hidden',
+        );
       });
     });
 
@@ -335,6 +346,7 @@ describe('DtChartHeatfield', () => {
 });
 
 function validatePosition(
+  backDrop: HTMLElement,
   fixture: ComponentFixture<SingleHeatfield>,
   expectedLeft: number,
   expectedWidth: number,
@@ -343,14 +355,11 @@ function validatePosition(
   const chartMarkerDebugElement = fixture.debugElement.query(
     By.css('.dt-chart-heatfield-marker'),
   );
-  const chartBackdropDebugElement = fixture.debugElement.query(
-    By.css('.dt-chart-heatfield-backdrop'),
-  );
   // cannot select svg subelements with By.css see - https://github.com/angular/angular/issues/15164
   const styleMarker = chartMarkerDebugElement.nativeElement.style;
   expect(styleMarker.left).toEqual(`${expectedLeft}px`);
   expect(styleMarker.width).toEqual(`${expectedWidth}px`);
-  const styleBackdrop = chartBackdropDebugElement.nativeElement.style;
+  const styleBackdrop = backDrop.style;
   expect(styleBackdrop.left).toEqual(`${expectedLeft}px`);
   expect(styleBackdrop.width).toEqual(`${expectedWidth}px`);
 }
@@ -367,6 +376,7 @@ function validatePosition(
         [active]="isActive"
         [text]="text"
         [alwaysExpanded]="alwaysExpanded"
+        [hideBackdrop]="hideBackdrop"
       >
         Problem 1:
         <button>focus</button>
@@ -381,6 +391,7 @@ class SingleHeatfield {
   text = '';
   isActive: boolean;
   alwaysExpanded = false;
+  hideBackdrop = false;
 }
 
 /** Test component that contains an two heatfields */

--- a/libs/barista-components/chart/src/heatfield/chart-heatfield.spec.ts
+++ b/libs/barista-components/chart/src/heatfield/chart-heatfield.spec.ts
@@ -160,10 +160,12 @@ describe('DtChartHeatfield', () => {
       it('should set correct classes on click', () => {
         marker.click();
         fixture.detectChanges();
+        expect(marker.classList).toContain('dt-chart-heatfield-expanded');
         expect(marker.classList).toContain('dt-chart-heatfield-active');
 
         marker.click();
         fixture.detectChanges();
+        expect(marker.classList).not.toContain('dt-chart-heatfield-expanded');
         expect(marker.classList).not.toContain('dt-chart-heatfield-active');
       });
 
@@ -188,6 +190,7 @@ describe('DtChartHeatfield', () => {
         marker.focus();
         dispatchKeyboardEvent(marker, 'click', ENTER);
         fixture.detectChanges();
+        expect(marker.classList).toContain('dt-chart-heatfield-expanded');
         expect(marker.classList).toContain('dt-chart-heatfield-active');
         expect(overlayContainerElement.textContent).toContain('Problem 1');
       }));
@@ -195,6 +198,7 @@ describe('DtChartHeatfield', () => {
       it('should handle programmatic activation', () => {
         instance.isActive = true;
         fixture.detectChanges();
+        expect(marker.classList).toContain('dt-chart-heatfield-expanded');
         expect(marker.classList).toContain('dt-chart-heatfield-active');
         expect(overlayContainerElement.textContent).toContain('Problem 1');
       });
@@ -217,6 +221,7 @@ describe('DtChartHeatfield', () => {
       it('clicking on x button should close overlay', () => {
         closeOverlayButton.click();
         fixture.detectChanges();
+        expect(marker.classList).not.toContain('dt-chart-heatfield-expanded');
         expect(marker.classList).not.toContain('dt-chart-heatfield-active');
       });
 
@@ -224,6 +229,7 @@ describe('DtChartHeatfield', () => {
         dispatchKeyboardEvent(overlayContainerElement, 'keydown', ESCAPE);
         tick();
         fixture.detectChanges();
+        expect(marker.classList).not.toContain('dt-chart-heatfield-expanded');
         expect(marker.classList).not.toContain('dt-chart-heatfield-active');
       }));
     });
@@ -261,6 +267,17 @@ describe('DtChartHeatfield', () => {
         instance.text = 'Text to be displayed';
         fixture.detectChanges();
         expect(heatfieldNative.textContent).toContain('Text to be displayed');
+      });
+    });
+
+    describe('alwaysExpanded', () => {
+      it('should always expand the marker no matter if it is active or not', () => {
+        expect(marker.classList).not.toContain('dt-chart-heatfield-expanded');
+        expect(marker.classList).not.toContain('dt-chart-heatfield-active');
+        instance.alwaysExpanded = true;
+        fixture.detectChanges();
+        expect(marker.classList).toContain('dt-chart-heatfield-expanded');
+        expect(marker.classList).not.toContain('dt-chart-heatfield-active');
       });
     });
 
@@ -349,6 +366,7 @@ function validatePosition(
         [color]="color"
         [active]="isActive"
         [text]="text"
+        [alwaysExpanded]="alwaysExpanded"
       >
         Problem 1:
         <button>focus</button>
@@ -362,6 +380,7 @@ class SingleHeatfield {
   color: string;
   text = '';
   isActive: boolean;
+  alwaysExpanded = false;
 }
 
 /** Test component that contains an two heatfields */

--- a/libs/barista-components/chart/src/heatfield/chart-heatfield.spec.ts
+++ b/libs/barista-components/chart/src/heatfield/chart-heatfield.spec.ts
@@ -248,6 +248,22 @@ describe('DtChartHeatfield', () => {
       });
     });
 
+    describe('text', () => {
+      let heatfieldNative: HTMLElement;
+
+      beforeEach(() => {
+        heatfieldNative = fixture.debugElement.query(
+          By.css('.dt-chart-heatfield-text'),
+        ).nativeElement;
+      });
+
+      it('should display the text received as input', () => {
+        instance.text = 'Text to be displayed';
+        fixture.detectChanges();
+        expect(heatfieldNative.textContent).toContain('Text to be displayed');
+      });
+    });
+
     it('should focus the marker when tab clicked', () => {
       marker.focus();
       fixture.detectChanges();
@@ -332,6 +348,7 @@ function validatePosition(
         [end]="end"
         [color]="color"
         [active]="isActive"
+        [text]="text"
       >
         Problem 1:
         <button>focus</button>
@@ -343,6 +360,7 @@ class SingleHeatfield {
   start: number | undefined = 10000;
   end: number | undefined = 20000;
   color: string;
+  text = '';
   isActive: boolean;
 }
 

--- a/libs/barista-components/chart/src/heatfield/chart-heatfield.ts
+++ b/libs/barista-components/chart/src/heatfield/chart-heatfield.ts
@@ -96,6 +96,8 @@ export class DtChartHeatfield
   @Input() text = '';
   /** Flag to force the size of the marker */
   @Input() alwaysExpanded = false;
+  /** Flag to prevent the backdrop to be displayed when active */
+  @Input() hideBackdrop = false;
 
   private _active = false;
 

--- a/libs/barista-components/chart/src/heatfield/chart-heatfield.ts
+++ b/libs/barista-components/chart/src/heatfield/chart-heatfield.ts
@@ -94,6 +94,8 @@ export class DtChartHeatfield
   @Input() end: number;
   /** Optional text to be displayed inside heatfield button */
   @Input() text = '';
+  /** Flag to force the size of the marker */
+  @Input() alwaysExpanded = false;
 
   private _active = false;
 

--- a/libs/barista-components/chart/src/heatfield/chart-heatfield.ts
+++ b/libs/barista-components/chart/src/heatfield/chart-heatfield.ts
@@ -92,6 +92,8 @@ export class DtChartHeatfield
   @Input() start: number;
   /** End on the xAxis of the chart for the heatfield */
   @Input() end: number;
+  /** Optional text to be displayed inside heatfield button */
+  @Input() text = '';
 
   private _active = false;
 


### PR DESCRIPTION
### <strong>Pull Request</strong>

#### Type of PR

Feature (non-breaking change which adds functionality)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Details

## Goal
- Place text (only numbers by now) inside the markers of the dt-chart-heatfield component. 
- Possibility to hide the backdrop

## Changes

- Included a new `@Input()` named `text` used to display that text within the marker.
- Included a new `@Input()` named `alwaysExpanded` to force the size of the marker, which improves readability of the text within.
- Included a new `@Input()` named `hideBackdrop` to prevent the backdrop to be displayed when active.
- Demo page has been updated. Maybe adding a new component instance for specific cases would be nice to have.
- Unit tests have been updated.
