### PR TITLE
feat(filter-field): Adding keyboard functionality to multiselect dropbox

### DIFF
--- a/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
+++ b/apps/components-e2e/src/components/filter-field/filter-field.e2e.ts
@@ -353,7 +353,7 @@ test('should choose a multiselect node with the keyboard and submit the correct 
     .expect(tags.length)
     .eql(1)
     .expect(tags[0])
-    .eql('SeasoningKetchup');
+    .eql('SeasoningNone');
 });
 
 test('should not apply an empty multiselect node with the keyboard', async (testController: TestController) => {

--- a/libs/barista-components/filter-field/src/filter-field-multi-select/filter-field-multi-select-trigger.ts
+++ b/libs/barista-components/filter-field/src/filter-field-multi-select/filter-field-multi-select-trigger.ts
@@ -78,6 +78,15 @@ export class DtFilterFieldMultiSelectTrigger<T>
     super.elementDisabled = value;
   }
 
+  /**
+   * It will allow to check if the key manager is already focused on the first active item on multi select panel
+   */
+  isKeyManagerFocusAlreadyOnTop = false;
+  /**
+   * It will allow to check if the key manager is already focused on the last active item on multi select panel
+   */
+  isKeyManagerFocusAlreadyOnBottom = false;
+
   constructor(
     protected _elementRef: ElementRef,
     protected _overlay: Overlay,
@@ -106,7 +115,102 @@ export class DtFilterFieldMultiSelectTrigger<T>
   /** Opens the filter-field multiSelect panel. */
   openPanel(): void {
     if (!this.element._isOpen) {
+      // As now there is no autofocus anymore, the key manager and its boundaries must be reset after opening the panel
+      this.resetActiveItemAndKeyManagerLimitsOnPanel();
       super.openPanel();
+    }
+  }
+
+  /** Closes the filter-field multiSelect panel. */
+  closePanel(shouldEmit: boolean = true): void {
+    if (this.element._isOpen) {
+      // As now there is no autofocus anymore, the key manager and its boundaries must be reset after closing the panel
+      this.resetActiveItemAndKeyManagerLimitsOnPanel();
+      super.closePanel(shouldEmit);
+    }
+  }
+
+  /** Reset the focus of keymanager and limits on panel */
+  resetActiveItemAndKeyManagerLimitsOnPanel(doScroll: boolean = true): void {
+    this._resetActiveItem();
+    this._resetBoundariesOnKeyManager(doScroll);
+  }
+
+  /** Before, navigation was done via wrapping the keymanager, now is done checking current active indexes and key event */
+  handleCustomArrowKeyNavigation(keyCode: number): void {
+    if (keyCode === DOWN_ARROW || keyCode === UP_ARROW) {
+      // Identify valid indexes of active items as key manager cant provide list
+      const activeItemIndexes: number[] = [];
+      this.element._options.toArray().forEach((element, index) => {
+        if (!element.disabled) {
+          activeItemIndexes.push(index);
+        }
+      });
+
+      // if is the first active element
+      if (
+        keyCode == UP_ARROW &&
+        this.element._keyManager.activeItemIndex == activeItemIndexes[0] &&
+        activeItemIndexes.length > 1
+      ) {
+        // if has limit set, go to input focus
+        if (this.isKeyManagerFocusAlreadyOnTop) {
+          this.resetActiveItemAndKeyManagerLimitsOnPanel();
+          // set limit on top
+        } else {
+          this.isKeyManagerFocusAlreadyOnTop = true;
+          this.isKeyManagerFocusAlreadyOnBottom =
+            activeItemIndexes.length === 1;
+        }
+        // from input focus, go to the last active item
+      } else if (
+        keyCode == UP_ARROW &&
+        this.element._keyManager.activeItemIndex == -1 &&
+        activeItemIndexes.length > 0
+      ) {
+        this.element._keyManager.setLastItemActive();
+        this.isKeyManagerFocusAlreadyOnTop = activeItemIndexes.length === 1;
+        this.isKeyManagerFocusAlreadyOnBottom = true;
+        // update limit on first active item
+      } else if (
+        keyCode == DOWN_ARROW &&
+        this.element._keyManager.activeItemIndex == activeItemIndexes[0] &&
+        activeItemIndexes.length > 1
+      ) {
+        this.isKeyManagerFocusAlreadyOnTop = true;
+        this.isKeyManagerFocusAlreadyOnBottom = false;
+        // if is the last active element
+      } else if (
+        keyCode == DOWN_ARROW &&
+        this.element._keyManager.activeItemIndex ==
+          activeItemIndexes[activeItemIndexes.length - 1]
+      ) {
+        // if has limit set, go to input focus
+        if (this.isKeyManagerFocusAlreadyOnBottom) {
+          this.resetActiveItemAndKeyManagerLimitsOnPanel();
+          // set limit on bottom
+        } else {
+          this.isKeyManagerFocusAlreadyOnTop = activeItemIndexes.length === 1;
+          this.isKeyManagerFocusAlreadyOnBottom = true;
+        }
+        // if unique option, reset to input focus
+      } else if (activeItemIndexes.length === 1) {
+        this.resetActiveItemAndKeyManagerLimitsOnPanel();
+        // in any other case, reset
+      } else {
+        this.isKeyManagerFocusAlreadyOnTop = false;
+        this.isKeyManagerFocusAlreadyOnBottom = false;
+      }
+      // do scroll, specially when jumping from panel to input and viceversa
+      if (
+        this.isKeyManagerFocusAlreadyOnTop ||
+        this.isKeyManagerFocusAlreadyOnBottom
+      ) {
+        // When selecting the first active or last active element from list, scroll will take place
+        this.element._keyManager.activeItem
+          ?._getHostElement()
+          ?.scrollIntoView();
+      }
     }
   }
 
@@ -124,7 +228,7 @@ export class DtFilterFieldMultiSelectTrigger<T>
 
     if (!this.element._applyDisabled && keyCode === ENTER && this.panelOpen) {
       this.element._handleSubmit(event);
-      this._resetActiveItem();
+      this.resetActiveItemAndKeyManagerLimitsOnPanel();
 
       event.preventDefault();
     } else if (this.element && this.element._keyManager) {
@@ -147,15 +251,16 @@ export class DtFilterFieldMultiSelectTrigger<T>
         this.element._keyManager.activeItem !== prevActiveItem
       ) {
         this._scrollToOption();
+        this.element._keyManager.activeItem
+          ?._getHostElement()
+          ?.scrollIntoView();
       }
     }
   }
 
