### PR TITLE
feat(filter-field): Adding keyboard functionality to multiselect dropbox

### DIFF
--- a/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
@@ -353,7 +353,7 @@ test('should choose a multiselect node with the keyboard and submit the correct 
     .expect(tags.length)
     .eql(1)
     .expect(tags[0])
-    .eql('SeasoningKetchup');
+    .eql('SeasoningNone');
 });
 
 test('should not apply an empty multiselect node with the keyboard', async (testController: TestController) => {

--- a/libs/barista-components/filter-field/src/filter-field-multi-select/filter-field-multi-select.ts
+++ b/libs/barista-components/filter-field/src/filter-field-multi-select/filter-field-multi-select.ts
@@ -15,7 +15,6 @@
  */
 
 import { ActiveDescendantKeyManager, Highlightable } from '@angular/cdk/a11y';
-import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { TemplatePortal } from '@angular/cdk/portal';
 /* eslint-disable @angular-eslint/template/cyclomatic-complexity */
 import {
@@ -65,19 +64,6 @@ export class DtFilterFieldMultiSelectSubmittedEvent<T> {
 export class DtFilterFieldMultiSelect<T>
   implements DtFilterFieldElement<T>, AfterViewInit
 {
-  /**
-   * Whether the first option should be highlighted when the multi-select panel is opened.
-   * Can be configured globally through the `DT_MULTI_SELECT_DEFAULT_OPTIONS` token.
-   */
-  @Input()
-  get autoActiveFirstOption(): boolean {
-    return this._autoActiveFirstOption;
-  }
-  set autoActiveFirstOption(value: boolean) {
-    this._autoActiveFirstOption = coerceBooleanProperty(value);
-  }
-  private _autoActiveFirstOption: boolean;
-
   /**
    * Specify the width of the multi-select panel.  Can be any CSS sizing value, otherwise it will
    * match the width of its host.
@@ -183,7 +169,7 @@ export class DtFilterFieldMultiSelect<T>
     // init keymanager with options
     this._keyManager = new ActiveDescendantKeyManager<DtOption<T>>(
       this._options,
-    ).withWrap();
+    );
 
     this._options.changes
       .pipe(

--- a/libs/barista-components/filter-field/src/filter-field.html
+++ b/libs/barista-components/filter-field/src/filter-field.html
@@ -44,7 +44,11 @@
       #input
       type="text"
       class="dt-filter-field-input"
-      [readonly]="loading"
+      [class.dt-not-blinking]="
+        _currentDef &&
+        _currentDef.multiSelect &&
+        _multiSelectTrigger.element._keyManager.activeItemIndex !== -1
+      "
       [attr.aria-label]="ariaLabel"
       [dtAutocomplete]="autocomplete"
       [dtAutocompleteDisabled]="!_autocompleteOptionsOrGroups.length || loading"
@@ -58,8 +62,16 @@
       "
       (keydown)="_handleInputKeyDown($event)"
       (keyup)="_handleInputKeyUp($event)"
+      (focus)="_handleFocus()"
+      (mousemove)="_handleMouseMove()"
       [value]="_inputValue"
       [disabled]="disabled"
+      [readonly]="
+        loading ||
+        (_currentDef &&
+          _currentDef.multiSelect &&
+          _multiSelectTrigger.element._keyManager.activeItemIndex !== -1)
+      "
     />
     <dt-autocomplete
       #autocomplete="dtAutocomplete"

--- a/libs/barista-components/filter-field/src/filter-field.scss
+++ b/libs/barista-components/filter-field/src/filter-field.scss
@@ -120,6 +120,10 @@ $dt-filter-field-inner-height: 30px;
   outline: none;
   background: transparent;
   z-index: 1;
+  &.dt-not-blinking {
+    color: transparent;
+    text-shadow: 0 0 0 $default-font-color;
+  }
 }
 
 .dt-filter-field-spinner {

--- a/libs/barista-components/filter-field/src/filter-field.ts
+++ b/libs/barista-components/filter-field/src/filter-field.ts
@@ -611,7 +611,6 @@ export class DtFilterField<T = any>
             return;
           } else if (isDtMultiSelectDef(this._currentDef)) {
             this._multiSelectTrigger.openPanel();
-            this._multiSelectTrigger.element.focus();
           }
           // It is necessary to restore the focus back to the input field
           // so the user can directly continue creating more filter nodes.
@@ -794,6 +793,7 @@ export class DtFilterField<T = any>
     this.inputChange.emit(value);
 
     this._validateInput();
+    this._resetFocusOnMultiSelectDef();
     this._changeDetectorRef.markForCheck();
   }
 
@@ -828,8 +828,16 @@ export class DtFilterField<T = any>
       }
     } else if (keyCode === ESCAPE || (keyCode === UP_ARROW && event.altKey)) {
       this._closeFilterPanels();
-    } else if (isDtMultiSelectDef(this._currentDef) && keyCode === SPACE) {
-      event.preventDefault();
+    } else if (isDtMultiSelectDef(this._currentDef)) {
+      // if there is any option focused dont allow typing on input, but allow the use of space to mark/unmarked the checkbox
+      if (
+        keyCode === SPACE &&
+        this._multiSelectTrigger.element._keyManager.activeItemIndex !== null &&
+        this._multiSelectTrigger.element._keyManager.activeItemIndex > -1
+      ) {
+        event.preventDefault();
+      }
+      this._multiSelectTrigger.handleCustomArrowKeyNavigation(keyCode);
     } else {
       if (this._inputFieldKeyboardLocked) {
         return;
@@ -877,6 +885,16 @@ export class DtFilterField<T = any>
     } else {
       this._allowArrowKeyFocusOnTags = this._getAllowArrowKeyFocusOnTags();
     }
+  }
+
+  /** @internal Handles focus on the input */
+  _handleFocus(): void {
+    this._resetFocusOnMultiSelectDef();
+  }
+
+  /** @internal Handles mousemove on the input */
+  _handleMouseMove(): void {
+    this._resetFocusOnMultiSelectDef(false);
   }
 
   /** @internal Handles the navigation through the list of tags when using arrow keys */
@@ -1900,6 +1918,13 @@ export class DtFilterField<T = any>
         this.interactionStateChange.emit(interactionState);
       }
     }
+  }
+
+  private _resetFocusOnMultiSelectDef(doScroll = true): void {
+    if (isDtMultiSelectDef(this._currentDef))
+      this._multiSelectTrigger.resetActiveItemAndKeyManagerLimitsOnPanel(
+        doScroll,
+      );
   }
 }
 /* eslint-disable max-lines */

--- a/libs/barista-components/filter-field/src/testing/filter-field-test-helpers.ts
+++ b/libs/barista-components/filter-field/src/testing/filter-field-test-helpers.ts
@@ -43,10 +43,12 @@ import {
   DtFilterValue,
   isDtAutocompleteValue,
 } from '../types';
+import { DOWN_ARROW, UP_ARROW } from '@angular/cdk/keycodes';
 
 export interface FilterFieldTestContext {
   fixture: ComponentFixture<TestApp>;
   filterField: DtFilterField;
+  inputEl: HTMLInputElement;
   zone: MockNgZone;
   overlayContainer: OverlayContainer;
   overlayContainerElement: HTMLElement;
@@ -64,6 +66,7 @@ export interface FilterFieldTestContext {
 export function setupFilterFieldTest(): FilterFieldTestContext {
   let fixture: ComponentFixture<TestApp> | undefined;
   let filterField: DtFilterField | undefined;
+  let inputEl: HTMLInputElement | undefined;
   let zone: MockNgZone | undefined;
   let overlayContainer: OverlayContainer | undefined;
   let overlayContainerElement: HTMLElement | undefined;
@@ -94,6 +97,7 @@ export function setupFilterFieldTest(): FilterFieldTestContext {
     filterField = fixture.debugElement.query(
       By.directive(DtFilterField),
     ).componentInstance;
+    inputEl = fixture!.debugElement.query(By.css('input')).nativeElement;
   });
   configureTestModule();
 
@@ -132,13 +136,13 @@ export function setupFilterFieldTest(): FilterFieldTestContext {
    * Types the passed value into the filter field input element
    */
   function typeIntoFilterElement(inputString: string): void {
-    const inputEl = fixture!.debugElement.query(By.css('input')).nativeElement;
-    typeInElement(inputString, inputEl);
+    typeInElement(inputString, inputEl!);
   }
 
   return {
     fixture: fixture!,
     filterField: filterField!,
+    inputEl: inputEl!,
     zone: zone!,
     overlayContainer: overlayContainer!,
     overlayContainerElement: overlayContainerElement!,
@@ -298,9 +302,7 @@ export function getRangeApplyButton(
 export function getMultiSelectTrigger(
   overlayContainerElement: HTMLElement,
 ): HTMLElement[] {
-  return Array.from(
-    overlayContainerElement.querySelectorAll('input[dtFilterFieldMultiSelect]'),
-  );
+  return Array.from(overlayContainerElement.querySelectorAll('input'));
 }
 
 export function getMultiSelect(
@@ -422,4 +424,12 @@ export function isClearAllVisible(fixture: ComponentFixture<any>): boolean {
     clearAll !== null &&
     !clearAll.classList.contains('dt-filter-field-clear-all-button-hidden')
   );
+}
+
+export function moveKeyUp(): KeyboardEvent {
+  return new KeyboardEvent('keydown', { keyCode: UP_ARROW });
+}
+
+export function moveKeyDown(): KeyboardEvent {
+  return new KeyboardEvent('keydown', { keyCode: DOWN_ARROW });
 }


### PR DESCRIPTION
### <strong>Pull Request</strong>

<hr>

#### Type of PR

Feature (non-breaking change which adds functionality)
Breaking change (fix or change that would cause existing functionality to not work as expected) 

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Changes

User now is able to navigate from the filter bar to the multiselect options and the other way around, due to that, the auto focus is not working anymore (autoActiveFirstOption) as the focus is set via arrow key navigation.

Cases to consider: 

***Acceptance Criteria 1***
HAVING the filter bar
THEN selecting a multiselect filter
AND start typing
THEN no option should be focused by default
THEN the user press the down arrow key
AND the first option should be focused

***Acceptance Criteria 2***
HAVING the filter bar
THEN selecting a multiselect filter
AND start typing
THEN no option should be focused by default
THEN the user press the up arrow key
THEN it scrolls down to the end of the list
AND the last option must be focused

***Acceptance Criteria 3***
HAVING the first multiselect option focused
THEN the user press the up arrow key
AND the filter field should be focused
AND no option in the list should be focused

***Acceptance Criteria 4***
HAVING the last multiselect option focused
THEN the user press the down arrow key
AND the filter field should be focused
AND no option in the list should be focused

*Note: Navigating through the options with the arrow keys should be still working as it is at this moment*


