### PR TITLE
feat(tag-add): Add possibility to customise add tag button label and …

### DIFF
--- a/apps/demos/src/app-routing.module.ts
+++ b/apps/demos/src/app-routing.module.ts
@@ -341,6 +341,7 @@ import {
   DtExampleTreeTableDefault,
   DtExampleTreeTableProblemIndicator,
   DtExampleTreeTableSimple,
+  DtExampleOverrideLabelsTag,
 } from '@dynatrace/barista-examples';
 
 // The Routing Module replaces the routing configuration in the root or feature module.
@@ -1223,6 +1224,10 @@ const ROUTES: Routes = [
     component: DtExampleSelectCustomValueTemplate,
   },
   { path: 'tag-custom-add-form-example', component: DtExampleCustomAddFormTag },
+  {
+    path: 'tag-override-labels-example',
+    component: DtExampleOverrideLabelsTag,
+  },
 ];
 
 @NgModule({

--- a/apps/demos/src/nav-items.ts
+++ b/apps/demos/src/nav-items.ts
@@ -1510,6 +1510,10 @@ export const DT_DEMOS_EXAMPLE_NAV_ITEMS = [
         name: 'tag-custom-add-form-example',
         route: '/tag-custom-add-form-example',
       },
+      {
+        name: 'tag-override-labels-example',
+        route: '/tag-override-labels-example',
+      },
     ],
   },
   {

--- a/apps/dev/src/app.module.ts
+++ b/apps/dev/src/app.module.ts
@@ -23,7 +23,7 @@ import {
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { HttpClientModule } from '@angular/common/http';
 import { Component, NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { DevAppRoutingModule } from './devapp-routing.module';
@@ -115,6 +115,7 @@ export class NoopRouteComponent {}
     DtIconModule.forRoot({ svgIconLocation: '/assets/icons/{{name}}.svg' }),
     DevAppDynatraceModule,
     DragDropModule,
+    ReactiveFormsModule,
   ],
   declarations: [
     DevApp,

--- a/apps/dev/src/tag/tag-demo.component.html
+++ b/apps/dev/src/tag/tag-demo.component.html
@@ -79,3 +79,59 @@
     dt-ui-test-id="tag-add"
   ></dt-tag-add>
 </dt-tag-list>
+<br /><br />
+
+<dt-tag-list>
+  <dt-tag *ngFor="let zone of zones">{{ zone }}</dt-tag>
+  <dt-tag-add
+    placeholder="Name"
+    title="Add Custom Management Zone"
+    label="Add Zone"
+    submitLabel="Save"
+    (submitted)="addZone($event)"
+    dt-ui-test-id="tag-add"
+  ></dt-tag-add>
+</dt-tag-list>
+<br /><br />
+
+<dt-tag-list aria-label="A list of tags.">
+  <dt-tag *ngFor="let tag of tagsWithKeys">
+    <dt-tag-key *ngIf="tag.key">[{{ tag.key }}]:</dt-tag-key>
+    {{ tag.value }}
+  </dt-tag>
+  <dt-tag-add
+    placeholder="insert tag name here"
+    aria-label="tag input"
+    title="This is a very long overlay title that might not fit in the modal"
+    label="Add very long tags here"
+    submitLabel="Submit this very long tag"
+    #tagAdd
+    (submitted)="addTag($event)"
+  >
+    <form [formGroup]="keyValueForm" class="ba-key-value-form">
+      <dt-form-field class="ba-key-form-field">
+        <dt-label>Key (Required)</dt-label>
+        <input
+          #key
+          type="text"
+          dtInput
+          aria-label="Tag key"
+          required
+          formControlName="key"
+          (keyup.enter)="tagAdd.submit()"
+        />
+      </dt-form-field>
+      <dt-form-field>
+        <dt-label>Value</dt-label>
+        <input
+          #value
+          type="text"
+          dtInput
+          aria-label="Tag value"
+          formControlName="value"
+          (keyup.enter)="tagAdd.submit()"
+        />
+      </dt-form-field>
+    </form>
+  </dt-tag-add>
+</dt-tag-list>

--- a/apps/dev/src/tag/tag-demo.component.ts
+++ b/apps/dev/src/tag/tag-demo.component.ts
@@ -17,6 +17,7 @@
 import { Component, OnInit } from '@angular/core';
 
 import { DtTag } from '@dynatrace/barista-components/tag';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 
 @Component({
   selector: 'tag-dev-app-demo',
@@ -26,6 +27,18 @@ import { DtTag } from '@dynatrace/barista-components/tag';
 export class TagDemo implements OnInit {
   tags = new Set<string>();
   users = new Set<string>();
+  zones = new Set<string>();
+
+  tagsWithKeys = new Set<{ key: string; value?: string }>([
+    { key: 'someKey', value: 'someValue' },
+    { key: 'anotherKey', value: 'anotherValue' },
+    { key: 'onlyKey' },
+  ]);
+
+  keyValueForm = new FormGroup({
+    key: new FormControl('', [Validators.required]),
+    value: new FormControl(''),
+  });
 
   value1 = 'My value 1';
   value2 = 'My value 2';
@@ -85,6 +98,8 @@ export class TagDemo implements OnInit {
       .add('Pine1233');
 
     this.users.add('John').add('Jane').add('Max');
+
+    this.zones.add('[Kubernetes] Google Kubernetes Engine').add('casp-test');
   }
 
   addTag(tag: string): void {
@@ -93,6 +108,10 @@ export class TagDemo implements OnInit {
 
   addUser(event: { tag: string }): void {
     this.users.add(event.tag);
+  }
+
+  addZone(event: { tag: string }): void {
+    this.zones.add(event.tag);
   }
 
   doRemove(tag: DtTag<string>): void {

--- a/libs/barista-components/tag/README.md
+++ b/libs/barista-components/tag/README.md
@@ -65,11 +65,13 @@ elements.
 
 ### Inputs
 
-| Name          | Type     | Default      | Description                                                             |
-| ------------- | -------- | ------------ | ----------------------------------------------------------------------- |
-| `placeholder` | `string` | `undefined`  | Placeholder string for the add tag input overlay.                       |
-| `aria-label`  | `string` | `undefinded` | Used to set the 'aria-label' attribute on the underlying input element. |
-| `title`       | `string` | `Add Tag`    | Title of the 'Add' button and overlay.                                  |
+| Name          | Type     | Default     | Description                                                             |
+| ------------- | -------- | ----------- | ----------------------------------------------------------------------- |
+| `placeholder` | `string` | `undefined` | Placeholder string for the add tag input overlay.                       |
+| `aria-label`  | `string` | `undefined` | Used to set the 'aria-label' attribute on the underlying input element. |
+| `title`       | `string` | `Add Tag`   | Title of the overlay and 'Add Tag' button.                              |
+| `submitLabel` | `string` | `Add`       | Title of the 'Add' submit button.                                       |
+| `label`       | `string` | `undefined` | Title of the 'Add Tag' button. Used to overwrite the default label.     |
 
 ### Outputs
 

--- a/libs/barista-components/tag/src/tag-add/tag-add-button.ts
+++ b/libs/barista-components/tag/src/tag-add/tag-add-button.ts
@@ -24,9 +24,8 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
       dt-button
       (click)="handleClick($event)"
       [disabled]="!this.valid"
-      i18n
     >
-      Add
+      {{ label }}
     </button>
   `,
 })
@@ -34,6 +33,8 @@ export class DtTagAddButton {
   @Output() readonly click = new EventEmitter<Event>();
 
   @Input() valid: boolean;
+
+  @Input() label: string;
 
   handleClick(event: Event): void {
     this.click.emit(event);

--- a/libs/barista-components/tag/src/tag-add/tag-add.html
+++ b/libs/barista-components/tag/src/tag-add/tag-add.html
@@ -5,9 +5,10 @@
     cdk-overlay-origin
     (click)="open()"
     #origin="cdkOverlayOrigin"
+    [title]="label ?? title"
   >
     <dt-icon class="dt-tag-add-icon-button" name="plus-add"></dt-icon>
-    <span class="dt-tag-add-button-text">{{ title }}</span>
+    <span class="dt-tag-add-button-text">{{ label ?? title }}</span>
   </button>
   <ng-template
     #overlay
@@ -32,7 +33,7 @@
     >
       <div class="dt-tag-add-header">
         <dt-icon class="dt-tag-add-icon" name="plus-add"></dt-icon>
-        {{ title }}
+        <span class="dt-tag-add-header-text">{{ title }}</span>
       </div>
       <div *ngIf="_hasCustomForm$ | async" class="dt-tag-add-custom-form">
         <ng-content></ng-content>
@@ -53,6 +54,7 @@
           <dt-tag-add-button
             [valid]="_currentFormValid$ | async"
             (click)="submit()"
+            [label]="submitLabel"
           ></dt-tag-add-button>
         </form>
       </ng-container>
@@ -60,6 +62,7 @@
         *ngIf="_hasCustomForm$ | async"
         [valid]="_currentFormValid$ | async"
         (click)="submit()"
+        [label]="submitLabel"
       ></dt-tag-add-button>
       <button
         class="dt-tag-add-close-button"

--- a/libs/barista-components/tag/src/tag-add/tag-add.scss
+++ b/libs/barista-components/tag/src/tag-add/tag-add.scss
@@ -51,10 +51,11 @@
   display: grid;
   gap: 4px;
   grid-template-columns: 1fr 32px;
-  grid-template-rows: 32px 1fr;
+  grid-template-rows: 32px 1fr fit-content(32px);
   grid-template-areas:
     'header close'
-    'form form';
+    'form form'
+    'submit submit';
   border: 1px solid $gray-700;
   border-radius: 3px;
   background-color: $gray-700;
@@ -71,6 +72,7 @@
   gap: 8px;
   align-items: center;
 
+  @include dt-text-ellipsis();
   @include dt-cdkmonitor-focus-style(true);
 }
 
@@ -78,6 +80,7 @@
 .dt-tag-add-icon-button {
   width: 16px;
   height: 16px;
+  min-width: 16px;
   vertical-align: text-top;
   fill: #ffffff;
 
@@ -90,9 +93,15 @@
   fill: $turquoise-600;
 }
 
-.dt-tag-add-submit-button {
-  grid-area: form;
-  justify-self: flex-end;
+dt-tag-add-button {
+  grid-area: submit;
+  max-width: 100%;
+
+  ::ng-deep .dt-tag-add-submit-button {
+    max-width: 100%;
+
+    @include dt-text-ellipsis();
+  }
 }
 
 .dt-tag-add-custom-form {
@@ -106,5 +115,15 @@
 .dt-tag-add-default-form {
   grid-area: form;
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
+
+  .dt-tag-add-input {
+    flex-grow: 1;
+    flex-basis: max-content;
+  }
+}
+
+.dt-tag-add-header-text {
+  @include dt-text-ellipsis();
 }

--- a/libs/barista-components/tag/src/tag-add/tag-add.spec.ts
+++ b/libs/barista-components/tag/src/tag-add/tag-add.spec.ts
@@ -374,6 +374,66 @@ describe('DtTagAdd', () => {
       expect(formHeader.textContent).toMatch(customTitle);
     });
   });
+
+  describe('with custom button label', () => {
+    let fixture: ComponentFixture<DtTagComponentCustomButtonLabel>;
+
+    beforeEach(() => {
+      fixture = configureTestingModule(DtTagComponentCustomButtonLabel);
+    });
+
+    afterEach(() => {
+      overlayContainer.ngOnDestroy();
+    });
+
+    it('should have a custom button title', () => {
+      const customLabel = 'custom';
+      const addButtonSpan = addTagNativeElement.querySelector(
+        '.dt-tag-add-button-text',
+      ) as HTMLSpanElement;
+
+      expect(addTagInstance.label).toBe(customLabel);
+      expect(addButtonSpan.textContent).toMatch(customLabel);
+    });
+
+    it('should not change form title', () => {
+      addTagInstance.open();
+      fixture.detectChanges();
+
+      const formHeader = overlayContainerElement.querySelector(
+        '.dt-tag-add-header',
+      ) as HTMLButtonElement;
+      const title = 'Add Tag';
+
+      expect(addTagInstance.title).toBe(title);
+      expect(formHeader.textContent).toMatch(title);
+    });
+  });
+
+  describe('with custom submit button label', () => {
+    let fixture: ComponentFixture<DtTagComponentCustomSubmitButtonLabel>;
+
+    beforeEach(() => {
+      fixture = configureTestingModule(DtTagComponentCustomSubmitButtonLabel);
+    });
+
+    afterEach(() => {
+      overlayContainer.ngOnDestroy();
+    });
+
+    it('should have custom submit button label', () => {
+      addTagInstance.open();
+      fixture.detectChanges();
+
+      const customLabel = 'custom';
+      const submitButtonSpan = overlayContainerElement.querySelector(
+        '.dt-tag-add-submit-button',
+      ) as HTMLSpanElement;
+
+      expect(addTagInstance.submitLabel).toBe(customLabel);
+      expect(submitButtonSpan.textContent).toMatch(customLabel);
+    });
+  });
 });
 
 /** Test component that contains an DtTagAdd. */
@@ -455,6 +515,56 @@ class DtTagCustomFormComponent implements OnInit {
   `,
 })
 class DtTagComponentCustomTitle implements OnInit {
+  tags = new Set<string>();
+
+  ngOnInit(): void {
+    this.tags.add('Window').add('Managed').add('Errors');
+  }
+
+  addTag(event: DtTagAddSubmittedDefaultEvent): void {
+    this.tags.add(event.tag);
+  }
+}
+
+/** Test component that contains an DtTagAdd with a custom button label. */
+@Component({
+  selector: 'dt-test-app',
+  template: `
+    <dt-tag *ngFor="let tag of tags">{{ tag }}</dt-tag>
+    <dt-tag-add
+      placeholder="insert tag here"
+      label="custom"
+      (submitted)="addTag($event)"
+      dt-ui-test-id="tag-add"
+    ></dt-tag-add>
+  `,
+})
+class DtTagComponentCustomButtonLabel implements OnInit {
+  tags = new Set<string>();
+
+  ngOnInit(): void {
+    this.tags.add('Window').add('Managed').add('Errors');
+  }
+
+  addTag(event: DtTagAddSubmittedDefaultEvent): void {
+    this.tags.add(event.tag);
+  }
+}
+
+/** Test component that contains an DtTagAdd with a custom submit button label. */
+@Component({
+  selector: 'dt-test-app',
+  template: `
+    <dt-tag *ngFor="let tag of tags">{{ tag }}</dt-tag>
+    <dt-tag-add
+      placeholder="insert tag here"
+      submitLabel="custom"
+      (submitted)="addTag($event)"
+      dt-ui-test-id="tag-add"
+    ></dt-tag-add>
+  `,
+})
+class DtTagComponentCustomSubmitButtonLabel implements OnInit {
   tags = new Set<string>();
 
   ngOnInit(): void {

--- a/libs/barista-components/tag/src/tag-add/tag-add.ts
+++ b/libs/barista-components/tag/src/tag-add/tag-add.ts
@@ -76,8 +76,17 @@ export class DtTagAdd implements OnDestroy, AfterContentInit {
   /** Placeholder for the input of the add-tag overlay input. */
   @Input() placeholder: string;
 
-  /** Title of the button and the add-tag overlay input. */
+  /** Title of the add-tag overlay input. */
   @Input() title = 'Add Tag';
+
+  /**
+   * Used to override the label for the button that triggers the Overlay.
+   * If not provided, label will be the same as title of add-tag overlay input
+   */
+  @Input() label?: string;
+
+  /** Used to override the label of the submit button in add-tag Overlay */
+  @Input() submitLabel = 'Add';
 
   /** Used to set the 'aria-label' attribute on the underlying input element. */
   @Input('aria-label') ariaLabel: string;

--- a/libs/examples/src/index.ts
+++ b/libs/examples/src/index.ts
@@ -349,6 +349,7 @@ import { DtExampleTreeTableProblemIndicator } from './tree-table/tree-table-prob
 import { DtExampleTreeTableSimple } from './tree-table/tree-table-simple-example/tree-table-simple-example';
 import { DtExampleCustomAddFormTag } from '././tag/tag-custom-add-form-example/tag-custom-add-form-example';
 import { DtExampleStackedSeriesChartHeatField } from '././stacked-series-chart/stacked-series-chart-heat-field-example/stacked-series-chart-heat-field-example';
+import { DtExampleOverrideLabelsTag } from '././tag/tag-override-labels-example/tag-override-labels-example';
 import { DtExampleHighlightTermArray } from './highlight';
 export { DtAlertExamplesModule } from './alert/alert-examples.module';
 export { DtAutocompleteExamplesModule } from './autocomplete/autocomplete-examples.module';
@@ -741,6 +742,7 @@ export {
   DtExampleDatepickerDark,
   DtExampleDatepickerDefault,
   DtExampleCustomAddFormTag,
+  DtExampleOverrideLabelsTag,
 };
 
 export const EXAMPLES_MAP = new Map<string, Type<unknown>>([
@@ -1141,4 +1143,5 @@ export const EXAMPLES_MAP = new Map<string, Type<unknown>>([
   ['DtExampleTreeTableProblemIndicator', DtExampleTreeTableProblemIndicator],
   ['DtExampleTreeTableSimple', DtExampleTreeTableSimple],
   ['DtExampleCustomAddFormTag', DtExampleCustomAddFormTag],
+  ['DtExampleOverrideLabelsTag', DtExampleOverrideLabelsTag],
 ]);

--- a/libs/examples/src/tag/tag-examples.module.ts
+++ b/libs/examples/src/tag/tag-examples.module.ts
@@ -26,6 +26,7 @@ import { DtExampleTagListWithTagAdd } from './tag-list-with-tag-add-example/tag-
 import { DtExampleTagRemovable } from './tag-removable-example/tag-removable-example';
 import { DtExampleCustomAddFormTag } from './tag-custom-add-form-example/tag-custom-add-form-example';
 import { DtInputModule } from '@dynatrace/barista-components/input';
+import { DtExampleOverrideLabelsTag } from './tag-override-labels-example/tag-override-labels-example';
 
 @NgModule({
   imports: [
@@ -44,6 +45,7 @@ import { DtInputModule } from '@dynatrace/barista-components/input';
     DtExampleTagListWithTagAdd,
     DtExampleTagRemovable,
     DtExampleCustomAddFormTag,
+    DtExampleOverrideLabelsTag,
   ],
 })
 export class DtExamplesTagModule {}

--- a/libs/examples/src/tag/tag-override-labels-example/tag-override-labels-example.html
+++ b/libs/examples/src/tag/tag-override-labels-example/tag-override-labels-example.html
@@ -1,0 +1,11 @@
+<dt-tag-list>
+  <dt-tag *ngFor="let zone of zones">{{ zone }}</dt-tag>
+  <dt-tag-add
+    placeholder="Name"
+    title="Add Custom Management Zone"
+    label="Add Zone"
+    submitLabel="Save"
+    (submitted)="addZone($event)"
+    dt-ui-test-id="tag-add"
+  ></dt-tag-add>
+</dt-tag-list>

--- a/libs/examples/src/tag/tag-override-labels-example/tag-override-labels-example.ts
+++ b/libs/examples/src/tag/tag-override-labels-example/tag-override-labels-example.ts
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
-export * from './tag-default-example/tag-default-example';
-export * from './tag-examples.module';
-export * from './tag-interactive-example/tag-interactive-example';
-export * from './tag-key-example/tag-key-example';
-export * from './tag-list-with-tag-add-example/tag-list-with-tag-add-example';
-export * from './tag-removable-example/tag-removable-example';
-export * from './tag-custom-add-form-example/tag-custom-add-form-example';
-export * from './tag-override-labels-example/tag-override-labels-example';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'dt-example-override-labels-tag',
+  templateUrl: './tag-override-labels-example.html',
+})
+export class DtExampleOverrideLabelsTag {
+  zones = new Set(['[Kubernetes] Google Kubernetes Engine', 'casp-test']);
+
+  addZone(event: { tag: string }): void {
+    this.zones.add(event.tag);
+  }
+}


### PR DESCRIPTION
…overlay header independently.

### <strong>Pull Request</strong>

Motivation: PS-3788

This PR adds possibility to define 'Add tag' and overlay header title independently, as well as making submit button label 'Add' configurable. 

After changes: 
<img width="469" alt="Screenshot 2022-09-29 at 16 29 55" src="https://user-images.githubusercontent.com/7198185/193062613-b9e06989-7fe0-4cc0-b1ea-03c4dc59d26b.png">
<img width="655" alt="Screenshot 2022-09-29 at 16 30 06" src="https://user-images.githubusercontent.com/7198185/193062629-87e92735-efed-4f9e-a325-c2deec02eb45.png">


<hr>

Please choose the type appropriate for the changes below: <br>

#### Type of PR

Feature

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
