### PR TITLE
fix(filter-field): Hide clear-all button when no filters are applied.

### DIFF
--- a/libs/barista-components/filter-field/src/filter-field.html
+++ b/libs/barista-components/filter-field/src/filter-field.html
@@ -168,7 +168,7 @@
     dt-button
     variant="secondary"
     class="dt-filter-field-clear-all-button"
-    *ngIf="clearAllLabel"
+    *ngIf="_showClearAll"
     (click)="_clearAll($event)"
     [disabled]="disabled"
   >

--- a/libs/barista-components/filter-field/src/filter-field.spec.ts
+++ b/libs/barista-components/filter-field/src/filter-field.spec.ts
@@ -1426,6 +1426,21 @@ describe('DtFilterField', () => {
       advanceFilterfieldCycle(false);
     });
 
+    it('should not display the clear all button if no filters are selected', () => {
+      filterField.filters = [];
+      fixture.detectChanges();
+
+      expect(isClearAllVisible(fixture)).toBe(false);
+    });
+
+    it('should not display the clear all button if neither a label is provided nor filters are selected', () => {
+      filterField.filters = [];
+      fixture.componentInstance.clearAllLabel = '';
+      fixture.detectChanges();
+
+      expect(isClearAllVisible(fixture)).toBe(false);
+    });
+
     it('should not display the clear all button if no label is provided', () => {
       const autocompleteFilter = [
         TEST_DATA_EDITMODE.autocomplete[0],
@@ -1438,6 +1453,19 @@ describe('DtFilterField', () => {
       fixture.detectChanges();
 
       expect(isClearAllVisible(fixture)).toBe(false);
+    });
+
+    it('should display the clear all button if any filters are selected', () => {
+      const autocompleteFilter = [
+        TEST_DATA_EDITMODE.autocomplete[0],
+        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0],
+        (TEST_DATA_EDITMODE as any).autocomplete[0].autocomplete[0]
+          .autocomplete[0].options[0],
+      ];
+      filterField.filters = [autocompleteFilter];
+      fixture.detectChanges();
+
+      expect(isClearAllVisible(fixture)).toBe(true);
     });
 
     it('should reset the entire filter field', () => {
@@ -1456,6 +1484,7 @@ describe('DtFilterField', () => {
       expect(tagsBefore[0].key).toBe('AUT');
       expect(tagsBefore[0].separator).toBe(':');
       expect(tagsBefore[0].value).toBe('Linz');
+      expect(isClearAllVisible(fixture)).toBe(true);
 
       const clearAllButtonEl = getClearAll(fixture);
       clearAllButtonEl!.click();
@@ -1463,6 +1492,7 @@ describe('DtFilterField', () => {
 
       const tagsAfter = getFilterTags(fixture);
       expect(tagsAfter.length).toBe(0);
+      expect(isClearAllVisible(fixture)).toBe(false);
     });
 
     it('should emit a filter-changed event with all removed filters in the removed array', () => {

--- a/libs/barista-components/filter-field/src/filter-field.ts
+++ b/libs/barista-components/filter-field/src/filter-field.ts
@@ -216,6 +216,10 @@ export class DtFilterField<T = any>
 
   /** Label for the "Clear all" button in the filter field (e.g. "Clear all"). */
   @Input() clearAllLabel = '';
+  /** @internal `true` if the "Clear all" button should be displayed. */
+  get _showClearAll(): boolean {
+    return !!this.clearAllLabel && this._filters.length > 0;
+  }
 
   /** An object used to control when error messages are shown. */
   @Input() errorStateMatcher: ErrorStateMatcher;

--- a/libs/barista-components/filter-field/src/testing/filter-field-test-helpers.ts
+++ b/libs/barista-components/filter-field/src/testing/filter-field-test-helpers.ts
@@ -408,9 +408,5 @@ export function getClearAll(
 
 /** Get the clearAll button and evaluate if it is visible or not. */
 export function isClearAllVisible(fixture: ComponentFixture<any>): boolean {
-  const clearAll = getClearAll(fixture);
-  return (
-    clearAll !== null &&
-    !clearAll.classList.contains('dt-filter-field-clear-all-button-hidden')
-  );
+  return getClearAll(fixture) !== null;
 }


### PR DESCRIPTION
### <strong>Bugfix</strong>

The "Clear all" button was always shown even if there were no filters selected in the filter-field. This has now been fixed and unit tests have been adapted.