### PR TITLE
feat(card): Set default color of card icons

### DIFF
--- a/apps/dev/src/card/card-demo.component.html
+++ b/apps/dev/src/card/card-demo.component.html
@@ -21,3 +21,13 @@
     </dt-card-footer-actions>
   </dt-card>
 </div>
+
+<div class="demo-card">
+  <dt-card>
+    <dt-card-icon>
+      <dt-icon name="incident"></dt-icon>
+    </dt-card-icon>
+    <dt-card-title>Top 3 JavaScript errors</dt-card-title>
+    This card has an icon
+  </dt-card>
+</div>

--- a/libs/barista-components/card/src/card.scss
+++ b/libs/barista-components/card/src/card.scss
@@ -30,6 +30,7 @@
   .dt-icon {
     width: 44px;
     height: 44px;
+    fill: $gray-700;
   }
 }
 

--- a/libs/examples/src/card/card-icon-example/card-icon-example.html
+++ b/libs/examples/src/card/card-icon-example/card-icon-example.html
@@ -1,11 +1,10 @@
 <div class="dt-demo-card">
   <dt-card>
     <dt-card-icon>
-      <dt-icon name="application"></dt-icon>
+      <dt-icon name="incident"></dt-icon>
     </dt-card-icon>
     <dt-card-title>Top 3 JavaScript errors</dt-card-title>
     <dt-card-subtitle>Some subtitle</dt-card-subtitle>
-    Icons are not yet implemented - this is an example to showcase the icon
-    placeholder
+    This card has an icon
   </dt-card>
 </div>


### PR DESCRIPTION


### <strong>Pull Request</strong>

<hr>

#### Type of PR

Feature (non-breaking change which adds functionality)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Changes

The default color of card icons is now `$gray-700` (like default background for e.g. tile icons). Before there was no default color for card icons, so they were displayed as black unless the user explicitly specified a color.