### PR TITLE
feat(stacked-series-chart): Disabled node.

### DIFF
--- a/apps/dev/src/stacked-series-chart/stacked-series-chart-demo-data.ts
+++ b/apps/dev/src/stacked-series-chart/stacked-series-chart-demo-data.ts
@@ -98,7 +98,9 @@ export const stackedSeriesChartDemoData = [
     nodes: [
       {
         value: 1,
-        label: 'Milk',
+        label: 'Non-active milk',
+        disabled: true,
+        color: '#606060',
       },
       {
         value: 1,

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.html
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.html
@@ -56,7 +56,9 @@
           class="dt-stacked-series-chart-slice"
           [dtOverlay]="_overlay"
           [dtOverlayConfig]="{ data: slice }"
-          [class.dt-stacked-series-chart-slice-selectable]="_selectable"
+          [class.dt-stacked-series-chart-slice-selectable]="
+            _selectable && !slice.origin.disabled
+          "
           [class.dt-stacked-series-chart-slice-selected]="slice.selected"
           [attr.aria-label]="slice.ariaLabel"
           [style]="

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.mock.ts
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.mock.ts
@@ -72,6 +72,28 @@ export const stackedSeriesChartDemoDataCoffee: DtStackedSeriesChartSeries[] = [
   },
 ];
 
+export const stackedSeriesChartDemoDataWithDisableNode: DtStackedSeriesChartSeries[] =
+  [
+    {
+      label: 'Mocha',
+      nodes: [
+        {
+          value: 2,
+          label: 'Coffee (disabled)',
+          disabled: true,
+        },
+        {
+          value: 2,
+          label: 'Chocolate',
+        },
+        {
+          value: 1,
+          label: 'Milk',
+        },
+      ],
+    },
+  ];
+
 export const stackedSeriesChartDemoDataShows: DtStackedSeriesChartSeries[] = [
   {
     label: 'Lost',

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.spec.ts
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.spec.ts
@@ -35,7 +35,10 @@ import { DtIconModule } from '@dynatrace/barista-components/icon';
 import { DtThemingModule } from '@dynatrace/barista-components/theming';
 import { createComponent, dispatchFakeEvent } from '@dynatrace/testing/browser';
 import { DtStackedSeriesChart } from './stacked-series-chart';
-import { stackedSeriesChartDemoDataCoffee } from './stacked-series-chart.mock';
+import {
+  stackedSeriesChartDemoDataCoffee,
+  stackedSeriesChartDemoDataWithDisableNode,
+} from './stacked-series-chart.mock';
 import { DtStackedSeriesChartModule } from './stacked-series-chart.module';
 import {
   DtStackedSeriesChartFillMode,
@@ -365,6 +368,21 @@ describe('DtStackedSeriesChart', () => {
       tick();
 
       expect(getSelectedSlice()).toBe(null);
+    }));
+
+    it('should not select disabled node', fakeAsync(() => {
+      rootComponent.series = stackedSeriesChartDemoDataWithDisableNode;
+      fixture.detectChanges();
+
+      const sliceByPosition = getSliceByPositionWithinTrack(0, 0);
+      dispatchFakeEvent(sliceByPosition.nativeElement, 'click');
+      fixture.detectChanges();
+
+      tick();
+
+      const selected = getSelectedSlice();
+
+      expect(selected).toBeNull();
     }));
   });
 

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.ts
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.ts
@@ -541,7 +541,11 @@ export class DtStackedSeriesChart implements OnDestroy, OnInit {
     series?: DtStackedSeriesChartSeries,
     node?: DtStackedSeriesChartNode,
   ): false | void {
-    return this._isNodeSelectionMode && this._toggleSelect(series, node);
+    return (
+      this._isNodeSelectionMode &&
+      node?.disabled !== true &&
+      this._toggleSelect(series, node)
+    );
   }
 
   /** @internal Toggle the visibility of an element */

--- a/libs/barista-components/stacked-series-chart/src/stacked-series-chart.util.ts
+++ b/libs/barista-components/stacked-series-chart/src/stacked-series-chart.util.ts
@@ -72,6 +72,8 @@ export interface DtStackedSeriesChartNode {
   value: number;
   /** Color to be used */
   color?: DtColors | string;
+  /** Whether node is not selectable */
+  disabled?: boolean;
 }
 
 /** Extended information of DtStackedSeriesChartNode containing useful information that can be used inside the overlay's template */


### PR DESCRIPTION
### <strong>New feature | Stacked series chart - disabled node</strong>
Single node of stacked series chart now cannot be set to 'disabled', meaning that it can be hovered over, but cannot be selected. Switch is optional and doesn't do anything unless it is set true.

#### Checklist

- [V] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [V] Lint and unit tests pass locally with my changes
- [V] I have added tests that prove my fix is effective or that my feature works
- [V] I have added necessary documentation (if appropriate)
