### PR TITLE
fix(expandable-panel): Fixed animation state issue when panel is insi…

### DIFF
--- a/libs/barista-components/expandable-panel/src/expandable-panel-animations.ts
+++ b/libs/barista-components/expandable-panel/src/expandable-panel-animations.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2021 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  AnimationTriggerMetadata,
+  animate,
+  state,
+  style,
+  transition,
+  trigger,
+} from '@angular/animations';
+
+export const dtExpandablePanelAnimation: AnimationTriggerMetadata[] = [
+  /**
+   * There is a bug in Angular's animation 'state' that causes the animation state to become void upon leaving the dom.
+   * This can lead to a situation for the expansion panel where the state
+   * of the panel is `expanded` or `collapsed` but the animation state is `void`.
+   *
+   * To correctly handle animating to the next state, we animate between `void` and `collapsed` which
+   * are defined to have the same styles. Since angular animates from the current styles to the
+   * destination state's style definition, in situations where we are moving from `void`'s styles to
+   * `collapsed` this acts a noop since no style values change.
+   *
+   * Thanks to Angular material docs for finding this out here:
+   * https://github.com/angular/components/blob/main/src/material/expansion/expansion-animations.ts
+   *
+   * Angular Bug: https://github.com/angular/angular/issues/18847
+   */
+  trigger('animationState', [
+    state('collapsed, void', style({ height: '0px', visibility: 'hidden' })),
+    state(
+      'expanded',
+      style({ height: '*', visibility: 'visible', overflow: 'visible' }),
+    ),
+    transition(
+      'expanded <=> collapsed, void => collapsed',
+      animate('225ms cubic-bezier(0.4,0.0,0.2,1)'),
+    ),
+  ]),
+];

--- a/libs/barista-components/expandable-panel/src/expandable-panel.html
+++ b/libs/barista-components/expandable-panel/src/expandable-panel.html
@@ -1,3 +1,3 @@
-<div [@animationState]="expanded">
+<div [@animationState]="_animationState">
   <ng-content></ng-content>
 </div>


### PR DESCRIPTION
…de a container that gets removed from the DOM.

Updated behavior
![heat-field-expandable-panel](https://user-images.githubusercontent.com/59170440/186408704-59829161-583a-46b8-b7f0-adf3f7581ba1.gif)


### <strong>Pull Request</strong>

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR

<!-- Bugfix (non-breaking change which fixes an issue) -->
<!-- Feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or change that would cause existing functionality to not work as expected) -->
<!-- Documentation update (changes to documentation) -->
<!-- Other (if none of the above apply) -->

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