-  /** Resets the active item to -1 so arrow events will activate the correct options, or to 0 if the consumer opted into it. */
+  /** Resets the active item to -1 so arrow events will activate the correct options. */
   protected _resetActiveItem(): void {
-    this.element._keyManager.setActiveItem(
-      this.element.autoActiveFirstOption ? 0 : -1,
-    );
+    this.element._keyManager.setActiveItem(-1);
   }
 
   /** The currently active option, coerced to DtOption type. */
@@ -164,6 +269,17 @@ export class DtFilterFieldMultiSelectTrigger<T>
       return this.element._keyManager.activeItem;
     }
     return null;
+  }
+
+  /**
+   * After doing use of key navigation, it will reset boundary controls on multi select panel
+   * @param doScroll if true, does scroll into view for the current focused element, on the key manager
+   */
+  private _resetBoundariesOnKeyManager(doScroll: boolean): void {
+    this.isKeyManagerFocusAlreadyOnTop = false;
+    this.isKeyManagerFocusAlreadyOnBottom = false;
+    if (doScroll)
+      this.element._options.get(0)?._getHostElement().scrollIntoView();
   }
 
   protected _scrollToOption(): void {

--- a/libs/barista-components/filter-field/src/filter-field-multi-select/filter-field-multi-select.ts
+++ b/libs/barista-components/filter-field/src/filter-field-multi-select/filter-field-multi-select.ts
@@ -15,7 +15,6 @@
  */
 
 import { ActiveDescendantKeyManager, Highlightable } from '@angular/cdk/a11y';
-import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { TemplatePortal } from '@angular/cdk/portal';
 // tslint:disable: template-cyclomatic-complexity
 import {
@@ -64,19 +63,6 @@ export class DtFilterFieldMultiSelectSubmittedEvent<T> {
 export class DtFilterFieldMultiSelect<T>
   implements DtFilterFieldElement<T>, AfterViewInit
 {
-  /**
-   * Whether the first option should be highlighted when the multi-select panel is opened.
-   * Can be configured globally through the `DT_MULTI_SELECT_DEFAULT_OPTIONS` token.
-   */
-  @Input()
-  get autoActiveFirstOption(): boolean {
-    return this._autoActiveFirstOption;
-  }
-  set autoActiveFirstOption(value: boolean) {
-    this._autoActiveFirstOption = coerceBooleanProperty(value);
-  }
-  private _autoActiveFirstOption: boolean;
-
   /**
    * Specify the width of the multi-select panel.  Can be any CSS sizing value, otherwise it will
    * match the width of its host.
@@ -179,7 +165,7 @@ export class DtFilterFieldMultiSelect<T>
     // init keymanager with options
     this._keyManager = new ActiveDescendantKeyManager<DtOption<T>>(
       this._options,
-    ).withWrap();
+    );
 
     this._options.changes
       .pipe(

--- a/libs/barista-components/filter-field/src/filter-field.html
+++ b/libs/barista-components/filter-field/src/filter-field.html
@@ -36,7 +36,6 @@
       type="text"
       class="dt-filter-field-input"
       [id]="_id"
-      [readonly]="loading"
       [attr.aria-label]="ariaLabel"
       [dtAutocomplete]="autocomplete"
       [dtAutocompleteDisabled]="!_autocompleteOptionsOrGroups.length || loading"
@@ -50,8 +49,11 @@
       "
       (keydown)="_handleInputKeyDown($event)"
       (keyup)="_handleInputKeyUp($event)"
+      (focus)="_handleFocus()"
+      (mousemove)="_handleMouseMove()"
       [value]="_inputValue"
       [disabled]="disabled"
+      [readonly]="loading || isOptionOnMultiSelectSelected"
     />
     <dt-autocomplete
       #autocomplete="dtAutocomplete"

--- a/libs/barista-components/filter-field/src/filter-field.ts
+++ b/libs/barista-components/filter-field/src/filter-field.ts
@@ -30,6 +30,7 @@ import {
   ESCAPE,
   LEFT_ARROW,
   SPACE,
+  TAB,
   UP_ARROW,
 } from '@angular/cdk/keycodes';
 import { DOCUMENT } from '@angular/common';
@@ -503,6 +504,17 @@ export class DtFilterField<T = any>
     return this._currentDef !== null && this._currentDef !== this._rootDef;
   }
 
+  /**
+   * Check if there is any option focused with keymanager on the opened multiselect panel
+   */
+  get isOptionOnMultiSelectSelected(): boolean {
+    return (
+      this._currentDef !== null &&
+      isDtMultiSelectDef(this._currentDef) &&
+      this._multiSelectTrigger.element._keyManager.activeItemIndex !== -1
+    );
+  }
+
   /** Emits whenever the component is destroyed. */
   private readonly _destroy$ = new Subject<void>();
 
@@ -599,7 +611,6 @@ export class DtFilterField<T = any>
             return;
           } else if (isDtMultiSelectDef(this._currentDef)) {
             this._multiSelectTrigger.openPanel();
-            this._multiSelectTrigger.element.focus();
           }
           // It is necessary to restore the focus back to the input field
           // so the user can directly continue creating more filter nodes.
@@ -782,6 +793,7 @@ export class DtFilterField<T = any>
     this.inputChange.emit(value);
 
     this._validateInput();
+    this._resetFocusOnMultiSelectDef();
     this._changeDetectorRef.markForCheck();
   }
 
@@ -816,8 +828,20 @@ export class DtFilterField<T = any>
       }
     } else if (keyCode === ESCAPE || (keyCode === UP_ARROW && event.altKey)) {
       this._closeFilterPanels();
-    } else if (isDtMultiSelectDef(this._currentDef) && keyCode === SPACE) {
-      event.preventDefault();
+    } else if (isDtMultiSelectDef(this._currentDef)) {
+      if (keyCode === TAB) {
+        this._multiSelectTrigger.closePanel();
+        return;
+      }
+      // if there is any option focused dont allow typing on input, but allow the use of space to mark/unmarked the checkbox
+      if (
+        keyCode === SPACE &&
+        this._multiSelectTrigger.element._keyManager.activeItemIndex !== null &&
+        this._multiSelectTrigger.element._keyManager.activeItemIndex > -1
+      ) {
+        event.preventDefault();
+      }
+      this._multiSelectTrigger.handleCustomArrowKeyNavigation(keyCode);
     } else {
       if (this._inputFieldKeyboardLocked) {
         return;
@@ -865,6 +889,16 @@ export class DtFilterField<T = any>
     } else {
       this._allowArrowKeyFocusOnTags = this._getAllowArrowKeyFocusOnTags();
     }
+  }
+
+  /** @internal Handles focus on the input */
+  _handleFocus(): void {
+    this._resetFocusOnMultiSelectDef();
+  }
+
+  /** @internal Handles mousemove on the input */
+  _handleMouseMove(): void {
+    this._resetFocusOnMultiSelectDef(false);
   }
 
   /** @internal Handles the navigation through the list of tags when using arrow keys */
