### PR TITLE
Refactor 10.x Replace const enums with regular enums

### DIFF
--- a/libs/barista-components/chart/src/selection-area/position-utils.ts
+++ b/libs/barista-components/chart/src/selection-area/position-utils.ts
@@ -31,7 +31,7 @@ import { clamp } from '@dynatrace/barista-components/core';
 const DT_SELECTION_AREA_KEYBOARD_BIG_STEP = 10;
 
 /** @internal Event-target for the mouse events on the selection area */
-export const enum DtSelectionAreaEventTarget {
+export enum DtSelectionAreaEventTarget {
   SelectedArea = 'selected-area',
   LeftHandle = 'left',
   RightHandle = 'right',

--- a/libs/barista-components/checkbox/src/checkbox.ts
+++ b/libs/barista-components/checkbox/src/checkbox.ts
@@ -61,7 +61,7 @@ import { Subject } from 'rxjs';
 let nextUniqueId = 0;
 
 /** Represents the different states that require custom transitions between them. */
-export const enum TransitionCheckState {
+export enum TransitionCheckState {
   /** The initial state of the component before any user interaction. */
   Init,
   /** The state representing the component when it's becoming checked. */

--- a/libs/barista-components/filter-field/src/types.ts
+++ b/libs/barista-components/filter-field/src/types.ts
@@ -90,7 +90,7 @@ export interface DtOptionDef {
   parentAutocomplete: DtNodeDef<unknown> | null;
 }
 
-export const enum DtOperatorTypes {
+export enum DtOperatorTypes {
   And = 0,
   Or = 1,
   Not = 2,
@@ -101,7 +101,7 @@ export interface DtOperatorDef {
   type: DtOperatorTypes;
 }
 
-export const enum DtRangeOperatorFlags {
+export enum DtRangeOperatorFlags {
   Equal = 1 << 0,
   LowerEqual = 1 << 1,
   GreatEqual = 1 << 2,

--- a/libs/barista-components/formatters/src/unit.ts
+++ b/libs/barista-components/formatters/src/unit.ts
@@ -17,7 +17,7 @@
 /**
  * Enumeration for the different basic units
  */
-export const enum DtUnit {
+export enum DtUnit {
   PERCENT = '%',
   COUNT = 'count',
   BYTES = 'B',

--- a/libs/barista-components/schematics/src/utils/ast/update-ng-module-decorator-properties.ts
+++ b/libs/barista-components/schematics/src/utils/ast/update-ng-module-decorator-properties.ts
@@ -25,7 +25,7 @@ const NO_DECORATORS_ERROR = (name: string, filename: string) =>
   `The <${name}> property cannot be updated, in case there is no @NgModule in this file!\n${filename}`;
 
 // tslint:disable:max-line-length
-export const enum NgModuleProperties {
+export enum NgModuleProperties {
   Providers = 'providers', // The set of injectable objects that are available in the injector of this module.
   declarations = 'declarations', // The set of components, directives, and pipes (declarables) that belong to this module.
   Imports = 'imports', // The set of NgModules whose exported declarables are available to templates in this module.

--- a/libs/shared/design-system/interfaces/src/lib/barista/barista-definitions.ts
+++ b/libs/shared/design-system/interfaces/src/lib/barista/barista-definitions.ts
@@ -15,7 +15,7 @@
  */
 
 /** Possible layout types for pages in Barista. */
-export const enum BaPageLayoutType {
+export enum BaPageLayoutType {
   Default = 'default',
   Overview = 'overview',
   IconOverview = 'iconOverview',


### PR DESCRIPTION
### <strong>Pull Request: 10.x Replace const enums with regular enums</strong>

This PR proposes a change to replace all `const enums` with regular `enums`. The main reason for this change is to improve compatibility with TypeScript projects that have `isolatedModules` enabled.

When `isolatedModules` is turned on, TypeScript ensures that each file can be transpiled independently without requiring information from other files. However, `const enums` are incompatible with this setting as they require type information from other files to be transpiled. This results in a compilation error when `const enums` are used.

It's important to note that regular `enums` are slightly less performant than `const enums` because their usage isn't inlined at compile time. However, the performance difference is generally negligible and is often considered an acceptable trade-off for the increased compatibility provided by regular `enums`.

<hr>
Hi, thank you for contributing to Barista with this pull request (PR).

To ensure a fast process and merging of your PR please make sure it fulfills the
coding standards and contribution guidelines.

- A feature proposal has been provided, discussed and approved first.
- There is a meaningful description of the issue in GitHub (Screenshots are
  often helpful).
- If the PR introduces breaking-changes or deprecations it matches the following
  guidelines.
  - The commit message follows our commit guidelines.
  - Tests for the changes have been added (for bug fixes / features).
  - Docs have been added / updated (for bug fixes / features).

Please choose the type appropriate for the changes below: <br>

#### Type of PR: Other

#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
