### PR TITLE
fix(formatters): Ensure auto-unit conversion works also for negative values.

### DIFF
--- a/libs/barista-components/formatters/src/bits-bytes-formatter.ts
+++ b/libs/barista-components/formatters/src/bits-bytes-formatter.ts
@@ -79,7 +79,7 @@ function getAutoUnitConversion(
   conversions: DtUnitConversion[],
   valueInUnit: number,
 ): DtUnitConversion | undefined {
-  return conversions.find((m) => valueInUnit >= m.multiplier);
+  return conversions.find((m) => Math.abs(valueInUnit) >= m.multiplier);
 }
 
 function getFixedUnitConversion(

--- a/libs/barista-components/formatters/src/bytes/bytes-formatter.spec.ts
+++ b/libs/barista-components/formatters/src/bytes/bytes-formatter.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2022 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KIBI_MULTIPLIER } from '../number-formatter';
+import { formatBytes } from './bytes-formatter';
+
+describe('formatBytes', () => {
+  it('should format positive million bytes', () => {
+    // given
+    const inputValue = 1000000.0;
+
+    // when
+    const result = formatBytes(inputValue, {
+      factor: KIBI_MULTIPLIER,
+      inputUnit: 'B',
+    });
+
+    // then
+    expect(result.displayData.displayValue).toEqual('977');
+    expect(result.displayData.displayUnit).toEqual('kiB');
+  });
+
+  it('should format negative million bytes', () => {
+    // given
+    const inputValue = -1000000.0;
+
+    // when
+    const result = formatBytes(inputValue, {
+      factor: KIBI_MULTIPLIER,
+      inputUnit: 'B',
+    });
+
+    // then
+    expect(result.displayData.displayValue).toEqual('-977');
+    expect(result.displayData.displayUnit).toEqual('kiB');
+  });
+});


### PR DESCRIPTION


Negative values of same magnitude should have same auto-unit conversion as equivalent positive values.