@@ -1884,6 +1918,16 @@ export class DtFilterField<T = any>
         this.interactionStateChange.emit(interactionState);
       }
     }
+  }
+
+  private _resetFocusOnMultiSelectDef(doScroll: boolean = true): void {
+    if (
+      isDtMultiSelectDef(this._currentDef) &&
+      this._multiSelect._keyManager.activeItemIndex !== -1
+    )
+      this._multiSelectTrigger.resetActiveItemAndKeyManagerLimitsOnPanel(
+        doScroll,
+      );
   }
 }
 // tslint:disable:max-file-line-count

--- a/libs/barista-components/filter-field/src/testing/filter-field-test-helpers.ts
+++ b/libs/barista-components/filter-field/src/testing/filter-field-test-helpers.ts
@@ -41,10 +41,12 @@ import {
   DtFilterValue,
   isDtAutocompleteValue,
 } from '../types';
+import { DOWN_ARROW, UP_ARROW } from '@angular/cdk/keycodes';
 
 export interface FilterFieldTestContext {
   fixture: ComponentFixture<TestApp>;
   filterField: DtFilterField;
+  inputElement: HTMLInputElement;
   zone: MockNgZone;
   overlayContainer: OverlayContainer;
   overlayContainerElement: HTMLElement;
@@ -62,6 +64,7 @@ export interface FilterFieldTestContext {
 export function setupFilterFieldTest(): FilterFieldTestContext {
   let fixture: ComponentFixture<TestApp> | undefined;
   let filterField: DtFilterField | undefined;
+  let inputElement: HTMLInputElement | undefined;
   let zone: MockNgZone | undefined;
   let overlayContainer: OverlayContainer | undefined;
   let overlayContainerElement: HTMLElement | undefined;
@@ -92,6 +95,7 @@ export function setupFilterFieldTest(): FilterFieldTestContext {
     filterField = fixture.debugElement.query(
       By.directive(DtFilterField),
     ).componentInstance;
+    inputElement = fixture!.debugElement.query(By.css('input')).nativeElement;
   });
   configureTestModule();
 
@@ -130,13 +134,13 @@ export function setupFilterFieldTest(): FilterFieldTestContext {
    * Types the passed value into the filter field input element
    */
   function typeIntoFilterElement(inputString: string): void {
-    const inputEl = fixture!.debugElement.query(By.css('input')).nativeElement;
-    typeInElement(inputString, inputEl);
+    typeInElement(inputString, inputElement!);
   }
 
   return {
     fixture: fixture!,
     filterField: filterField!,
+    inputElement: inputElement!,
     zone: zone!,
     overlayContainer: overlayContainer!,
     overlayContainerElement: overlayContainerElement!,
@@ -293,9 +297,7 @@ export function getRangeApplyButton(
 export function getMultiSelectTrigger(
   overlayContainerElement: HTMLElement,
 ): HTMLElement[] {
-  return Array.from(
-    overlayContainerElement.querySelectorAll('input[dtFilterFieldMultiSelect]'),
-  );
+  return Array.from(overlayContainerElement.querySelectorAll('input'));
 }
 
 export function getMultiSelect(
@@ -409,4 +411,12 @@ export function getClearAll(
 /** Get the clearAll button and evaluate if it is visible or not. */
 export function isClearAllVisible(fixture: ComponentFixture<any>): boolean {
   return getClearAll(fixture) !== null;
+}
+
+export function moveKeyUp(): KeyboardEvent {
+  return new KeyboardEvent('keydown', { keyCode: UP_ARROW });
+}
+
+export function moveKeyDown(): KeyboardEvent {
+  return new KeyboardEvent('keydown', { keyCode: DOWN_ARROW });
 }


### PR DESCRIPTION
### <strong>Pull Request</strong>

<hr>

#### Type of PR

Feature (non-breaking change which adds functionality)
Breaking change (fix or change that would cause existing functionality to not work as expected) 

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Changes

User now is able to navigate from the filter bar to the multiselect options and the other way around, due to that, the auto focus is not working anymore (autoActiveFirstOption) as the focus is set via arrow key navigation.

Cases to consider: 

***Acceptance Criteria 1***
HAVING the filter bar
THEN selecting a multiselect filter
AND start typing
THEN no option should be focused by default
THEN the user press the down arrow key
AND the first option should be focused

***Acceptance Criteria 2***
HAVING the filter bar
THEN selecting a multiselect filter
AND start typing
THEN no option should be focused by default
THEN the user press the up arrow key
THEN it scrolls down to the end of the list
AND the last option must be focused

***Acceptance Criteria 3***
HAVING the first multiselect option focused
THEN the user press the up arrow key
AND the filter field should be focused
AND no option in the list should be focused

***Acceptance Criteria 4***
HAVING the last multiselect option focused
THEN the user press the down arrow key
AND the filter field should be focused
AND no option in the list should be focused

*Note: Navigating through the options with the arrow keys should be still working as it is at this moment*


