### PR TITLE
fix(progress-bar): Fix faulty progress calculation when min and max a…

### DIFF
--- a/libs/barista-components/core/src/common-behaviours/progress.ts
+++ b/libs/barista-components/core/src/common-behaviours/progress.ts
@@ -115,8 +115,12 @@ export function mixinHasProgress<T extends Constructor<{}>>(
 
     /** Calculates the percentage of the progress component that a value is. */
     private _calculatePercentage(value: number | null): number {
-      // tslint:disable-next-line: no-magic-numbers
-      return clamp((((value || 0) - this.min) / (this.max - this.min)) * 100);
+      const { min, max } = this;
+      const actualValue = value ?? 0;
+
+      return max > min
+        ? clamp(Math.abs((actualValue - min) / (max - min)) * 100) // tslint:disable-line: no-magic-numbers
+        : 0;
     }
 
     /** @internal Updates all parameters */

--- a/libs/barista-components/progress-bar/src/progress-bar.spec.ts
+++ b/libs/barista-components/progress-bar/src/progress-bar.spec.ts
@@ -92,6 +92,58 @@ describe('DtProgressBar', () => {
     expect(progressComponent.value).toBe(0);
   });
 
+  it('should set progress to 0 if min is greater than max', () => {
+    const fixture = createComponent(BasicProgressBar);
+    const progressElement = fixture.debugElement.query(
+      By.css('dt-progress-bar'),
+    );
+    const progressComponent = progressElement.componentInstance;
+
+    progressComponent.min = 11;
+    progressComponent.max = 10;
+
+    progressComponent.value = 6;
+    expect(progressComponent.percent).toBe(0);
+
+    progressComponent.value = 1;
+    expect(progressComponent.percent).toBe(0);
+
+    progressComponent.value = 4;
+    expect(progressComponent.percent).toBe(0);
+  });
+
+  it('should set progress to 0 if min is equal to max', () => {
+    const fixture = createComponent(BasicProgressBar);
+    const progressElement = fixture.debugElement.query(
+      By.css('dt-progress-bar'),
+    );
+    const progressComponent = progressElement.componentInstance;
+
+    progressComponent.min = 0;
+    progressComponent.max = 0;
+
+    progressComponent.value = 6;
+    expect(progressComponent.percent).toBe(0);
+
+    progressComponent.value = 0;
+    expect(progressComponent.percent).toBe(0);
+
+    progressComponent.value = -2;
+    expect(progressComponent.percent).toBe(0);
+
+    progressComponent.min = 10;
+    progressComponent.max = 10;
+
+    progressComponent.value = 15;
+    expect(progressComponent.percent).toBe(0);
+
+    progressComponent.value = 10;
+    expect(progressComponent.percent).toBe(0);
+
+    progressComponent.value = 0;
+    expect(progressComponent.percent).toBe(0);
+  });
+
   it('should accept the value, min and max attribute as an input', () => {
     const fixture = createComponent(ValueProgressBar);
 


### PR DESCRIPTION
Fixed faulty algorithm for calculation the progress percentage of the progress component mixin. We did not account for a division-by-zero error.