### PR TITLE
fix(quick-filter): Fixes issue where long text overflowed container.

### DIFF
--- a/libs/barista-components/quick-filter/src/quick-filter-group.scss
+++ b/libs/barista-components/quick-filter/src/quick-filter-group.scss
@@ -12,6 +12,9 @@
 :host fieldset {
   border: 0;
   padding: 0;
+  // To prevent fieldset from overflowing flex container
+  min-width: 0;
+  max-width: 100%;
 }
 
 .dt-quick-filter-group-headline {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/59170440/171144066-72927cc8-1338-4961-9705-7f7f5b04ad38.png)

After:
![image](https://user-images.githubusercontent.com/59170440/171143672-55f5afc6-917e-4194-8209-e8a00062bb81.png)
