### PR TITLE
chore: Fix tsconfig path resolution.

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -210,7 +210,7 @@
         "libs/barista-components/tree-table/index.ts"
       ],
       "@dynatrace/barista-examples": ["libs/examples/src/index.ts"],
-      "@dynatrace/barista-examples/*": ["libs/examples/src/*/index.ts"],
+      "@dynatrace/barista-examples/*": ["libs/examples/src/*"],
       "@dynatrace/shared/data-access-strapi": [
         "libs/shared/data-access-strapi/index.ts"
       ],


### PR DESCRIPTION
'*' works as replacement for a module, not as a glob pattern here.

Fixes the error:
File '*/barista/libs/examples/src/*/index.ts' not found.
  The file is in the program because:
    Root file specified for compilation

This is visible only within IDE, here VSCode. I assume types resolution/paths replacement skips the problem during cli based execution:

![image](https://user-images.githubusercontent.com/14539/192365653-6c847c3c-196e-43af-9fec-e379c773f04e.png)


Thanks!


#### Type of PR

Bugfix (non-breaking change which fixes an issue)

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes